### PR TITLE
M2: fish/crop ratio optimizer + Streamlit Optimize tab

### DIFF
--- a/agent/optimizer_ui.py
+++ b/agent/optimizer_ui.py
@@ -1,0 +1,100 @@
+"""Streamlit view for the M2 optimizer — find the fish/crop ratio for max efficiency.
+
+A structured form → optimize() → the best ratio, the ranked alternatives, the improvement
+over a naive even split, and the honesty layer. Pure deterministic search, no LLM.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from aqua_model import optimize, OptimizeInput, OBJECTIVES
+from aqua_model.crops import CROPS
+from aqua_model.species import SPECIES
+
+_OBJECTIVE_LABELS = {
+    "water_efficiency": "Water efficiency (food per m³ water)",
+    "food": "Total food (kg/year)",
+    "protein": "Total protein (kg/year)",
+}
+
+
+def render_optimizer() -> None:
+    st.subheader("Optimize Ratio")
+    st.caption(
+        "Search fish × crop-mix combinations for the most efficient ratio under your "
+        "constraint. Deterministic — no AI guessing; every result is reproducible."
+    )
+
+    with st.form("optimize_form"):
+        col1, col2 = st.columns(2)
+        with col1:
+            grow_area = st.number_input("Grow area (m²)", min_value=0.1, value=10.0, step=0.5)
+            temperature = st.number_input("Mean water temp (°C)", min_value=0.0, max_value=45.0, value=28.0, step=0.5)
+            water_budget = st.number_input("Water budget (L/day)", min_value=0.0, value=5000.0, step=50.0)
+        with col2:
+            objective = st.selectbox(
+                "Maximize", list(OBJECTIVES),
+                format_func=lambda o: _OBJECTIVE_LABELS.get(o, o),
+            )
+            fish_palette = st.multiselect("Fish to consider", sorted(SPECIES), default=sorted(SPECIES))
+            crop_palette = st.multiselect("Crops to consider", sorted(CROPS), default=sorted(CROPS))
+        submitted = st.form_submit_button("Optimize", use_container_width=True)
+
+    if not submitted:
+        st.info("Set inputs and press **Optimize**.")
+        return
+
+    if not fish_palette or not crop_palette:
+        st.error("Pick at least one fish and one crop.")
+        return
+
+    res = optimize(OptimizeInput(
+        grow_area_m2=grow_area, temperature_c=temperature, water_budget_lpd=water_budget,
+        objective=objective, fish_palette=tuple(fish_palette), crop_palette=tuple(crop_palette),
+    ))
+
+    if res.best is None:
+        st.warning(
+            f"No feasible design within {water_budget:g} L/day. "
+            f"Searched {res.searched} combinations, none fit the water budget. "
+            "Increase the budget or reduce grow area."
+        )
+        return
+
+    b = res.best
+    st.success(f"Best ratio: **{b.fish_species}** + " + _fmt_mix(b.crop_allocation))
+    if res.improvement_vs_baseline_pct is not None:
+        st.metric(
+            f"{_OBJECTIVE_LABELS.get(objective, objective)}",
+            f"{b.score:g}",
+            delta=f"{res.improvement_vs_baseline_pct:+g}% vs even split",
+        )
+
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Food", f"{b.food_kg_yr:g} kg/yr")
+    c2.metric("Protein", f"{b.protein_kg_yr:g} kg/yr")
+    c3.metric("Makeup water", f"{b.makeup_water_lpd:g} L/day")
+    st.caption(f"Searched {res.searched} combinations, {res.feasible_count} feasible.")
+
+    with st.expander("Top alternatives"):
+        st.table([
+            {
+                "fish": c.fish_species,
+                "crop mix": _fmt_mix(c.crop_allocation),
+                "score": c.score,
+                "food kg/yr": c.food_kg_yr,
+                "makeup L/day": c.makeup_water_lpd,
+            }
+            for c in res.ranked[:8]
+        ])
+    with st.expander("What is NOT optimized (read before quoting outcomes)"):
+        for n in res.not_modeled:
+            st.markdown(f"- {n}")
+    with st.expander("Assumptions"):
+        for a in res.assumptions:
+            st.markdown(f"- {a}")
+
+
+def _fmt_mix(alloc: dict[str, float]) -> str:
+    return ", ".join(f"{int(round(frac * 100))}% {crop}" for crop, frac in alloc.items())

--- a/agent/tests/test_optimizer_ui.py
+++ b/agent/tests/test_optimizer_ui.py
@@ -1,0 +1,44 @@
+"""Headless smoke test of the Optimize Ratio Streamlit view."""
+
+import pytest
+
+pytest.importorskip("streamlit.testing.v1")
+from streamlit.testing.v1 import AppTest  # noqa: E402
+
+_APP = "from agent.optimizer_ui import render_optimizer; render_optimizer()"
+
+
+def test_optimizer_renders_form():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    assert not at.exception
+    assert "Optimize Ratio" in [s.value for s in at.subheader]
+    assert len(at.number_input) == 3
+    assert len(at.selectbox) == 1            # objective
+    assert len(at.multiselect) == 2          # fish + crop palettes
+
+
+def test_optimizer_runs_and_reports_a_best_ratio():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.number_input[0].set_value(10.0)       # grow area
+    at.number_input[1].set_value(28.0)       # temperature
+    at.number_input[2].set_value(5000.0)     # water budget
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    successes = " ".join(s.value for s in at.success)
+    assert "Best ratio" in successes
+    # A delta-bearing metric (improvement vs even split) is shown.
+    assert len(at.metric) >= 1
+
+
+def test_optimizer_warns_when_no_feasible_design():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.number_input[0].set_value(80.0)       # large area
+    at.number_input[1].set_value(28.0)
+    at.number_input[2].set_value(1.0)        # impossible budget
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    assert any("No feasible design" in w.value for w in at.warning)

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from typing import List
 import streamlit as st
 
 from agent.calculator_ui import render_calculator
+from agent.optimizer_ui import render_optimizer
 
 
 APP_TITLE = "Aquaponics Assistant"
@@ -139,12 +140,16 @@ def main() -> None:
 
     mode = st.sidebar.radio(
         "Mode",
-        ("Assistant (chat)", "Design Calculator"),
-        help="Chat troubleshoots a running system. Calculator sizes a new one deterministically.",
+        ("Assistant (chat)", "Design Calculator", "Optimize Ratio"),
+        help="Chat troubleshoots a running system. Calculator sizes one. Optimizer finds the "
+             "best fish/crop ratio for your constraint.",
     )
 
     if mode == "Design Calculator":
         render_calculator()
+        return
+    if mode == "Optimize Ratio":
+        render_optimizer()
         return
 
     _render_sidebar()

--- a/aqua_model/__init__.py
+++ b/aqua_model/__init__.py
@@ -17,11 +17,17 @@ Design rules (from the approved design doc + eng/CEO reviews):
 """
 
 from .sizing import size_system
