### PR TITLE
M1: deterministic aquaponics design calculator + pluggable LLM backend

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,24 @@
+# TODOS
+
+## Product (deferred from CEO review 2026-06-16)
+- [ ] **Pilot-proposal generator.** A funder-ready document: proposed system for a site + the
+  ask, projected food/water outcomes, cost, and the data the install will produce.
+  - **Why:** the artifact that moves a B2G deal.
+  - **Context:** thin wrapper over the M1 PDF report export. Build at sequencing step 3 — after
+    the Taiwan-system validation exists and a real in-region partner / program officer can shape
+    the framing. Do NOT build speculatively.
+  - **Depends on:** M1 report export; one live funding/partner conversation. Priority P2.
+- [ ] **Report sensitivity table.** Show outcome deltas when water budget or crop mix vary
+  (e.g. +20% water → +X kg/yr). Persuasive for funders.
+  - **Why:** makes a design feel analyzed, not asserted.
+  - **Context:** a slice of the M2 optimizer surfaced in the report. Build when M2 lands rather
+    than hand-rolling in M1. Depends on: M2 optimizer. Priority P3.
+
+## Cleanup
+- [ ] **Dedupe boilerplate-text filter.** `looks_like_boilerplate` (inside `build_vector_store`,
+  `srcs/chatbot.py:204`) and module-level `_is_boilerplate_text` (`srcs/chatbot.py:238`) are
+  near-identical. Collapse into one helper.
+  - **Why:** DRY; two copies drift out of sync.
+  - **Context:** Both live in the RAG layer that the design doc demotes to a citation tool in
+    M3. Fold this dedupe into the M3 refactor rather than a standalone change.
+  - **Depends on:** M3 (RAG demotion) — see the approved design doc.

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,5 @@
+"""agent — the LLM-facing layer that wraps the deterministic aqua_model core.
+
+Dependency rule (eng review): this layer may import from `aqua_model`, never the reverse.
+`aqua_model` stays pure and Ollama-free; everything that touches the LLM or the UI lives here.
+"""

--- a/agent/calculator_ui.py
+++ b/agent/calculator_ui.py
@@ -1,0 +1,90 @@
+"""Streamlit view for the M1 design calculator.
+
+A structured form (the right UI for fixed engineering inputs) → the validated trust gate
+→ size_system() → results + the funder-facing report as a download. No LLM in this path:
+every number shown is traceable to a cited coefficient.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from aqua_model import size_system
+from aqua_model.report import to_markdown
+from agent import facts
+
+
+def render_calculator() -> None:
+    st.subheader("Design Calculator")
+    st.caption(
+        "Size one system from fixed inputs. Pure deterministic model — no AI guessing; "
+        "every number is traceable to a cited coefficient."
+    )
+
+    with st.form("design_form"):
+        col1, col2 = st.columns(2)
+        with col1:
+            species = st.selectbox("Fish species", facts.available_species())
+            crop = st.selectbox("Crop", facts.available_crops())
+            site = st.text_input("Site / project name (optional)", "")
+        with col2:
+            grow_area = st.number_input("Grow area (m²)", min_value=0.1, value=6.0, step=0.5)
+            temperature = st.number_input("Mean water temp (°C)", min_value=0.0, max_value=45.0, value=26.0, step=0.5)
+            water_budget = st.number_input("Water budget (L/day)", min_value=0.0, value=200.0, step=10.0)
+        submitted = st.form_submit_button("Size system", use_container_width=True)
+
+    if not submitted:
+        st.info("Set your inputs and press **Size system**.")
+        return
+
+    try:
+        design = facts.design_from_form(
+            fish_species=species, crop=crop, grow_area_m2=grow_area,
+            temperature_c=temperature, water_budget_lpd=water_budget,
+        )
+    except facts.ValidationError as err:
+        st.error("Invalid inputs:\n" + "\n".join(f"- {e}" for e in err.errors))
+        return
+
+    out = size_system(design)
+
+    if out.feasible:
+        st.success("Feasible design.")
+    else:
+        st.warning(f"Not feasible — binding constraint: **{out.binding_constraint}**.")
+
+    for w in out.warnings:
+        st.warning(w)
+
+    m1, m2, m3 = st.columns(3)
+    m1.metric("Feed", f"{out.feed_g_per_day:g} g/day")
+    m2.metric("Fish", f"{out.fish_count} head")
+    m3.metric("Biomass", f"{out.fish_biomass_kg:g} kg")
+    m4, m5, m6 = st.columns(3)
+    m4.metric("System volume", f"{out.system_volume_l:g} L")
+    m5.metric("Pump", f"{out.pump_turnover_lph:g} L/h")
+    m6.metric("Makeup water", f"{out.makeup_water_lpd:g} L/day")
+
+    with st.expander("Bill of materials"):
+        st.table(out.bill_of_materials)
+    with st.expander("Operating envelope"):
+        st.json(out.operating_envelope)
+    with st.expander("Nitrogen consistency check"):
+        st.json(out.nitrogen_check)
+    with st.expander("What is NOT modeled (read before building)"):
+        for n in out.not_modeled:
+            st.markdown(f"- {n}")
+    with st.expander("Coefficients used (auditable)"):
+        st.table([
+            {"name": c.name, "value": c.value, "range": f"{c.low}–{c.high}", "unit": c.unit, "source": c.source}
+            for c in out.coefficients_used
+        ])
+
+    report_md = to_markdown(design, out, site=site or None)
+    st.download_button(
+        "Download design report (Markdown)",
+        data=report_md,
+        file_name=f"aquaponics-design-{(site or 'system').strip().replace(' ', '-').lower()}.md",
+        mime="text/markdown",
+        use_container_width=True,
+    )

--- a/agent/facts.py
+++ b/agent/facts.py
@@ -1,0 +1,55 @@
+"""Fact collection seam between the UI/LLM and the deterministic model.
+
+For M1 the design calculator takes FIXED, structured inputs, so the safest "fact collection"
+is a validated form (no free-text parsing, no LLM guessing engineering numbers). This module
+exposes the option lists the UI needs and a single typed entry point into the trust zone.
+
+The free-text parsers in `srcs/chatbot.py` (temperature/pH/species extraction for the
+conversational troubleshooting flow) are extracted here in M3, when the orchestrator is
+refactored. They are not needed by the M1 calculator and are intentionally left untouched.
+"""
+
+from __future__ import annotations
+
+from aqua_model.crops import CROPS
+from aqua_model.species import SPECIES
+from aqua_model.types import DesignInput
+from aqua_model.validate import ValidationError, validate_design_input
+
+
+def available_species() -> list[str]:
+    return sorted(SPECIES)
+
+
+def available_crops() -> list[str]:
+    return sorted(CROPS)
+
+
+def design_from_form(
+    fish_species: str,
+    crop: str,
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    source_water_note: str | None = None,
+) -> DesignInput:
+    """Validate structured form values into a DesignInput. Raises ValidationError on bad input.
+
+    This is the ONLY way the UI puts numbers into the model — the validation gate, reused.
+    """
+    return validate_design_input(
+        fish_species=fish_species,
+        crop=crop,
+        grow_area_m2=grow_area_m2,
+        temperature_c=temperature_c,
+        water_budget_lpd=water_budget_lpd,
+        source_water_note=source_water_note,
+    )
+
+
+__all__ = [
+    "available_species",
+    "available_crops",
+    "design_from_form",
+    "ValidationError",
+]

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -1,0 +1,92 @@
+"""Pluggable LLM backend for the agent/chat layer.
+
+The deterministic design core (`aqua_model`) uses NO LLM — this only powers fact-collection,
+routing, and explanation in the chat/troubleshooting flow. So the backend is freely swappable
+via config; correctness of any design is unaffected.
+
+Select with the LLM_PROVIDER env var (or pass `provider=`):
+    ollama  -> local open model via Ollama (offline; default)
+    nvidia  -> NVIDIA hosted open models (OpenAI-compatible; needs NVIDIA_API_KEY)
+    hf      -> Hugging Face Inference (needs HUGGINGFACEHUB_API_TOKEN)
+
+Override the model with LLM_MODEL (or pass `model=`).
+
+Provider libraries are imported LAZILY, only when that provider is selected, so importing
+this module (or the chat layer) never requires any of them to be installed.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Sensible default open model per provider.
+DEFAULT_MODELS = {
+    "ollama": "llama3",
+    "nvidia": "meta/llama-3.1-8b-instruct",
+    "hf": "meta-llama/Llama-3.1-8B-Instruct",
+}
+
+SUPPORTED = tuple(DEFAULT_MODELS)
+
+
+def resolve(provider: str | None = None, model: str | None = None) -> tuple[str, str]:
+    """Pure resolution of (provider, model) from args -> env -> defaults. Testable, no I/O."""
+    provider = (provider or os.getenv("LLM_PROVIDER") or "ollama").strip().lower()
+    if provider not in SUPPORTED:
+        raise ValueError(
+            f"Unknown LLM_PROVIDER {provider!r}. Supported: {', '.join(SUPPORTED)}."
+        )
+    model = model or os.getenv("LLM_MODEL") or DEFAULT_MODELS[provider]
+    return provider, model
+
+
+def normalize(output) -> str:
+    """Coerce any LangChain result (str from text LLMs, AIMessage from chat models) to str."""
+    if output is None:
+        return ""
+    content = getattr(output, "content", None)
+    return content if isinstance(content, str) else str(output)
+
+
+class StringLLM:
+    """Thin adapter so callers always get a string back from .invoke(), whatever the backend."""
+
+    def __init__(self, backend, provider: str, model: str):
+        self._backend = backend
+        self.provider = provider
+        self.model = model
+
+    def invoke(self, prompt) -> str:
+        return normalize(self._backend.invoke(prompt))
+
+
+def _build_backend(provider: str, model: str, temperature: float):
+    if provider == "ollama":
+        from langchain_ollama.llms import OllamaLLM
+        return OllamaLLM(model=model, temperature=temperature)
+    if provider == "nvidia":
+        # OpenAI-compatible NVIDIA API Catalog / NIM. Reads NVIDIA_API_KEY from env.
+        from langchain_nvidia_ai_endpoints import ChatNVIDIA
+        # NVIDIA endpoints reject temperature=0; nudge to a tiny positive value.
+        temp = temperature if temperature > 0 else 1e-3
+        return ChatNVIDIA(model=model, temperature=temp)
+    if provider == "hf":
+        from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+        endpoint = HuggingFaceEndpoint(
+            repo_id=model,
+            temperature=max(temperature, 1e-3),
+            task="text-generation",
+        )
+        return ChatHuggingFace(llm=endpoint)
+    raise ValueError(f"Unhandled provider {provider!r}")  # pragma: no cover
+
+
+def get_llm(provider: str | None = None, model: str | None = None, temperature: float = 0.0) -> StringLLM:
+    """Return a normalized LLM client for the configured provider.
+
+    Raises ValueError for an unknown provider, or ImportError if the selected provider's
+    library is not installed (install langchain-nvidia-ai-endpoints or langchain-huggingface).
+    """
+    provider, model = resolve(provider, model)
+    backend = _build_backend(provider, model, temperature)
+    return StringLLM(backend, provider, model)

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -20,10 +20,16 @@ from __future__ import annotations
 import os
 
 # Sensible default open model per provider.
+# HF default: Qwen2.5-7B-Instruct — Apache-2.0 (clean license for a commercial/B2G venture),
+# strong at structured/JSON output (the decision step), multilingual incl. French.
+# Alternatives (set via LLM_MODEL):
+#   - meta-llama/Llama-3.1-8B-Instruct   (slightly stronger French prose; Llama community license)
+#   - Qwen/Qwen2.5-1.5B-Instruct         (Apache-2.0, tiny — for low-resource/edge field use)
+#   - microsoft/Phi-4-mini-instruct      (small, multilingual)
 DEFAULT_MODELS = {
     "ollama": "llama3",
     "nvidia": "meta/llama-3.1-8b-instruct",
-    "hf": "meta-llama/Llama-3.1-8B-Instruct",
+    "hf": "Qwen/Qwen2.5-7B-Instruct",
 }
 
 SUPPORTED = tuple(DEFAULT_MODELS)

--- a/agent/tests/test_calculator_ui.py
+++ b/agent/tests/test_calculator_ui.py
@@ -1,0 +1,52 @@
+"""Headless smoke test of the Design Calculator Streamlit view.
+
+Uses Streamlit's AppTest to render the calculator and drive the form end to end, without a
+browser or the chat stack. Skips cleanly if streamlit's testing harness is unavailable.
+"""
+
+import pytest
+
+pytest.importorskip("streamlit.testing.v1")
+from streamlit.testing.v1 import AppTest  # noqa: E402
+
+_APP = "from agent.calculator_ui import render_calculator; render_calculator()"
+
+
+def test_calculator_renders_form():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    assert not at.exception
+    assert "Design Calculator" in [s.value for s in at.subheader]
+    assert [sb.label for sb in at.selectbox] == ["Fish species", "Crop"]
+    assert len(at.number_input) == 3
+
+
+def test_calculator_sizes_a_system_on_submit():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.selectbox[0].set_value("tilapia")
+    at.selectbox[1].set_value("lettuce")
+    at.number_input[0].set_value(6.0)    # grow area
+    at.number_input[1].set_value(26.0)   # temperature
+    at.number_input[2].set_value(200.0)  # water budget
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    assert "Feasible design." in [s.value for s in at.success]
+    metrics = {m.label: m.value for m in at.metric}
+    assert metrics["Feed"] == "360 g/day"
+    assert "head" in metrics["Fish"]
+
+
+def test_calculator_flags_infeasible_water_budget():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.selectbox[0].set_value("tilapia")
+    at.selectbox[1].set_value("lettuce")
+    at.number_input[0].set_value(50.0)   # large area
+    at.number_input[1].set_value(28.0)
+    at.number_input[2].set_value(10.0)   # tiny water budget
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    warnings = " ".join(w.value for w in at.warning)
+    assert "binding constraint" in warnings.lower() or "water" in warnings.lower()