+from .optimizer import optimize, OptimizeInput, OptimizeResult, Candidate, OBJECTIVES
 from .validate import validate_design_input, ValidationError
 from .types import DesignInput, DesignOutput, CoefficientUse
 
 __all__ = [
     "size_system",
+    "optimize",
+    "OptimizeInput",
+    "OptimizeResult",
+    "Candidate",
+    "OBJECTIVES",
     "validate_design_input",
     "ValidationError",
     "DesignInput",

--- a/aqua_model/crops.py
+++ b/aqua_model/crops.py
@@ -18,6 +18,8 @@ class Crop:
     frr_low: float
     frr_high: float
     n_uptake_g_per_m2_day: float # N removed by plants per m2/day — CONSISTENCY CHECK only
+    yield_kg_per_m2_year: float  # edible fresh yield per m2 per year — OPTIMIZER objective (seed/LIT)
+    edible_protein_pct: float    # % protein of edible fresh mass — for the protein objective
     ph_min: float
     ph_max: float
     temp_min_c: float
@@ -30,12 +32,14 @@ LETTUCE = Crop(
     name="lettuce", category="leafy",
     frr_g_per_m2_day=60.0, frr_low=40.0, frr_high=80.0,
     n_uptake_g_per_m2_day=0.8,
+    yield_kg_per_m2_year=25.0, edible_protein_pct=1.4,
     ph_min=5.5, ph_max=7.0, temp_min_c=10.0, temp_max_c=26.0, source="FAO589/UVI",
 )
 BASIL = Crop(
     name="basil", category="leafy",
     frr_g_per_m2_day=70.0, frr_low=50.0, frr_high=90.0,
     n_uptake_g_per_m2_day=1.0,
+    yield_kg_per_m2_year=15.0, edible_protein_pct=3.0,
     ph_min=5.5, ph_max=7.0, temp_min_c=18.0, temp_max_c=30.0, source="LIT",
 )
 
@@ -44,6 +48,7 @@ TOMATO = Crop(
     name="tomato", category="fruiting",
     frr_g_per_m2_day=110.0, frr_low=80.0, frr_high=140.0,
     n_uptake_g_per_m2_day=1.6,
+    yield_kg_per_m2_year=30.0, edible_protein_pct=0.9,
     ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589",
 )
 

--- a/aqua_model/optimizer.py
+++ b/aqua_model/optimizer.py
@@ -1,0 +1,192 @@
+"""M2 optimizer — adjust the fish/plant ratio for maximum efficiency.
+
+Method: BOUNDED ENUMERATION over the small palette (per the design doc — no LP/MILP solver;
+the objective and constraints are nonlinear and the palette is tiny, so enumeration is both
+simpler and correct). For each (fish species × crop-area allocation) it sizes the system,
+checks feasibility against the binding constraint (water budget in v1), scores it by the
+chosen objective, and returns the ranked best with the same honesty layer as M1.
+
+Objectives:
+  food            -> total edible mass per year (fish growth + crop yield), kg/yr
+  protein         -> total edible protein per year, kg/yr
+  water_efficiency-> food per unit makeup water, kg per m3/yr   (the founder's likely objective)
+
+What it does NOT optimize (seed model): money/value (no price data), labour, BOM cost,
+local availability. Those are real for Shape-B quoting and are deferred (see not_modeled).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations_with_replacement
+
+from . import coefficients as C
+from . import massbalance as mb
+from .crops import CROPS, get_crop
+from .species import SPECIES, get_species, temperature_feed_factor
+
+OBJECTIVES = ("food", "protein", "water_efficiency")
+_ALLOC_STEPS = 4  # area is split into quarters across crops (bounded enumeration granularity)
+
+
+@dataclass(frozen=True)
+class OptimizeInput:
+    grow_area_m2: float
+    temperature_c: float
+    water_budget_lpd: float
+    objective: str = "water_efficiency"
+    fish_palette: tuple[str, ...] = tuple(sorted(SPECIES))
+    crop_palette: tuple[str, ...] = tuple(sorted(CROPS))
+
+
+@dataclass
+class Candidate:
+    fish_species: str
+    crop_allocation: dict[str, float]   # crop -> fraction of grow area (sums to 1)
+    feasible: bool
+    score: float
+    food_kg_yr: float
+    protein_kg_yr: float
+    makeup_water_lpd: float
+    water_efficiency_kg_per_m3: float
+    feed_g_per_day: float
+    fish_biomass_kg: float
+
+
+@dataclass
+class OptimizeResult:
+    objective: str
+    best: Candidate | None
+    ranked: list[Candidate] = field(default_factory=list)
+    searched: int = 0
+    feasible_count: int = 0
+    baseline: Candidate | None = None          # naive even-split, same best fish
+    improvement_vs_baseline_pct: float | None = None
+    not_modeled: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+
+
+_NOT_MODELED = [
+    "monetary value / price, labour, and bill-of-materials cost",
+    "local availability of fish, crops, feed, and materials",
+    "market demand for the chosen crop/fish mix",
+    "per-crop evapotranspiration — water use is modeled per-m2 (crop-agnostic) in v1, so the "
+    "water-efficiency objective is currently yield-driven; calibrate per-crop ET to refine it",
+    "everything aqua_model already does not model (pH, micronutrients, solids, pests, cohorts)",
+]
+
+
+def _allocations(crops: tuple[str, ...], steps: int = _ALLOC_STEPS):
+    """Yield crop->fraction dicts: integer compositions of `steps` quarters over `crops`,
+    dropping zero-area crops. Bounded and deterministic."""
+    n = len(crops)
+    seen = set()
+    # Each composition = a multiset of `steps` picks among crop indices.
+    for combo in combinations_with_replacement(range(n), steps):
+        counts = [0] * n
+        for i in combo:
+            counts[i] += 1
+        alloc = {crops[i]: counts[i] / steps for i in range(n) if counts[i] > 0}
+        key = tuple(sorted(alloc.items()))
+        if key not in seen:
+            seen.add(key)
+            yield alloc
+
+
+def _evaluate(fish_name: str, alloc: dict[str, float], inp: OptimizeInput) -> Candidate:
+    species = get_species(fish_name)
+    area = inp.grow_area_m2
+
+    # Feed from the area-weighted FRR of the mix (FRR is the sizing rule).
+    feed_g_day = sum(area * frac * get_crop(c).frr_g_per_m2_day for c, frac in alloc.items())
+
+    temp_factor = temperature_feed_factor(species, inp.temperature_c)
+    eff_pct = species.feeding_rate_pct_bw * temp_factor
+    fish_biomass_kg = feed_g_day / (eff_pct / 100.0) / 1000.0 if eff_pct > 0 else 0.0
+
+    # Annual food: crop yield (per allocated area) + fish growth (= feed / FCR).
+    crop_food_kg_yr = sum(area * frac * get_crop(c).yield_kg_per_m2_year for c, frac in alloc.items())
+    fish_growth_kg_yr = (feed_g_day / species.fcr) / 1000.0 * 365.0
+    food_kg_yr = crop_food_kg_yr + fish_growth_kg_yr
+
+    crop_protein_kg_yr = sum(
+        area * frac * get_crop(c).yield_kg_per_m2_year * (get_crop(c).edible_protein_pct / 100.0)
+        for c, frac in alloc.items()
+    )
+    fish_protein_kg_yr = fish_growth_kg_yr * (species.body_protein_pct / 100.0)
+    protein_kg_yr = crop_protein_kg_yr + fish_protein_kg_yr
+
+    # Water balance + feasibility (water is the binding constraint in v1).
+    tank_surface_m2 = (fish_biomass_kg / species.stocking_density_kg_m3) / 1.0
+    makeup_lpd = mb.water_balance(area, tank_surface_m2)["makeup_water_lpd"]
+    annual_makeup_m3 = makeup_lpd * 365.0 / 1000.0
+    water_eff = food_kg_yr / annual_makeup_m3 if annual_makeup_m3 > 0 else 0.0
+    feasible = makeup_lpd <= inp.water_budget_lpd
+
+    score = {
+        "food": food_kg_yr,
+        "protein": protein_kg_yr,
+        "water_efficiency": water_eff,
+    }[inp.objective]
+
+    return Candidate(
+        fish_species=fish_name,
+        crop_allocation={c: round(f, 3) for c, f in alloc.items()},
+        feasible=feasible,
+        score=round(score, 3),
+        food_kg_yr=round(food_kg_yr, 1),
+        protein_kg_yr=round(protein_kg_yr, 2),
+        makeup_water_lpd=makeup_lpd,
+        water_efficiency_kg_per_m3=round(water_eff, 2),
+        feed_g_per_day=round(feed_g_day, 1),
+        fish_biomass_kg=round(fish_biomass_kg, 2),
+    )
+
+
+def optimize(inp: OptimizeInput) -> OptimizeResult:
+    if inp.objective not in OBJECTIVES:
+        raise ValueError(f"Unknown objective {inp.objective!r}. Supported: {OBJECTIVES}.")
+    if not inp.fish_palette or not inp.crop_palette:
+        raise ValueError("fish_palette and crop_palette must be non-empty.")
+
+    # Search the quarter-grid PLUS the exact even-split, so the optimizer provably can
+    # never score below the naive baseline (best >= baseline by construction).
+    even = {c: 1.0 / len(inp.crop_palette) for c in inp.crop_palette}
+    allocs = list(_allocations(tuple(inp.crop_palette)))
+    if not any(a == even for a in allocs):
+        allocs.append(even)
+
+    candidates: list[Candidate] = []
+    for fish in inp.fish_palette:
+        for alloc in allocs:
+            candidates.append(_evaluate(fish, alloc, inp))
+
+    feasible = [c for c in candidates if c.feasible]
+    ranked = sorted(feasible, key=lambda c: c.score, reverse=True)
+    best = ranked[0] if ranked else None
+
+    # Naive baseline: even split across the whole crop palette, using the best design's fish
+    # (or the first species if nothing is feasible). This is what the optimizer must beat.
+    baseline_fish = best.fish_species if best else inp.fish_palette[0]
+    baseline = _evaluate(baseline_fish, even, inp)
+
+    improvement = None
+    if best and baseline.score > 0:
+        improvement = round((best.score - baseline.score) / baseline.score * 100.0, 1)
+
+    return OptimizeResult(
+        objective=inp.objective,
+        best=best,
+        ranked=ranked,
+        searched=len(candidates),
+        feasible_count=len(feasible),
+        baseline=baseline,
+        improvement_vs_baseline_pct=improvement,
+        not_modeled=list(_NOT_MODELED),
+        assumptions=[
+            f"Bounded enumeration: {len(candidates)} candidates "
+            f"({len(inp.fish_palette)} fish × crop-mix allocations in 1/{_ALLOC_STEPS} steps).",
+            "Water budget is the binding feasibility constraint (v1).",
+            "Yields and protein are seed coefficients — calibrate before quoting outcomes.",
+        ],
+    )

--- a/aqua_model/tests/test_optimizer.py
+++ b/aqua_model/tests/test_optimizer.py
@@ -1,0 +1,81 @@
+"""M2 optimizer: feasibility, beats naive baseline, respects the binding constraint."""
+
+import pytest
+
+from aqua_model import optimize, OptimizeInput
+from aqua_model.crops import get_crop
+from aqua_model.species import get_species
+
+
+def _inp(**over):
+    base = dict(grow_area_m2=10.0, temperature_c=28.0, water_budget_lpd=5000.0,
+               objective="water_efficiency")
+    base.update(over)
+    return OptimizeInput(**base)
+
+
+def test_returns_a_feasible_best_with_normalized_allocation():
+    res = optimize(_inp())
+    assert res.best is not None
+    assert res.best.feasible
+    # Allocation fractions sum to ~1.0.
+    assert abs(sum(res.best.crop_allocation.values()) - 1.0) < 1e-6
+
+
+def test_searched_and_feasible_counts_make_sense():
+    res = optimize(_inp())
+    assert res.searched > 0
+    assert 0 < res.feasible_count <= res.searched
+
+
+def test_best_is_never_worse_than_naive_even_split():
+    # The even split is inside the search space, so best >= baseline by construction.
+    res = optimize(_inp(objective="water_efficiency"))
+    assert res.improvement_vs_baseline_pct is not None
+    assert res.improvement_vs_baseline_pct >= 0.0
+
+
+def test_water_efficiency_optimizer_actually_improves_on_even_split():
+    # With a tomato in the palette (high FRR -> more feed -> more makeup water), an
+    # all-leafy mix should give strictly better food-per-water than the even split.
+    res = optimize(_inp(objective="water_efficiency"))
+    assert res.improvement_vs_baseline_pct > 0.0
+
+
+def test_objective_changes_the_winner_or_score():
+    food = optimize(_inp(objective="food")).best
+    water = optimize(_inp(objective="water_efficiency")).best
+    # Different objectives should not generally yield identical full designs.
+    assert (food.crop_allocation, food.fish_species) != (water.crop_allocation, water.fish_species) \
+        or food.score != water.score
+
+
+def test_binding_constraint_is_respected():
+    res = optimize(_inp(water_budget_lpd=5000.0))
+    for cand in res.ranked:
+        assert cand.makeup_water_lpd <= 5000.0
+
+
+def test_infeasible_budget_yields_no_best_and_no_improvement():
+    res = optimize(_inp(grow_area_m2=80.0, water_budget_lpd=1.0))
+    assert res.best is None
+    assert res.feasible_count == 0
+    assert res.improvement_vs_baseline_pct is None
+
+
+def test_single_crop_palette_matches_m1_feed():
+    # One crop at 100% must reproduce the M1 FRR feed (area * FRR).
+    res = optimize(_inp(crop_palette=("lettuce",)))
+    expected_feed = 10.0 * get_crop("lettuce").frr_g_per_m2_day
+    assert res.best.feed_g_per_day == pytest.approx(expected_feed, abs=0.1)
+
+
+def test_unknown_objective_raises():
+    with pytest.raises(ValueError):
+        optimize(_inp(objective="maximize_vibes"))
+
+
+def test_honesty_layer_present():
+    res = optimize(_inp())
+    assert res.not_modeled and any("value" in n or "cost" in n for n in res.not_modeled)
+    assert res.assumptions


### PR DESCRIPTION
M2 of the refactor — the headline feature: **adjust the fish/plant ratio to maximize efficiency.** (Re-targeted to main after M1 #9 merged; prior stacked PR #10 auto-closed when its base branch was deleted.)

## How it works
Bounded enumeration (per the design doc — no LP/MILP) over fish species × crop-area allocations. Sizes each candidate, drops those exceeding the binding constraint (water budget in v1), scores by objective, returns the ranked best + improvement over a naive even-split (which is inside the search space, so best >= baseline by construction).

Objectives: `food` (kg/yr), `protein` (kg/yr), `water_efficiency` (kg per m³/yr).

```
10 m² / 28°C / 5000 L·day⁻¹
  water-efficiency → catfish + 100% tomato   (+26% vs even-split)
  food            → trout  + 100% tomato     (+33% vs even-split)
```

## Honesty layer
Flags what it does NOT optimize: value/cost, local availability, demand, and that v1 models evapotranspiration per-m² (crop-agnostic), so water-efficiency is yield-driven until per-crop ET is calibrated.

## Included
- `aqua_model/optimizer.py` — `optimize(OptimizeInput) -> OptimizeResult`.
- `aqua_model/crops.py` — seed `yield_kg_per_m2_year` + `edible_protein_pct` (cited LIT, calibration-flagged).
- `agent/optimizer_ui.py` + `app.py` — "Optimize Ratio" Streamlit mode. No LLM.
- 13 tests (10 optimizer + 3 headless UI). Suite: 57 passed, 2 skipped (M1 calibration gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)