--- a/agent/tests/test_facts.py
+++ b/agent/tests/test_facts.py
@@ -1,0 +1,29 @@
+"""The UI<->model seam: option lists and the validated entry point (no streamlit needed)."""
+
+import pytest
+
+from agent import facts
+from aqua_model.types import DesignInput
+
+
+def test_option_lists_match_the_databases():
+    assert "tilapia" in facts.available_species()
+    assert "lettuce" in facts.available_crops()
+    assert facts.available_species() == sorted(facts.available_species())
+
+
+def test_design_from_form_returns_validated_input():
+    di = facts.design_from_form(
+        fish_species="tilapia", crop="lettuce", grow_area_m2=6.0,
+        temperature_c=26.0, water_budget_lpd=200.0,
+    )
+    assert isinstance(di, DesignInput)
+    assert di.fish_species == "tilapia"
+
+
+def test_design_from_form_rejects_bad_input():
+    with pytest.raises(facts.ValidationError):
+        facts.design_from_form(
+            fish_species="dragon", crop="lettuce", grow_area_m2=6.0,
+            temperature_c=26.0, water_budget_lpd=200.0,
+        )

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -1,0 +1,61 @@
+"""The pluggable LLM factory: resolution, normalization, error handling. No network."""
+
+import pytest
+
+from agent import llm as L
+
+
+def test_default_provider_and_model(monkeypatch):
+    monkeypatch.delenv("LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    provider, model = L.resolve()
+    assert provider == "ollama"
+    assert model == "llama3"
+
+
+def test_env_selects_provider_and_model(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "NVIDIA")  # case-insensitive
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    provider, model = L.resolve()
+    assert provider == "nvidia"
+    assert model == L.DEFAULT_MODELS["nvidia"]
+
+
+def test_explicit_args_override_env(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    provider, model = L.resolve(provider="hf", model="my/custom-model")
+    assert provider == "hf"
+    assert model == "my/custom-model"
+
+
+def test_unknown_provider_raises():
+    with pytest.raises(ValueError):
+        L.resolve(provider="skynet")
+
+
+def test_get_llm_unknown_provider_raises_before_importing_anything():
+    with pytest.raises(ValueError):
+        L.get_llm(provider="skynet")
+
+
+def test_normalize_handles_str_and_message_and_none():
+    assert L.normalize("hello") == "hello"
+    assert L.normalize(None) == ""
+
+    class _Msg:
+        content = "from a chat model"
+
+    assert L.normalize(_Msg()) == "from a chat model"
+
+
+def test_stringllm_always_returns_str():
+    class _FakeBackend:
+        def invoke(self, prompt):
+            class _Msg:
+                content = f"echo:{prompt}"
+            return _Msg()
+
+    client = L.StringLLM(_FakeBackend(), "fake", "fake-model")
+    out = client.invoke("ping")
+    assert isinstance(out, str)
+    assert out == "echo:ping"

--- a/app.py
+++ b/app.py
@@ -4,29 +4,38 @@ from __future__ import annotations
 
 from typing import List
 
-import requests_cache
 import streamlit as st
 
-import srcs.chatbot as core
+from agent.calculator_ui import render_calculator
 
 
 APP_TITLE = "Aquaponics Assistant"
 
 
+def _core():
+    """Lazy-import the chat/RAG core so the Design Calculator mode runs without the
+    chat stack (langchain, faiss, Ollama, requests_cache) installed."""
+    import srcs.chatbot as core
+    return core
+
+
 def _init_cache() -> None:
     # Cache HTTP fetches for RAG content.
+    import requests_cache
+    core = _core()
     requests_cache.install_cache(core.CACHE_NAME, expire_after=core.CACHE_EXPIRE)
 
 
 @st.cache_resource(show_spinner=False)
 def _build_vectorstore() -> object | None:
     _init_cache()
-    return core.build_rag_index_from_urls()
+    return _core().build_rag_index_from_urls()
 
 
 def _reset_session_state() -> None:
     st.session_state.messages = []
     st.session_state.last_bot = ""
+    core = _core()
     core.state.reset()
     core.last_bot = ""
 
@@ -39,6 +48,7 @@ def _ensure_session_state() -> None:
 
 
 def _set_rag(use_rag: bool) -> None:
+    core = _core()
     if use_rag:
         with st.spinner("Building knowledge index..."):
             core.VECTORSTORE = _build_vectorstore()
@@ -73,7 +83,7 @@ def _render_sidebar() -> None:
 
     _set_rag(use_rag)
     if use_rag:
-        if core.VECTORSTORE is None:
+        if _core().VECTORSTORE is None:
             st.sidebar.caption("RAG unavailable; using general knowledge.")
         else:
             st.sidebar.caption("RAG ready.")
@@ -99,6 +109,7 @@ def _render_messages() -> None:
 
 
 def _handle_user_input(user_text: str) -> None:
+    core = _core()
     _add_message("user", user_text)
 
     prev_pending = list(core.state.pending_questions)
@@ -125,6 +136,17 @@ def main() -> None:
     )
     _ensure_session_state()
     _render_header()
+
+    mode = st.sidebar.radio(
+        "Mode",
+        ("Assistant (chat)", "Design Calculator"),
+        help="Chat troubleshoots a running system. Calculator sizes a new one deterministically.",
+    )
+
+    if mode == "Design Calculator":
+        render_calculator()
+        return
+
     _render_sidebar()
 
     _render_messages()

--- a/aqua_model/__init__.py
+++ b/aqua_model/__init__.py
@@ -1,0 +1,32 @@
+"""aqua_model — deterministic aquaponics design & sizing core.
+
+This package is the TRUST ZONE. It is pure Python: no LLM, no network, no Ollama,
+no imports from `srcs/`. Every number it produces is traceable to a cited
+coefficient (see `coefficients.py`) and every design states what it does NOT model.
+
+Public API:
+    size_system(DesignInput) -> DesignOutput   # the calculator
+    validate_design_input(...) -> DesignInput  # the trust gate
+
+Design rules (from the approved design doc + eng/CEO reviews):
+  - FRR (feeding-rate ratio) is the single SIZING rule. The nitrogen balance is an
+    independent CONSISTENCY CHECK, never a second sizing path.
+  - Coefficients carry value + range + unit + source. They are seed defaults meant to
+    be CALIBRATED against a real system, not universal constants.
+  - Every output lists what is NOT modeled. Calibration != validation.
+"""
+
+from .sizing import size_system
+from .validate import validate_design_input, ValidationError
+from .types import DesignInput, DesignOutput, CoefficientUse
+
+__all__ = [
+    "size_system",
+    "validate_design_input",
+    "ValidationError",
+    "DesignInput",
+    "DesignOutput",
+    "CoefficientUse",
+]
+
+__version__ = "0.1.0"

--- a/aqua_model/coefficients.py
+++ b/aqua_model/coefficients.py
@@ -1,0 +1,123 @@
+"""Cited coefficient layer — the trust artifact.
+
+Every magic number the model uses lives here as a `Coefficient` with a value, a
+plausible range, a unit, and a SOURCE. Functions read from this registry; they never
+hard-code numbers. When a design runs, it echoes exactly which coefficients (and which
+sources) it used, so an institutional reviewer can audit the math without trusting any LLM.
+
+IMPORTANT — these are SEED DEFAULTS, not universal truths. Aquaponics coefficients vary by
+species, cultivar, climate, feed, and system type. The whole point of the calibration step
+(validate against a real running system) is to replace these defaults with measured values.
+Ranges are deliberately wide to reflect that uncertainty; a conservative SAFETY_FACTOR is
+applied where undersizing would be dangerous (biofilter, aeration).
+
+Primary sources:
+  FAO589 = Somerville, Cohen, Pantanella, Stankus & Lovatelli (2014),
+           "Small-scale aquaponic food production", FAO Fisheries and Aquaculture
+           Technical Paper 589. (Free PDF.)
+  UVI    = Rakocy et al., University of the Virgin Islands raft aquaponics work
+           (feeding-rate ratio).
+  LIT    = General aquaculture/hydroponics literature consensus (ranges, not a single paper).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Coefficient:
+    """A single, sourced, ranged constant used by the model."""
+
+    name: str
+    value: float          # the default used in calculations
+    low: float            # plausible lower bound
+    high: float           # plausible upper bound
+    unit: str
+    source: str           # e.g. "FAO589", "UVI", "LIT"
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        if not (self.low <= self.value <= self.high):
+            raise ValueError(
+                f"Coefficient {self.name!r}: value {self.value} not within "
+                f"[{self.low}, {self.high}]"
+            )
+
+
+# A conservative multiplier applied to sizing outputs where UNDER-sizing is dangerous
+# (biofilter media, aeration headroom). >1 means "build a bit bigger to be safe".
+SAFETY_FACTOR = Coefficient(
+    name="safety_factor",
+    value=1.3, low=1.1, high=1.5, unit="dimensionless", source="LIT",
+    note="Headroom for losses, peaks, clogging, and coefficient uncertainty.",
+)
+
+# Nitrogen chemistry — well established.
+N_FRACTION_OF_PROTEIN = Coefficient(
+    name="n_fraction_of_protein",
+    value=0.16, low=0.16, high=0.16, unit="g N / g protein", source="LIT",
+    note="Protein is ~16% nitrogen by mass (Kjeldahl factor 6.25). Effectively exact.",
+)
+
+# Plant uptake fraction: of the nitrogen a fish EXCRETES, what share do plants actually
+# take up (the rest leaves via solids removal, water exchange, denitrification)? Sizing
+# beds to absorb 100% of excreted N oversizes them — this fraction is the guard.
+PLANT_N_UPTAKE_FRACTION = Coefficient(
+    name="plant_n_uptake_fraction",
+    value=0.40, low=0.30, high=0.50, unit="dimensionless", source="LIT",
+    note="Plants recover only ~30-50% of excreted N; the rest exits via non-plant sinks.",
+)
+
+# Water-use rates (the binding objective for the founder's market).
+EVAPOTRANSPIRATION_RATE = Coefficient(
+    name="evapotranspiration_rate",
+    value=4.0, low=2.0, high=8.0, unit="L / m2 plant / day", source="LIT",
+    note="Crop ET; climate- and stage-dependent. Wide range; calibrate per site.",
+)
+TANK_EVAPORATION_RATE = Coefficient(
+    name="tank_evaporation_rate",
+    value=3.0, low=1.0, high=7.0, unit="L / m2 water-surface / day", source="LIT",
+    note="Open-water evaporation; depends on cover, humidity, temperature.",
+)
+
+# System geometry assumptions (raft / DWC, the v1 system type).
+RAFT_WATER_DEPTH = Coefficient(
+    name="raft_water_depth",
+    value=0.30, low=0.20, high=0.40, unit="m", source="FAO589",
+    note="Typical raft/DWC canal water depth.",
+)
+SUMP_FRACTION = Coefficient(
+    name="sump_fraction",
+    value=0.10, low=0.05, high=0.20, unit="fraction of system volume", source="LIT",
+)
+PUMP_TURNOVER_RATE = Coefficient(
+    name="pump_turnover_rate",
+    value=1.0, low=0.5, high=2.0, unit="system volumes / hour", source="FAO589",
+)
+
+# Biofilter: nitrification rate per m2 of media surface. HIGHLY media- and
+# temperature-dependent; deliberately conservative (low) so we don't undersize.
+NITRIFICATION_RATE = Coefficient(
+    name="nitrification_rate",
+    value=0.40, low=0.20, high=0.80, unit="g TAN / m2 media / day", source="LIT",
+    note="Conservative. Tank/raft surfaces also nitrify but are NOT counted here (eng decision).",
+)
+
+
+def registry() -> dict[str, Coefficient]:
+    """All global coefficients by name (species/crop coefficients live in their own modules)."""
+    return {
+        c.name: c
+        for c in (
+            SAFETY_FACTOR,
+            N_FRACTION_OF_PROTEIN,
+            PLANT_N_UPTAKE_FRACTION,
+            EVAPOTRANSPIRATION_RATE,
+            TANK_EVAPORATION_RATE,
+            RAFT_WATER_DEPTH,
+            SUMP_FRACTION,
+            PUMP_TURNOVER_RATE,
+            NITRIFICATION_RATE,
+        )
+    }

--- a/aqua_model/crops.py
+++ b/aqua_model/crops.py
@@ -1,0 +1,57 @@
+"""Crop database — seed defaults, cited and ranged.
+
+`frr_g_per_m2_day` is the feeding-rate ratio: grams of fish FEED per m2 of this crop's
+growing area per day. It is the load-bearing SIZING coefficient (FAO 589 / UVI).
+`n_uptake_g_per_m2_day` is used only by the nitrogen CONSISTENCY CHECK, never for sizing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Crop:
+    name: str
+    category: str               # "leafy" or "fruiting"
+    frr_g_per_m2_day: float      # feeding-rate ratio (g feed / m2 / day) — SIZING rule
+    frr_low: float
+    frr_high: float
+    n_uptake_g_per_m2_day: float # N removed by plants per m2/day — CONSISTENCY CHECK only
+    ph_min: float
+    ph_max: float
+    temp_min_c: float
+    temp_max_c: float
+    source: str
+
+
+# Leafy greens: lower feed ratio. FAO 589 / UVI cite ~40-100 g/m2/day for leafy raft.
+LETTUCE = Crop(
+    name="lettuce", category="leafy",
+    frr_g_per_m2_day=60.0, frr_low=40.0, frr_high=80.0,
+    n_uptake_g_per_m2_day=0.8,
+    ph_min=5.5, ph_max=7.0, temp_min_c=10.0, temp_max_c=26.0, source="FAO589/UVI",
+)
+BASIL = Crop(
+    name="basil", category="leafy",
+    frr_g_per_m2_day=70.0, frr_low=50.0, frr_high=90.0,
+    n_uptake_g_per_m2_day=1.0,
+    ph_min=5.5, ph_max=7.0, temp_min_c=18.0, temp_max_c=30.0, source="LIT",
+)
+
+# Fruiting: higher feed ratio (FAO 589 cites ~100+ g/m2/day for fruiting raft).
+TOMATO = Crop(
+    name="tomato", category="fruiting",
+    frr_g_per_m2_day=110.0, frr_low=80.0, frr_high=140.0,
+    n_uptake_g_per_m2_day=1.6,
+    ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589",
+)
+
+CROPS: dict[str, Crop] = {c.name: c for c in (LETTUCE, BASIL, TOMATO)}
+
+
+def get_crop(name: str) -> Crop:
+    key = (name or "").strip().lower()
+    if key not in CROPS:
+        raise KeyError(f"Unknown crop {name!r}. Known: {sorted(CROPS)}")
+    return CROPS[key]

--- a/aqua_model/logging_schema.py
+++ b/aqua_model/logging_schema.py
@@ -1,0 +1,98 @@
+"""Install-logging standard (CEO-accepted expansion B) — the dataset moat.
+
+A versioned, documented schema for what every installed system logs. The point: every
+install — the founder's and any partner's — logs the SAME fields, the SAME units, the SAME
+cadence, so the aggregate is research-grade from the first row instead of a pile of
+inconsistent CSVs. This is also the raw material that, once collected across sites, lets the
+M4 digital twin calibrate against reality.
+
+Versioned on purpose: when the schema changes, the version bumps, and old rows stay
+interpretable. `validate_row` rejects bad data loudly (same philosophy as the trust gate).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+SCHEMA_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class Field:
+    name: str
+    unit: str
+    required: bool
+    cadence: str          # "per-reading" | "daily" | "weekly"
+    description: str
+    min_value: float | None = None
+    max_value: float | None = None
+
+
+# The standard. Add fields by appending and bumping SCHEMA_VERSION (never silently reuse).
+FIELDS: tuple[Field, ...] = (
+    Field("system_id", "", True, "per-reading", "Stable unique id for the installed system."),
+    Field("timestamp", "ISO-8601", True, "per-reading", "When the reading was taken."),
+    Field("water_temp_c", "°C", True, "daily", "Water temperature.", 0.0, 45.0),
+    Field("ph", "", True, "weekly", "Water pH.", 3.0, 10.0),
+    Field("ammonia_mg_l", "mg/L", True, "weekly", "Total ammonia nitrogen.", 0.0, 20.0),
+    Field("nitrite_mg_l", "mg/L", True, "weekly", "Nitrite.", 0.0, 20.0),
+    Field("nitrate_mg_l", "mg/L", True, "weekly", "Nitrate.", 0.0, 500.0),
+    Field("dissolved_oxygen_mg_l", "mg/L", False, "daily", "Dissolved oxygen.", 0.0, 20.0),
+    Field("feed_g", "g", True, "daily", "Feed given that day.", 0.0, 1_000_000.0),
+    Field("makeup_water_l", "L", True, "daily", "Water added that day.", 0.0, 1_000_000.0),
+    Field("fish_mortality_count", "count", True, "daily", "Fish deaths that day.", 0.0, 1_000_000.0),
+    Field("harvest_fish_kg", "kg", False, "per-reading", "Fish harvested.", 0.0, 1_000_000.0),
+    Field("harvest_crop_kg", "kg", False, "per-reading", "Crop harvested.", 0.0, 1_000_000.0),
+    Field("note", "", False, "per-reading", "Free-text observation."),
+)
+
+_BY_NAME = {f.name: f for f in FIELDS}
+
+
+def csv_header() -> list[str]:
+    """Column order for a logging CSV. Stable for a given SCHEMA_VERSION."""
+    return [f.name for f in FIELDS]
+
+
+def required_fields() -> list[str]:
+    return [f.name for f in FIELDS if f.required]
+
+
+def validate_row(row: dict) -> list[str]:
+    """Return a list of problems with a logged row (empty list = valid). Never raises."""
+    problems: list[str] = []
+
+    for name in required_fields():
+        if row.get(name) in (None, ""):
+            problems.append(f"missing required field: {name}")
+
+    for name, value in row.items():
+        field = _BY_NAME.get(name)
+        if field is None:
+            problems.append(f"unknown field not in schema v{SCHEMA_VERSION}: {name}")
+            continue
+        if value in (None, ""):
+            continue
+        if field.min_value is not None or field.max_value is not None:
+            try:
+                v = float(value)
+            except (TypeError, ValueError):
+                problems.append(f"{name} must be numeric, got {value!r}")
+                continue
+            lo = field.min_value if field.min_value is not None else float("-inf")
+            hi = field.max_value if field.max_value is not None else float("inf")
+            if not (lo <= v <= hi):
+                problems.append(f"{name}={v} out of range [{lo}, {hi}]")
+
+    return problems
+
+
+def schema_doc() -> str:
+    """Human-readable schema documentation (ship this with every install)."""
+    lines = [f"# Aquaponics install-logging standard v{SCHEMA_VERSION}\n",
+             "| Field | Unit | Required | Cadence | Description |",
+             "|---|---|---|---|---|"]
+    for f in FIELDS:
+        req = "yes" if f.required else "no"
+        lines.append(f"| {f.name} | {f.unit or '—'} | {req} | {f.cadence} | {f.description} |")
+    return "\n".join(lines)

--- a/aqua_model/massbalance.py
+++ b/aqua_model/massbalance.py
@@ -1,0 +1,130 @@
+"""Mass balance: nitrogen CONSISTENCY CHECK, water balance, biofilter sizing.
+
+  FEED  ──FRR sizes──▶  the system (see sizing.py)
+    │
+    │  nitrogen flows (THIS module — a CHECK, not a sizing path):
+    ▼
+  N_fed = feed * protein% * 0.16
+    │
+    ├─ N_retained = growth * body_protein% * 0.16   (growth = feed / FCR)
+    │
+    └─ N_excreted = N_fed - N_retained
+          │
+          ├─ plants take up ~30-50% (PLANT_N_UPTAKE_FRACTION)   ◀── checked vs FRR area
+          └─ the rest leaves via solids / water-exchange / denitrification
+                                  (estimated INDEPENDENTLY, not as a residual)
+
+The check never RESIZES anything. It asks: does the FRR-sized grow area roughly match the
+area the nitrogen flow implies? If they disagree beyond tolerance, it raises a flag instead
+of silently reconciling. (This is what makes the test non-vacuous: sinks are independent.)
+"""
+
+from __future__ import annotations
+
+from . import coefficients as C
+from .crops import Crop
+from .species import FishSpecies
+
+
+# Independent estimates of where excreted N goes (NOT a residual). These are coarse
+# literature fractions; they must sum to ~1.0 with the plant-uptake fraction so the
+# balance is a real check, not a tautology.
+SOLIDS_REMOVAL_FRACTION = 0.35   # settleable solids / sludge removal
+WATER_EXCHANGE_FRACTION = 0.20   # leaves with purge / overflow water
+DENITRIFICATION_FRACTION = 0.05  # anoxic loss
+
+
+def nitrogen_check(
+    feed_g_per_day: float,
+    species: FishSpecies,
+    crop: Crop,
+    frr_grow_area_m2: float,
+) -> dict:
+    """Compare the FRR-sized grow area against the area implied by nitrogen flow.
+
+    Returns a dict with the full balance plus an `agreement` verdict. Never mutates sizing.
+    """
+    n_frac = C.N_FRACTION_OF_PROTEIN.value
+    uptake_frac = C.PLANT_N_UPTAKE_FRACTION.value
+
+    n_fed = feed_g_per_day * (species.feed_protein_pct / 100.0) * n_frac
+    growth_g_per_day = feed_g_per_day / species.fcr
+    n_retained = growth_g_per_day * (species.body_protein_pct / 100.0) * n_frac
+    n_excreted = max(0.0, n_fed - n_retained)
+
+    # Independent sink estimates (NOT residual).
+    n_plant = n_excreted * uptake_frac
+    n_solids = n_excreted * SOLIDS_REMOVAL_FRACTION
+    n_water = n_excreted * WATER_EXCHANGE_FRACTION
+    n_denitri = n_excreted * DENITRIFICATION_FRACTION
+    n_sinks_total = n_plant + n_solids + n_water + n_denitri
+
+    # Area the nitrogen flow implies, given the crop's uptake rate.
+    if crop.n_uptake_g_per_m2_day > 0:
+        n_implied_area = n_plant / crop.n_uptake_g_per_m2_day
+    else:
+        n_implied_area = float("inf")
+
+    # Do the two independent methods agree? (FRR area vs N-implied area.)
+    if frr_grow_area_m2 > 0 and n_implied_area not in (0.0, float("inf")):
+        disagreement = abs(n_implied_area - frr_grow_area_m2) / frr_grow_area_m2
+    else:
+        disagreement = float("inf")
+    agrees = disagreement <= 0.35  # within 35% is "consistent" for a seed model
+
+    # How close do the independently-estimated sinks come to closing the excreted N?
+    # (A real check: if this is ~0, our sink fractions are self-consistent; large means
+    # our independent estimates don't add up and the model needs calibration.)
+    closure_residual = n_excreted - n_sinks_total
+
+    return {
+        "n_fed_g_day": round(n_fed, 2),
+        "n_retained_g_day": round(n_retained, 2),
+        "n_excreted_g_day": round(n_excreted, 2),
+        "n_plant_uptake_g_day": round(n_plant, 2),
+        "n_solids_g_day": round(n_solids, 2),
+        "n_water_exchange_g_day": round(n_water, 2),
+        "n_denitrification_g_day": round(n_denitri, 2),
+        "closure_residual_g_day": round(closure_residual, 2),
+        "frr_grow_area_m2": round(frr_grow_area_m2, 2),
+        "n_implied_area_m2": round(n_implied_area, 2) if n_implied_area != float("inf") else None,
+        "disagreement_fraction": round(disagreement, 3) if disagreement != float("inf") else None,
+        "agrees": agrees,
+        "flag": None if agrees else (
+            "FRR sizing and nitrogen balance disagree by "
+            f"{round(disagreement * 100)}% — calibrate coefficients or check inputs."
+        ),
+    }
+
+
+def water_balance(grow_area_m2: float, tank_surface_m2: float, rainfall_lpd: float = 0.0) -> dict:
+    """Daily makeup water = evapotranspiration + tank evaporation + sludge loss - rainfall.
+
+    Rainfall defaults to 0 (covered/controlled system) — counting uncaptured rain would be
+    fantasy accounting. The result drives the water-budget feasibility check.
+    """
+    et = grow_area_m2 * C.EVAPOTRANSPIRATION_RATE.value
+    evap = tank_surface_m2 * C.TANK_EVAPORATION_RATE.value
+    sludge = 0.05 * (et + evap)  # small loss with solids removal
+    makeup = max(0.0, et + evap + sludge - rainfall_lpd)
+    return {
+        "evapotranspiration_lpd": round(et, 1),
+        "tank_evaporation_lpd": round(evap, 1),
+        "sludge_loss_lpd": round(sludge, 1),
+        "rainfall_lpd": round(rainfall_lpd, 1),
+        "makeup_water_lpd": round(makeup, 1),
+    }
+
+
+def biofilter_media_m2(feed_g_per_day: float, species: FishSpecies) -> float:
+    """Required nitrifying media area, sized to TAN production with a safety factor.
+
+    Conservative by decision: tank/raft surfaces also nitrify but are NOT counted here, so
+    we never undersize. TAN production is approximated as the excreted-N rate.
+    """
+    n_frac = C.N_FRACTION_OF_PROTEIN.value
+    n_fed = feed_g_per_day * (species.feed_protein_pct / 100.0) * n_frac
+    n_retained = (feed_g_per_day / species.fcr) * (species.body_protein_pct / 100.0) * n_frac
+    tan_g_day = max(0.0, n_fed - n_retained)
+    media = tan_g_day / C.NITRIFICATION_RATE.value
+    return round(media * C.SAFETY_FACTOR.value, 2)

--- a/aqua_model/report.py
+++ b/aqua_model/report.py
@@ -1,0 +1,117 @@
+"""Funder-facing design report (CEO-accepted expansion A).
+
+Renders a DesignOutput to clean Markdown: system spec, projected outcomes, operating
+envelope, bill of materials, the nitrogen consistency check, every coefficient WITH its
+source, and an explicit "not modeled" section. This is the credibility artifact handed to
+a program officer or attached to a grant.
+
+PDF is a thin render step over this Markdown (pandoc, the gstack /make-pdf skill, or any
+Markdown->PDF tool) — kept out of the core so the trust zone stays dependency-free and the
+report is fully unit-testable. `to_markdown` is the contract; PDF is downstream.
+"""
+
+from __future__ import annotations
+
+from .types import DesignInput, DesignOutput
+
+
+def to_markdown(design: DesignInput, out: DesignOutput, *, site: str | None = None) -> str:
+    lines: list[str] = []
+    title = f"Aquaponics System Design — {site}" if site else "Aquaponics System Design"
+    lines.append(f"# {title}\n")
+
+    status = "FEASIBLE" if out.feasible else f"NOT FEASIBLE (binding: {out.binding_constraint})"
+    lines.append(f"**Status:** {status}\n")
+
+    lines.append("## Inputs\n")
+    lines.append(f"- Fish species: **{design.fish_species}**")
+    lines.append(f"- Crop: **{design.crop}**")
+    lines.append(f"- Grow area: **{design.grow_area_m2} m²**")
+    lines.append(f"- Mean water temperature: **{design.temperature_c} °C**")
+    lines.append(f"- Water budget: **{design.water_budget_lpd} L/day**")
+    if design.source_water_note:
+        lines.append(f"- Source-water note: {design.source_water_note}")
+    lines.append("")
+
+    lines.append("## Sized System\n")
+    lines.append("| Quantity | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Feed | {out.feed_g_per_day} g/day |")
+    lines.append(f"| Fish | {out.fish_count} head (~{out.fish_biomass_kg} kg biomass) |")
+    lines.append(f"| Rearing tank | {out.rearing_tank_volume_l} L |")
+    lines.append(f"| System volume | {out.system_volume_l} L |")
+    lines.append(f"| Pump turnover | {out.pump_turnover_lph} L/h |")
+    lines.append(f"| Biofilter media | {out.biofilter_media_m2} m² |")
+    lines.append(f"| Makeup water | {out.makeup_water_lpd} L/day |")
+    lines.append("")
+
+    if out.warnings:
+        lines.append("## Warnings\n")
+        for w in out.warnings:
+            lines.append(f"- ⚠️ {w}")
+        lines.append("")
+
+    lines.append("## Bill of Materials\n")
+    lines.append("| Item | Spec | Qty |")
+    lines.append("|---|---|---|")
+    for item in out.bill_of_materials:
+        lines.append(f"| {item['item']} | {item['spec']} | {item['qty']} |")
+    lines.append("")
+
+    env = out.operating_envelope
+    if env:
+        lines.append("## Operating Envelope\n")
+        lines.append(f"- pH target: {env.get('ph_target')} (do not exceed {env.get('ph_do_not_exceed')})")
+        lines.append(
+            f"- Temperature target: {env.get('temperature_target_c')} °C "
+            f"(do not exceed {env.get('temperature_do_not_exceed_c')} °C)"
+        )
+        lines.append(f"- Dissolved oxygen: ≥ {env.get('dissolved_oxygen_min_mg_l')} mg/L")
+        lines.append(f"- Ammonia/nitrite: {env.get('ammonia_nitrite_target')}")
+        lines.append("")
+
+    if out.maintenance_checklist:
+        lines.append("## Maintenance Checklist\n")
+        for task in out.maintenance_checklist:
+            lines.append(f"- {task}")
+        lines.append("")
+
+    nc = out.nitrogen_check
+    if nc:
+        lines.append("## Nitrogen Consistency Check\n")
+        verdict = "consistent" if nc.get("agrees") else "DISAGREEMENT — calibration needed"
+        lines.append(f"FRR sizing vs nitrogen-balance: **{verdict}**.\n")
+        lines.append(f"- N fed: {nc.get('n_fed_g_day')} g/day")
+        lines.append(f"- N retained in fish: {nc.get('n_retained_g_day')} g/day")
+        lines.append(f"- N excreted: {nc.get('n_excreted_g_day')} g/day")
+        lines.append(
+            f"- Of excreted N → plants: {nc.get('n_plant_uptake_g_day')}, "
+            f"solids: {nc.get('n_solids_g_day')}, water exchange: {nc.get('n_water_exchange_g_day')}, "
+            f"denitrification: {nc.get('n_denitrification_g_day')} (g/day)"
+        )
+        lines.append("")
+
+    if out.assumptions:
+        lines.append("## Assumptions\n")
+        for a in out.assumptions:
+            lines.append(f"- {a}")
+        lines.append("")
+
+    lines.append("## NOT Modeled (read before building)\n")
+    lines.append("This design accounts for nitrogen and water only. It does NOT model:")
+    for n in out.not_modeled:
+        lines.append(f"- {n}")
+    lines.append("\n*A reviewer must not treat this as a complete engineering design.*\n")
+
+    lines.append("## Coefficients Used (auditable)\n")
+    lines.append("| Coefficient | Value | Range | Unit | Source |")
+    lines.append("|---|---|---|---|---|")
+    for c in out.coefficients_used:
+        lines.append(f"| {c.name} | {c.value} | {c.low}–{c.high} | {c.unit} | {c.source} |")
+    lines.append("")
+    lines.append(
+        "Sources: FAO589 = Somerville et al. (2014), FAO Technical Paper 589; "
+        "UVI = Rakocy et al. (University of the Virgin Islands); LIT = literature consensus.\n"
+    )
+
+    return "\n".join(lines)

--- a/aqua_model/sizing.py
+++ b/aqua_model/sizing.py
@@ -1,0 +1,180 @@
+"""size_system() — the calculator.
+
+Solve order (FRR anchors; nitrogen only CHECKS):
+
+    grow_area ──FRR──▶ feed/day ──feeding%──▶ fish biomass ──harvest wt──▶ fish count
+                                                   │
+                                                   ├─ stocking density ─▶ rearing tank vol
+                                                   ├─ raft depth + sump ─▶ system vol ─▶ pump
+                                                   ├─ massbalance.water_balance ─▶ makeup water
+                                                   ├─ massbalance.biofilter ─────▶ media area
+                                                   └─ massbalance.nitrogen_check ▶ consistency flag
+
+Feasibility: if makeup water exceeds the budget, return feasible=False with the binding
+constraint and a nearest-feasible hint (the smallest single-input change that restores it).
+Never raises on a valid DesignInput; never returns a silently-wrong number.
+"""
+
+from __future__ import annotations
+
+import math
+
+from . import coefficients as C
+from . import massbalance as mb
+from .crops import get_crop
+from .species import get_species, temperature_feed_factor
+from .types import CoefficientUse, DesignInput, DesignOutput
+
+# What this v1 model does NOT account for. Every output carries this so a design can
+# never be mistaken for complete. (Eng + CEO review honesty layer.)
+NOT_MODELED = [
+    "pH / alkalinity dynamics and buffering",
+    "potassium, calcium, iron and other non-nitrogen nutrients",
+    "salinity / mineral build-up from source water",
+    "solids handling and biofilter maturation over time",
+    "pests, disease, and biosecurity",
+    "fish cohort logic (stocking batches, mortality, growth curve, staggered harvest)",
+    "diel temperature swings and seasonal min/max (mean temperature only)",
+]
+
+
+def _coeff_uses(*coeffs) -> list[CoefficientUse]:
+    return [CoefficientUse(c.name, c.value, c.low, c.high, c.unit, c.source) for c in coeffs]
+
+
+def size_system(design: DesignInput) -> DesignOutput:
+    species = get_species(design.fish_species)
+    crop = get_crop(design.crop)
+
+    # 1. FRR sizes feed from grow area (the anchor).
+    feed_g_per_day = design.grow_area_m2 * crop.frr_g_per_m2_day
+
+    # 2. Feed -> fish biomass, adjusted for how well fish eat at this temperature.
+    temp_factor = temperature_feed_factor(species, design.temperature_c)
+    effective_feed_pct = species.feeding_rate_pct_bw * temp_factor
+    # biomass(kg) = feed(g/day) / (feed% as fraction) / 1000
+    fish_biomass_kg = feed_g_per_day / (effective_feed_pct / 100.0) / 1000.0
+
+    # 3. Biomass -> fish count (steady-state average; cohort logic NOT modeled).
+    fish_count = max(1, math.ceil(fish_biomass_kg / species.harvest_weight_kg))
+
+    # 4. Rearing tank volume from stocking density.
+    rearing_tank_volume_m3 = fish_biomass_kg / species.stocking_density_kg_m3
+    rearing_tank_volume_l = rearing_tank_volume_m3 * 1000.0
+
+    # 5. System volume = rearing tank + raft water + sump.
+    raft_water_m3 = design.grow_area_m2 * C.RAFT_WATER_DEPTH.value
+    subtotal_m3 = rearing_tank_volume_m3 + raft_water_m3
+    system_volume_m3 = subtotal_m3 / (1.0 - C.SUMP_FRACTION.value)
+    system_volume_l = system_volume_m3 * 1000.0
+
+    # 6. Pump turnover.
+    pump_turnover_lph = system_volume_l * C.PUMP_TURNOVER_RATE.value
+
+    # 7. Water balance (tank surface approximated from rearing tank at ~1 m depth).
+    tank_surface_m2 = rearing_tank_volume_m3 / 1.0
+    water = mb.water_balance(design.grow_area_m2, tank_surface_m2)
+    makeup_lpd = water["makeup_water_lpd"]
+
+    # 8. Biofilter media.
+    media_m2 = mb.biofilter_media_m2(feed_g_per_day, species)
+
+    # 9. Nitrogen consistency check (does NOT resize anything).
+    n_check = mb.nitrogen_check(feed_g_per_day, species, crop, design.grow_area_m2)
+
+    out = DesignOutput(
+        feasible=True,
+        system_volume_l=round(system_volume_l, 1),
+        rearing_tank_volume_l=round(rearing_tank_volume_l, 1),
+        fish_count=fish_count,
+        fish_biomass_kg=round(fish_biomass_kg, 2),
+        feed_g_per_day=round(feed_g_per_day, 1),
+        grow_area_m2=design.grow_area_m2,
+        pump_turnover_lph=round(pump_turnover_lph, 1),
+        biofilter_media_m2=media_m2,
+        makeup_water_lpd=makeup_lpd,
+        nitrogen_check=n_check,
+        not_modeled=list(NOT_MODELED),
+    )
+
+    # 10. Feasibility: water budget is the binding constraint we check in v1.
+    if makeup_lpd > design.water_budget_lpd:
+        out.feasible = False
+        out.binding_constraint = "water_budget"
+        # Nearest feasible: shrink grow area proportionally so makeup fits the budget.
+        if makeup_lpd > 0:
+            feasible_area = design.grow_area_m2 * (design.water_budget_lpd / makeup_lpd)
+            out.warnings.append(
+                f"Makeup water {makeup_lpd} L/day exceeds budget {design.water_budget_lpd} L/day. "
+                f"Nearest feasible: reduce grow area to ~{round(feasible_area, 1)} m2 "
+                f"(a {round((1 - feasible_area / design.grow_area_m2) * 100)}% cut)."
+            )
+
+    if not n_check["agrees"] and n_check["flag"]:
+        out.warnings.append(n_check["flag"])
+
+    # Temperature warning if fish are outside their optimal band.
+    if temp_factor < 1.0:
+        out.warnings.append(
+            f"{design.temperature_c} C is outside {species.name}'s optimal band "
+            f"({species.temp_opt_low_c}-{species.temp_opt_high_c} C); feeding scaled to "
+            f"{round(temp_factor * 100)}% — yields and sizing reflect reduced intake."
+        )
+
+    out.operating_envelope = _operating_envelope(species, crop, design)
+    out.bill_of_materials = _bill_of_materials(out)
+    out.maintenance_checklist = _maintenance_checklist()
+    out.assumptions = _assumptions(species, crop, temp_factor)
+    out.coefficients_used = _coeff_uses(
+        C.N_FRACTION_OF_PROTEIN, C.PLANT_N_UPTAKE_FRACTION, C.RAFT_WATER_DEPTH,
+        C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, C.NITRIFICATION_RATE,
+        C.EVAPOTRANSPIRATION_RATE, C.TANK_EVAPORATION_RATE, C.SAFETY_FACTOR,
+    )
+    return out
+
+
+def _operating_envelope(species, crop, design) -> dict:
+    return {
+        "ph_target": [max(species_ph_low(crop), 6.0), min(crop.ph_max, 7.0)],
+        "ph_do_not_exceed": [crop.ph_min, crop.ph_max],
+        "temperature_target_c": [species.temp_opt_low_c, species.temp_opt_high_c],
+        "temperature_do_not_exceed_c": [species.temp_min_c, species.temp_max_c],
+        "dissolved_oxygen_min_mg_l": 5.0,
+        "ammonia_nitrite_target": "as low as possible (≈0)",
+    }
+
+
+def species_ph_low(crop) -> float:
+    # Aquaponics compromise pH sits between fish, plants, and nitrifiers (~6.0-7.0).
+    return crop.ph_min
+
+
+def _bill_of_materials(out: DesignOutput) -> list[dict]:
+    return [
+        {"item": "rearing tank", "spec": f"~{round(out.rearing_tank_volume_l)} L", "qty": 1},
+        {"item": "raft / DWC grow bed", "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
+        {"item": "water pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
+        {"item": "biofilter media", "spec": f"~{out.biofilter_media_m2} m2 surface", "qty": 1},
+        {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L", "qty": 1},
+        {"item": "fish (fingerlings)", "spec": f"~{out.fish_count} head", "qty": out.fish_count},
+    ]
+
+
+def _maintenance_checklist() -> list[str]:
+    return [
+        "Daily: check fish behaviour, feed response, and aeration/pump operation.",
+        "Daily: top up makeup water; record the amount (logging standard).",
+        "Weekly: test pH, ammonia, nitrite, nitrate; record readings.",
+        "Weekly: inspect and clean pump intake and biofilter; check flow.",
+        "Monthly: remove settled solids; inspect roots for browning/slime.",
+    ]
+
+
+def _assumptions(species, crop, temp_factor) -> list[str]:
+    return [
+        f"Raft/DWC system, single fish species ({species.name}), single crop ({crop.name}).",
+        "Steady-state average biomass (no cohort/harvest scheduling).",
+        f"Feeding scaled to {round(temp_factor * 100)}% for the given mean temperature.",
+        "Coefficients are seed defaults — CALIBRATE against a real system before building.",
+        "Rainfall assumed 0 (covered/controlled system).",
+    ]

--- a/aqua_model/species.py
+++ b/aqua_model/species.py
@@ -1,0 +1,87 @@
+"""Fish species database — seed defaults, cited and ranged.
+
+v1 palette is intentionally small. Tilapia is the best-characterized aquaponics fish
+(FAO 589 uses it as the reference species); the others are coarser stubs to be
+calibrated. Every value should eventually be replaced by measured data per system.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FishSpecies:
+    name: str
+    feeding_rate_pct_bw: float    # % of body weight fed per day at grow-out (temp-adjusted at use)
+    fcr: float                    # feed conversion ratio (g feed / g growth)
+    feed_protein_pct: float       # % protein in the feed used for this species
+    body_protein_pct: float       # % protein of fish wet body mass (for N-retention)
+    harvest_weight_kg: float      # target individual weight at harvest
+    stocking_density_kg_m3: float # rearing-tank biomass density
+    temp_min_c: float             # viable water-temperature window
+    temp_opt_low_c: float
+    temp_opt_high_c: float
+    temp_max_c: float
+    source: str
+
+
+# Tilapia: the FAO 589 / UVI reference species. Best-supported numbers.
+TILAPIA = FishSpecies(
+    name="tilapia",
+    feeding_rate_pct_bw=1.5, fcr=1.7, feed_protein_pct=32.0,
+    body_protein_pct=16.0, harvest_weight_kg=0.5, stocking_density_kg_m3=20.0,
+    temp_min_c=14.0, temp_opt_low_c=27.0, temp_opt_high_c=30.0, temp_max_c=36.0,
+    source="FAO589/UVI",
+)
+
+# Catfish: warm-water, hardy. Coarse stub — calibrate.
+CATFISH = FishSpecies(
+    name="catfish",
+    feeding_rate_pct_bw=1.5, fcr=1.6, feed_protein_pct=32.0,
+    body_protein_pct=16.0, harvest_weight_kg=0.7, stocking_density_kg_m3=25.0,
+    temp_min_c=15.0, temp_opt_low_c=26.0, temp_opt_high_c=30.0, temp_max_c=34.0,
+    source="LIT",
+)
+
+# Trout: cold-water. Included to make the temperature logic meaningful. Coarse stub.
+TROUT = FishSpecies(
+    name="trout",
+    feeding_rate_pct_bw=1.2, fcr=1.2, feed_protein_pct=42.0,
+    body_protein_pct=18.0, harvest_weight_kg=0.4, stocking_density_kg_m3=20.0,
+    temp_min_c=5.0, temp_opt_low_c=12.0, temp_opt_high_c=18.0, temp_max_c=21.0,
+    source="LIT",
+)
+
+SPECIES: dict[str, FishSpecies] = {s.name: s for s in (TILAPIA, CATFISH, TROUT)}
+
+
+def get_species(name: str) -> FishSpecies:
+    key = (name or "").strip().lower()
+    if key not in SPECIES:
+        raise KeyError(
+            f"Unknown fish species {name!r}. Known: {sorted(SPECIES)}"
+        )
+    return SPECIES[key]
+
+
+def temperature_feed_factor(species: FishSpecies, temperature_c: float) -> float:
+    """Scale feeding rate by how close water temp is to the species optimum.
+
+    Fish eat most in their optimal band and progressively less toward their limits.
+    Outside the viable window the factor floors at a small positive value (they barely
+    eat) rather than zero, so sizing degrades gracefully instead of dividing by zero.
+    Returns a multiplier in [0.25, 1.0]. This is a coarse model (see not_modeled).
+    """
+    t = temperature_c
+    if species.temp_opt_low_c <= t <= species.temp_opt_high_c:
+        return 1.0
+    if t <= species.temp_min_c or t >= species.temp_max_c:
+        return 0.25
+    if t < species.temp_opt_low_c:
+        span = species.temp_opt_low_c - species.temp_min_c
+        frac = (t - species.temp_min_c) / span if span > 0 else 1.0
+    else:
+        span = species.temp_max_c - species.temp_opt_high_c
+        frac = (species.temp_max_c - t) / span if span > 0 else 1.0
+    return round(0.25 + 0.75 * max(0.0, min(1.0, frac)), 3)

--- a/aqua_model/tests/test_calibration.py
+++ b/aqua_model/tests/test_calibration.py
@@ -1,0 +1,68 @@
+"""CRITICAL — the acceptance gate. Reproduce the founder's REAL running system.
+
+This test is the line between "a model that runs" and "a model you can trust." It stays
+SKIPPED until the founder fills in REAL_SYSTEM from the one-sheet calibration record of the
+actual Taiwan system. The moment those numbers exist, this runs and must pass within the
+agreed tolerances (±15% on feed/day and grow area). Nitrate is intentionally NOT gated here
+(too sampling-dependent) — it belongs in a sanity band, not an acceptance test.
+
+To activate: replace REAL_SYSTEM = None with the measured values below.
+"""
+
+import math
+
+import pytest
+
+from aqua_model import size_system
+from aqua_model.validate import validate_design_input
+
+# Fill this from the calibration sheet to activate the gate, e.g.:
+# REAL_SYSTEM = {
+#     "fish_species": "tilapia",
+#     "crop": "lettuce",
+#     "grow_area_m2": 6.0,
+#     "temperature_c": 26.0,
+#     "water_budget_lpd": 200.0,
+#     "measured_feed_g_per_day": 360.0,   # what you actually feed
+#     "measured_grow_area_m2": 6.0,       # actual planted area (sanity cross-check)
+# }
+REAL_SYSTEM = None
+
+FEED_TOLERANCE = 0.15   # ±15%
+AREA_TOLERANCE = 0.15   # ±15%
+
+
+@pytest.mark.skipif(REAL_SYSTEM is None, reason="Awaiting founder's calibration sheet (Taiwan system).")
+def test_model_reproduces_real_system_within_tolerance():
+    di = validate_design_input(
+        fish_species=REAL_SYSTEM["fish_species"],
+        crop=REAL_SYSTEM["crop"],
+        grow_area_m2=REAL_SYSTEM["grow_area_m2"],
+        temperature_c=REAL_SYSTEM["temperature_c"],
+        water_budget_lpd=REAL_SYSTEM["water_budget_lpd"],
+    )
+    out = size_system(di)
+
+    feed_err = abs(out.feed_g_per_day - REAL_SYSTEM["measured_feed_g_per_day"]) / REAL_SYSTEM["measured_feed_g_per_day"]
+    assert feed_err <= FEED_TOLERANCE, (
+        f"feed/day off by {feed_err:.0%}: model {out.feed_g_per_day} vs "
+        f"measured {REAL_SYSTEM['measured_feed_g_per_day']}"
+    )
+
+    area_err = abs(out.grow_area_m2 - REAL_SYSTEM["measured_grow_area_m2"]) / REAL_SYSTEM["measured_grow_area_m2"]
+    assert area_err <= AREA_TOLERANCE
+
+
+@pytest.mark.skipif(REAL_SYSTEM is None, reason="Awaiting founder's calibration sheet (Taiwan system).")
+def test_real_system_is_feasible_or_flags_why_not():
+    di = validate_design_input(
+        fish_species=REAL_SYSTEM["fish_species"],
+        crop=REAL_SYSTEM["crop"],
+        grow_area_m2=REAL_SYSTEM["grow_area_m2"],
+        temperature_c=REAL_SYSTEM["temperature_c"],
+        water_budget_lpd=REAL_SYSTEM["water_budget_lpd"],
+    )
+    out = size_system(di)
+    # A real, running system should not be flagged infeasible; if it is, the warning
+    # must explain why (a signal our coefficients need calibration).
+    assert out.feasible or out.warnings

--- a/aqua_model/tests/test_logging_schema.py
+++ b/aqua_model/tests/test_logging_schema.py
@@ -1,0 +1,63 @@
+"""The logging standard validates rows loudly and stays versioned/consistent."""
+
+from aqua_model import logging_schema as ls
+
+
+def _good_row(**over):
+    row = {
+        "system_id": "tw-001",
+        "timestamp": "2026-06-16T08:00:00Z",
+        "water_temp_c": 26.0,
+        "ph": 6.8,
+        "ammonia_mg_l": 0.1,
+        "nitrite_mg_l": 0.0,
+        "nitrate_mg_l": 40.0,
+        "feed_g": 360.0,
+        "makeup_water_l": 30.0,
+        "fish_mortality_count": 0,
+    }
+    row.update(over)
+    return row
+
+
+def test_schema_is_versioned():
+    assert ls.SCHEMA_VERSION == "1.0.0"
+
+
+def test_header_matches_field_order_and_is_stable():
+    header = ls.csv_header()
+    assert header[0] == "system_id"
+    assert header[1] == "timestamp"
+    assert len(header) == len(ls.FIELDS)
+
+
+def test_good_row_validates_clean():
+    assert ls.validate_row(_good_row()) == []
+
+
+def test_missing_required_field_is_flagged():
+    row = _good_row()
+    del row["feed_g"]
+    problems = ls.validate_row(row)
+    assert any("feed_g" in p for p in problems)
+
+
+def test_out_of_range_value_is_flagged():
+    problems = ls.validate_row(_good_row(ph=99.0))
+    assert any("ph" in p for p in problems)
+
+
+def test_unknown_field_is_flagged_against_version():
+    problems = ls.validate_row(_good_row(secret_sauce=1))
+    assert any("unknown field" in p for p in problems)
+
+
+def test_non_numeric_where_numeric_expected_is_flagged():
+    problems = ls.validate_row(_good_row(water_temp_c="warm"))
+    assert any("water_temp_c" in p for p in problems)
+
+
+def test_schema_doc_renders():
+    doc = ls.schema_doc()
+    assert "install-logging standard v1.0.0" in doc
+    assert "nitrate_mg_l" in doc

--- a/aqua_model/tests/test_massbalance.py
+++ b/aqua_model/tests/test_massbalance.py
@@ -1,0 +1,70 @@
+"""CRITICAL: nitrogen check is a real (non-vacuous) consistency check, and the
+bed-oversizing bug is guarded — plants take a FRACTION of excreted N, never all of it."""
+
+import pytest
+
+from aqua_model import coefficients as C
+from aqua_model import massbalance as mb
+from aqua_model.crops import get_crop
+from aqua_model.species import get_species
+
+
+def test_excreted_n_derives_from_fcr_not_a_free_number():
+    sp = get_species("tilapia")
+    crop = get_crop("lettuce")
+    r = mb.nitrogen_check(feed_g_per_day=600.0, species=sp, crop=crop, frr_grow_area_m2=10.0)
+    # N retained must come from growth = feed / FCR, so excreted < fed and > 0.
+    assert r["n_retained_g_day"] > 0
+    assert 0 < r["n_excreted_g_day"] < r["n_fed_g_day"]
+
+
+def test_oversizing_guard_plants_take_a_fraction_not_all():
+    """REGRESSION GUARD: plant uptake must be ~30-50% of excreted N, never 100%."""
+    sp = get_species("tilapia")
+    crop = get_crop("lettuce")
+    r = mb.nitrogen_check(feed_g_per_day=600.0, species=sp, crop=crop, frr_grow_area_m2=10.0)
+    frac = r["n_plant_uptake_g_day"] / r["n_excreted_g_day"]
+    assert 0.30 <= frac <= 0.50
+    # approx because the output dict rounds N values to 2 decimals.
+    assert frac == pytest.approx(C.PLANT_N_UPTAKE_FRACTION.value, abs=1e-3)
+
+
+def test_check_is_non_vacuous_sinks_are_independent_not_residual():
+    """If sinks were a residual, closure would be exactly 0 by construction. They are
+    independent estimates, so closure is a genuine (small but nonzero-capable) signal."""
+    sp = get_species("tilapia")
+    crop = get_crop("lettuce")
+    r = mb.nitrogen_check(feed_g_per_day=600.0, species=sp, crop=crop, frr_grow_area_m2=10.0)
+    # plant + solids + water + denitri fractions = 0.40+0.35+0.20+0.05 = 1.00 here,
+    # but each is set INDEPENDENTLY; the residual is computed, not assumed zero.
+    assert "closure_residual_g_day" in r
+    independent_sum = (
+        r["n_plant_uptake_g_day"] + r["n_solids_g_day"]
+        + r["n_water_exchange_g_day"] + r["n_denitrification_g_day"]
+    )
+    # Residual is excreted minus the INDEPENDENT sum, not forced to zero.
+    assert abs((r["n_excreted_g_day"] - independent_sum) - r["closure_residual_g_day"]) < 0.1
+
+
+def test_check_flags_disagreement_when_area_is_wrong():
+    sp = get_species("tilapia")
+    crop = get_crop("lettuce")
+    # Pass a wildly wrong FRR area; the check should NOT silently agree.
+    r = mb.nitrogen_check(feed_g_per_day=600.0, species=sp, crop=crop, frr_grow_area_m2=1.0)
+    assert r["agrees"] is False
+    assert r["flag"] is not None
+
+
+def test_biofilter_media_positive_and_conservative():
+    sp = get_species("tilapia")
+    media = mb.biofilter_media_m2(feed_g_per_day=600.0, species=sp)
+    assert media > 0
+    # Safety factor makes it larger than the bare requirement.
+    bare = media / C.SAFETY_FACTOR.value
+    assert media > bare
+
+
+def test_water_balance_makeup_is_positive_and_excludes_uncaptured_rain():
+    w = mb.water_balance(grow_area_m2=10.0, tank_surface_m2=2.0)
+    assert w["makeup_water_lpd"] > 0
+    assert w["rainfall_lpd"] == 0.0  # covered system default

--- a/aqua_model/tests/test_report.py
+++ b/aqua_model/tests/test_report.py
@@ -1,0 +1,51 @@
+"""The funder-facing report renders completely and carries the honesty layer."""
+
+from aqua_model import size_system
+from aqua_model.report import to_markdown
+from aqua_model.validate import validate_design_input
+
+
+def _out_and_design():
+    di = validate_design_input(
+        fish_species="tilapia", crop="lettuce", grow_area_m2=6.0,
+        temperature_c=26.0, water_budget_lpd=200.0,
+    )
+    return di, size_system(di)
+
+
+def test_report_includes_all_major_sections():
+    di, out = _out_and_design()
+    md = to_markdown(di, out, site="Ouagadougou pilot")
+    for heading in (
+        "# Aquaponics System Design — Ouagadougou pilot",
+        "## Inputs", "## Sized System", "## Bill of Materials",
+        "## Operating Envelope", "## Maintenance Checklist",
+        "## Nitrogen Consistency Check", "## NOT Modeled", "## Coefficients Used",
+    ):
+        assert heading in md
+
+
+def test_report_cites_every_coefficient_with_a_source():
+    di, out = _out_and_design()
+    md = to_markdown(di, out)
+    # Every coefficient row must carry a source token.
+    for c in out.coefficients_used:
+        assert c.name in md
+        assert c.source in md
+
+
+def test_report_states_what_is_not_modeled():
+    di, out = _out_and_design()
+    md = to_markdown(di, out)
+    assert "must not treat this as a complete engineering design" in md
+    assert "pH" in md
+
+
+def test_report_surfaces_infeasibility():
+    di = validate_design_input(
+        fish_species="tilapia", crop="lettuce", grow_area_m2=50.0,
+        temperature_c=28.0, water_budget_lpd=10.0,
+    )
+    out = size_system(di)
+    md = to_markdown(di, out)
+    assert "NOT FEASIBLE" in md

--- a/aqua_model/tests/test_sizing.py
+++ b/aqua_model/tests/test_sizing.py
@@ -1,0 +1,69 @@
+"""Sizing behaviour: happy path, infeasibility, temperature sensitivity, honesty layer."""
+
+from aqua_model import size_system
+from aqua_model.validate import validate_design_input
+
+
+def _design(**over):
+    base = dict(
+        fish_species="tilapia", crop="lettuce", grow_area_m2=10.0,
+        temperature_c=28.0, water_budget_lpd=5000.0,
+    )
+    base.update(over)
+    return validate_design_input(**base)
+
+
+def test_happy_path_produces_complete_artifact():
+    out = size_system(_design())
+    assert out.feasible is True
+    assert out.feed_g_per_day > 0
+    assert out.fish_count >= 1
+    assert out.fish_biomass_kg > 0
+    assert out.system_volume_l > out.rearing_tank_volume_l  # system includes raft + sump
+    assert out.pump_turnover_lph > 0
+    assert out.biofilter_media_m2 and out.biofilter_media_m2 > 0
+    # Build artifacts present (Shape B output).
+    assert out.bill_of_materials and len(out.bill_of_materials) >= 5
+    assert out.operating_envelope.get("temperature_target_c")
+    assert out.maintenance_checklist
+    # Honesty layer present.
+    assert out.not_modeled and any("pH" in n for n in out.not_modeled)
+    assert out.coefficients_used and all(c.source for c in out.coefficients_used)
+
+
+def test_feed_follows_frr_exactly():
+    out = size_system(_design(grow_area_m2=10.0, crop="lettuce"))
+    # lettuce FRR default = 60 g/m2/day -> 10 m2 = 600 g/day
+    assert out.feed_g_per_day == 600.0
+
+
+def test_fruiting_crop_feeds_more_than_leafy():
+    leafy = size_system(_design(crop="lettuce"))
+    fruiting = size_system(_design(crop="tomato"))
+    assert fruiting.feed_g_per_day > leafy.feed_g_per_day
+
+
+def test_infeasible_when_water_budget_too_low():
+    out = size_system(_design(grow_area_m2=50.0, water_budget_lpd=10.0))
+    assert out.feasible is False
+    assert out.binding_constraint == "water_budget"
+    # Nearest-feasible hint names a smaller area, not an exception or silent number.
+    assert any("reduce grow area" in w for w in out.warnings)
+
+
+def test_temperature_sensitivity_changes_sizing():
+    warm = size_system(_design(temperature_c=28.0))   # optimal for tilapia
+    cold = size_system(_design(temperature_c=16.0))   # well below optimum
+    # Same feed (FRR is area-based), but colder fish eat less per kg, so the SAME feed
+    # implies MORE standing biomass -> larger tank. Sizing must differ.
+    assert warm.feed_g_per_day == cold.feed_g_per_day
+    assert cold.fish_biomass_kg > warm.fish_biomass_kg
+    assert any("outside" in w for w in cold.warnings)
+
+
+def test_never_raises_on_valid_input_extremes():
+    # Tiny and huge valid systems both return a result object.
+    small = size_system(_design(grow_area_m2=0.5))
+    big = size_system(_design(grow_area_m2=1000.0, water_budget_lpd=10_000_000.0))
+    assert small.fish_count >= 1
+    assert big.feasible in (True, False)

--- a/aqua_model/tests/test_validate.py
+++ b/aqua_model/tests/test_validate.py
@@ -1,0 +1,57 @@
+"""CRITICAL: the trust gate rejects bad inputs loudly (no silent defaults/clamps)."""
+
+import pytest
+
+from aqua_model.validate import validate_design_input, ValidationError
+
+
+def _ok(**over):
+    base = dict(
+        fish_species="tilapia", crop="lettuce", grow_area_m2=10.0,
+        temperature_c=28.0, water_budget_lpd=500.0,
+    )
+    base.update(over)
+    return validate_design_input(**base)
+
+
+def test_valid_input_passes_and_normalizes():
+    di = _ok(fish_species="Tilapia", crop="Lettuce")  # mixed case
+    assert di.fish_species == "tilapia"
+    assert di.crop == "lettuce"
+    assert di.grow_area_m2 == 10.0
+
+
+def test_unknown_species_rejected():
+    with pytest.raises(ValidationError) as e:
+        _ok(fish_species="dragon")
+    assert any("fish_species" in m for m in e.value.errors)
+
+
+def test_unknown_crop_rejected():
+    with pytest.raises(ValidationError):
+        _ok(crop="moonfruit")
+
+
+def test_out_of_range_temperature_rejected():
+    with pytest.raises(ValidationError) as e:
+        _ok(temperature_c=99.0)
+    assert any("temperature_c" in m for m in e.value.errors)
+
+
+def test_non_numeric_area_rejected_not_defaulted():
+    with pytest.raises(ValidationError):
+        _ok(grow_area_m2="lots")
+
+
+def test_bool_is_not_accepted_as_number():
+    with pytest.raises(ValidationError):
+        _ok(water_budget_lpd=True)
+
+
+def test_multiple_errors_collected_together():
+    with pytest.raises(ValidationError) as e:
+        validate_design_input(
+            fish_species="dragon", crop="moonfruit",
+            grow_area_m2=-5, temperature_c=200, water_budget_lpd="n/a",
+        )
+    assert len(e.value.errors) >= 4

--- a/aqua_model/types.py
+++ b/aqua_model/types.py
@@ -1,0 +1,68 @@
+"""Typed inputs and outputs for the calculator.
+
+The DesignInput is the ONLY thing the trust zone accepts. It is built by the
+validation gate (`validate.py`), never populated directly from raw LLM output.
+
+The DesignOutput is a build artifact, not just numbers: it carries the bill of
+materials, operating envelope, maintenance checklist, the nitrogen consistency
+check, the coefficients used (with sources), and an explicit list of what is NOT
+modeled. That honesty layer is the credibility collateral (CEO review).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class DesignInput:
+    """Fixed inputs for ONE system. No palette, no objective — this is a calculator,
+    not an optimizer (the species/crop search and goal belong to the M2 optimizer)."""
+
+    fish_species: str          # must exist in species.SPECIES
+    crop: str                  # must exist in crops.CROPS
+    grow_area_m2: float        # the anchor; effective raft/DWC planted area
+    temperature_c: float       # mean water temperature
+    water_budget_lpd: float    # makeup water available per day (sanity-checked)
+    source_water_note: str | None = None  # salinity/quality caveat
+
+
+@dataclass(frozen=True)
+class CoefficientUse:
+    """Provenance record: one coefficient as it was used in a specific design run."""
+
+    name: str
+    value: float
+    low: float
+    high: float
+    unit: str
+    source: str
+
+
+@dataclass
+class DesignOutput:
+    feasible: bool
+    binding_constraint: str | None = None   # set when infeasible -> nearest-feasible hint
+
+    # --- sizing numbers ---
+    system_volume_l: float = 0.0
+    rearing_tank_volume_l: float = 0.0
+    fish_count: int = 0
+    fish_biomass_kg: float = 0.0
+    feed_g_per_day: float = 0.0
+    grow_area_m2: float = 0.0
+    pump_turnover_lph: float = 0.0
+    biofilter_media_m2: float | None = None
+    makeup_water_lpd: float = 0.0
+
+    # --- build artifacts (Shape B) ---
+    bill_of_materials: list[dict] = field(default_factory=list)
+    operating_envelope: dict = field(default_factory=dict)
+    maintenance_checklist: list[str] = field(default_factory=list)
+
+    # --- honesty layer ---
+    nitrogen_check: dict = field(default_factory=dict)
+    coefficients_used: list[CoefficientUse] = field(default_factory=list)
+    not_modeled: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)

--- a/aqua_model/validate.py
+++ b/aqua_model/validate.py
@@ -1,0 +1,89 @@
+"""The trust boundary.
+
+Nothing enters the model except a DesignInput built HERE, after range/unit/type checks.
+The LLM (or any caller) may PROPOSE raw values, but `validate_design_input` is the only
+door into `aqua_model`. A bad value is rejected loudly — never silently defaulted, never
+silently clamped — so a hallucinated input cannot produce a confidently-wrong design.
+"""
+
+from __future__ import annotations
+
+from .crops import CROPS
+from .species import SPECIES
+from .types import DesignInput
+
+
+class ValidationError(ValueError):
+    """Raised when a proposed input cannot safely enter the model. Carries all problems."""
+
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+# Hard sanity bounds. Outside these, refuse rather than compute nonsense.
+_BOUNDS = {
+    "grow_area_m2": (0.1, 100_000.0),
+    "temperature_c": (0.0, 45.0),
+    "water_budget_lpd": (0.0, 10_000_000.0),
+}
+
+
+def validate_design_input(
+    fish_species,
+    crop,
+    grow_area_m2,
+    temperature_c,
+    water_budget_lpd,
+    source_water_note=None,
+) -> DesignInput:
+    errors: list[str] = []
+
+    species_key = str(fish_species or "").strip().lower()
+    if species_key not in SPECIES:
+        errors.append(f"unknown fish_species {fish_species!r}; known: {sorted(SPECIES)}")
+
+    crop_key = str(crop or "").strip().lower()
+    if crop_key not in CROPS:
+        errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
+
+    grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
+    temperature_c = _as_float(temperature_c, "temperature_c", errors)
+    water_budget_lpd = _as_float(water_budget_lpd, "water_budget_lpd", errors)
+
+    for field, val in (
+        ("grow_area_m2", grow_area_m2),
+        ("temperature_c", temperature_c),
+        ("water_budget_lpd", water_budget_lpd),
+    ):
+        if val is None:
+            continue
+        lo, hi = _BOUNDS[field]
+        if not (lo <= val <= hi):
+            errors.append(f"{field}={val} out of range [{lo}, {hi}]")
+
+    if source_water_note is not None and not isinstance(source_water_note, str):
+        errors.append("source_water_note must be a string or None")
+
+    if errors:
+        raise ValidationError(errors)
+
+    return DesignInput(
+        fish_species=species_key,
+        crop=crop_key,
+        grow_area_m2=float(grow_area_m2),
+        temperature_c=float(temperature_c),
+        water_budget_lpd=float(water_budget_lpd),
+        source_water_note=source_water_note,
+    )
+
+
+def _as_float(value, field, errors):
+    if isinstance(value, bool):  # bool is an int subclass; reject explicitly
+        errors.append(f"{field} must be a number, got bool")
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        errors.append(f"{field} must be a number, got {value!r}")
+        return None

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = aqua_model/tests
+testpaths = aqua_model/tests agent/tests
 python_files = test_*.py
 addopts = -v

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = aqua_model/tests
+python_files = test_*.py
+addopts = -v

--- a/requirement.txt
+++ b/requirement.txt
@@ -7,6 +7,7 @@ transformers
 sentence-transformers
 langchain
 langchain_community
+langchain_ollama
 faiss-cpu
 openpyxl
 streamlit

--- a/requirement.txt
+++ b/requirement.txt
@@ -7,7 +7,10 @@ transformers
 sentence-transformers
 langchain
 langchain_community
-langchain_ollama
+# LLM backends (pluggable via LLM_PROVIDER). Install only the one(s) you use.
+langchain_ollama                  # local/offline (default)
+# langchain-nvidia-ai-endpoints   # hosted NVIDIA open models (needs NVIDIA_API_KEY)
+# langchain-huggingface           # hosted HF Inference (needs HUGGINGFACEHUB_API_TOKEN)
 faiss-cpu
 openpyxl
 streamlit

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -22,7 +22,6 @@ from uuid import uuid4
 
 import requests_cache
 from langchain.prompts import ChatPromptTemplate
-from langchain_ollama.llms import OllamaLLM
 
 # --- RAG deps (FAISS) ---
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -63,7 +62,22 @@ logging.basicConfig(level=LOG_LEVEL, format="[%(levelname)s] %(message)s")
 # LLM
 # =============================================================================
 
-llm = OllamaLLM(model="llama3", temperature=0)
+class _LazyLLM:
+    """Defer LLM construction until first use, and route through the pluggable backend
+    (agent.llm). Importing this module therefore needs NO provider library or running
+    model server — the calculator/design path stays free of the chat stack. Set the
+    backend with LLM_PROVIDER=ollama|nvidia|hf (see agent/llm.py)."""
+
+    _client = None
+
+    def invoke(self, prompt):
+        if _LazyLLM._client is None:
+            from agent.llm import get_llm
+            _LazyLLM._client = get_llm(temperature=0.0)
+        return _LazyLLM._client.invoke(prompt)
+
+
+llm = _LazyLLM()
 
 
 # =============================================================================


### PR DESCRIPTION
## What this is

M1 of the refactor from RAG chatbot → aquaponics **design/optimization agent**. Introduces a verified, deterministic design core with the LLM demoted to a swappable wrapper. Grounded in the approved design doc + eng/CEO reviews.

The guiding split: **the design math has zero LLM in it.** The LLM only does fact-collection, routing, and explanation. So a sized system is auditable and reproducible regardless of which model (or no model) is running.

## What's included

**`aqua_model/` — the trust zone (pure Python, no LLM, no network, no `srcs/` imports)**
- `coefficients.py` — cited data layer: every constant carries value + range + unit + source (FAO 589 / UVI / literature) + a conservative safety factor.
- `species.py` / `crops.py` — seed databases; FRR (sizing) kept separate from N-uptake (check).
- `sizing.py` — `size_system()`: FRR anchors sizing; infeasibility returns a nearest-feasible hint; output is a build artifact (BOM, operating envelope, maintenance checklist, not-modeled caveats).
- `massbalance.py` — nitrogen **consistency check** (sinks estimated independently, never a residual — guards the bed-oversizing bug), water balance, biofilter.
- `validate.py` — the trust gate: typed `DesignInput` only, bad input rejected loudly.
- `report.py` — funder-facing Markdown report (cited coefficients + "NOT modeled" disclosure).
- `logging_schema.py` — versioned (v1.0.0) install-logging standard — the dataset moat.

**`agent/` — the LLM-facing layer (may import `aqua_model`, never the reverse)**
- `llm.py` — pluggable backend: `LLM_PROVIDER=ollama|nvidia|hf` (+ `LLM_MODEL`). Provider libs imported lazily. HF default `Qwen/Qwen2.5-7B-Instruct` (Apache-2.0, strong at JSON).
- `facts.py` — UI↔model seam (validated `design_from_form`).
- `calculator_ui.py` — Streamlit "Design Calculator" view.

**`app.py`** — sidebar Mode switch (chat | calculator); `srcs/chatbot.py` lazy-loaded so the calculator runs with only Streamlit installed (no langchain/faiss/Ollama). Completes the lazy-LLM-init decision.

## Tests
44 passed, 2 skipped. The 2 skips are the **calibration gate** — they go green once the founder's real-system numbers fill `REAL_SYSTEM` in `test_calibration.py` (model → validated, not just built). Includes headless Streamlit `AppTest` smokes that drive the form end to end.

## Also
- `requirement.txt`: add `langchain_ollama` (fixes an import-time crash); list optional provider packages.
- `TODOS.md`: deferred items (pilot-proposal generator, report sensitivity table, RAG dedup).

## Not in this PR (sequenced)
- M2 optimizer (palette/objective search) · PDF render of the report · `agent/facts.py` full parser extraction (M3) · digital twin (M4) · phone maintenance assistant (M5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)