### PR TITLE
feat: tool-calling Telegram assistant (agronaut_agent)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ chroma_db/
 srcs/chroma_db/
 faiss_document_store.db
 web_cache.sqlite
+data/*.sqlite3
+data/*.sqlite3-*   # WAL/SHM sidecar files
 
 # Local models
 bge-large-en/

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,10 @@ chroma_db/
 srcs/chroma_db/
 faiss_document_store.db
 web_cache.sqlite
+# Bot SQLite store + WAL/SHM sidecar files
 data/*.sqlite3
-data/*.sqlite3-*   # WAL/SHM sidecar files
+data/*.sqlite3-shm
+data/*.sqlite3-wal
 
 # Local models
 bge-large-en/

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -118,3 +118,26 @@ def get_llm(provider: str | None = None, model: str | None = None, temperature: 
     provider, model = resolve(provider, model)
     backend = _build_backend(provider, model, temperature)
     return StringLLM(backend, provider, model)
+
+
+class ToolCallingUnsupported(RuntimeError):
+    """Raised when the resolved backend cannot bind tools (no .bind_tools())."""
+
+
+def get_chat_model(provider: str | None = None, model: str | None = None, temperature: float = 0.0):
+    """Return the RAW LangChain chat model so callers can `.bind_tools(...)` and read
+    `AIMessage.tool_calls`. Unlike get_llm()->StringLLM, this does NOT normalize to str —
+    the tool-calling agent loop needs the message object.
+
+    Use a tool-calling-capable provider: `nvidia` (ChatNVIDIA) is the supported default;
+    `hf`/`hf_local` chat models technically expose bind_tools but tool-calling reliability
+    varies. `ollama`'s text LLM backend does not support tools.
+    """
+    provider, model = resolve(provider, model)
+    backend = _build_backend(provider, model, temperature)
+    if not hasattr(backend, "bind_tools"):
+        raise ToolCallingUnsupported(
+            f"Provider {provider!r} (model {model!r}) has no .bind_tools(); it can't drive the "
+            f"tool-calling agent. Use LLM_PROVIDER=nvidia (needs NVIDIA_API_KEY)."
+        )
+    return backend

--- a/agronaut_agent/__init__.py
+++ b/agronaut_agent/__init__.py
@@ -1,0 +1,6 @@
+"""agronaut_agent — the channel-agnostic, tool-calling assistant brain.
+
+The LLM orchestrates; it never invents numbers. Every figure it reports comes from a
+deterministic `aqua_model` tool call, carried through with its cited coefficients and
+"not modeled" caveats. Channels (Telegram first) are thin adapters over `AgronautAgent`.
+"""

--- a/agronaut_agent/channels/__init__.py
+++ b/agronaut_agent/channels/__init__.py
@@ -1,0 +1,1 @@
+"""Channel adapters — thin I/O translators over AgronautAgent. Telegram first."""

--- a/agronaut_agent/channels/base.py
+++ b/agronaut_agent/channels/base.py
@@ -1,0 +1,43 @@
+"""ChannelAdapter — the contract every channel (Telegram, Discord, WhatsApp) implements.
+
+An adapter only translates a platform's native message events into
+`agent.handle_message(channel, native_user_id, text)` and sends the reply back. The brain,
+tools, memory, and persistence live in AgronautAgent and never change per channel.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..core import AgronautAgent
+
+
+class ChannelAdapter(ABC):
+    channel_name: str = "base"
+
+    def __init__(self, agent: AgronautAgent):
+        self.agent = agent
+
+    @abstractmethod
+    def run(self) -> None:
+        """Start listening for messages (blocking)."""
+        raise NotImplementedError
+
+
+def chunk(text: str, size: int = 4000) -> list[str]:
+    """Split a long reply to fit platform message-size caps (Telegram's is 4096)."""
+    if len(text) <= size:
+        return [text]
+    parts, buf = [], ""
+    for line in text.splitlines(keepends=True):
+        if len(buf) + len(line) > size and buf:
+            parts.append(buf)
+            buf = ""
+        # a single line longer than `size` gets hard-split
+        while len(line) > size:
+            parts.append(line[:size])
+            line = line[size:]
+        buf += line
+    if buf:
+        parts.append(buf)
+    return parts

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -1,0 +1,91 @@
+"""Telegram adapter (python-telegram-bot, async).
+
+Maps a Telegram chat to a stable user_id, runs the (sync) agent in a worker thread so the
+bot's event loop never blocks, and enforces a personal-assistant allowlist. /start and
+/reset are handled locally; everything else goes to the agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from telegram import Update
+from telegram.constants import ChatAction
+from telegram.ext import Application, CommandHandler, MessageHandler, ContextTypes, filters
+
+from ..core import AgronautAgent
+from .base import ChannelAdapter, chunk
+
+log = logging.getLogger(__name__)
+
+
+def _parse_allowlist(raw: str | None) -> set[str]:
+    return {x.strip() for x in (raw or "").split(",") if x.strip()}
+
+
+class TelegramAdapter(ChannelAdapter):
+    channel_name = "telegram"
+
+    def __init__(self, agent: AgronautAgent, token: str | None = None, allowed_ids=None):
+        super().__init__(agent)
+        self.token = token or os.environ["TELEGRAM_BOT_TOKEN"]
+        # Allowlist of Telegram user IDs. Empty set => open to anyone (discouraged).
+        self.allowed_ids = (
+            set(map(str, allowed_ids)) if allowed_ids is not None
+            else _parse_allowlist(os.getenv("AGRONAUT_ALLOWED_IDS"))
+        )
+
+    def _allowed(self, update: Update) -> bool:
+        if not self.allowed_ids:
+            return True
+        user = update.effective_user
+        return bool(user and str(user.id) in self.allowed_ids)
+
+    async def _on_start(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        await update.message.reply_text(
+            "🌱 I'm Agronaut — your aquaponics assistant. Tell me about your system "
+            "(species, grow area, water temp, water budget) and I'll size it, optimize the "
+            "fish/crop ratio, or help troubleshoot. /reset clears our conversation."
+        )
+
+    async def _on_reset(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        await asyncio.to_thread(self.agent.reset, self.channel_name, str(update.effective_chat.id))
+        await update.message.reply_text("Cleared. Fresh start — what are we working on?")
+
+    async def _on_text(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        chat_id = str(update.effective_chat.id)
+        await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
+        try:
+            reply = await asyncio.to_thread(
+                self.agent.handle_message,
+                self.channel_name, chat_id, update.message.text,
+                update.effective_user.full_name if update.effective_user else None,
+            )
+        except Exception:  # never leave the user hanging on an unexpected error
+            log.exception("agent.handle_message failed")
+            reply = "Something went wrong on my side. Try again, or rephrase?"
+        for part in chunk(reply):
+            await update.message.reply_text(part)
+
+    async def _deny(self, update: Update) -> None:
+        await update.message.reply_text(
+            "This is a private Agronaut assistant. Ask the owner to add your Telegram ID "
+            f"(yours is {update.effective_user.id})." if update.effective_user else "Access restricted."
+        )
+
+    def run(self) -> None:
+        app = Application.builder().token(self.token).build()
+        app.add_handler(CommandHandler("start", self._on_start))
+        app.add_handler(CommandHandler("reset", self._on_reset))
+        app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))
+        scope = f"{len(self.allowed_ids)} allowed id(s)" if self.allowed_ids else "OPEN (no allowlist)"
+        log.info("Agronaut Telegram bot starting — %s", scope)
+        app.run_polling()

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -32,7 +32,15 @@ HARD RULES (these are your credibility):
   and your general knowledge; say when you are reasoning from general knowledge.
 
 You can size systems, optimize fish/crop ratios, render full reports, cross-check against real
-pond data, and search curated knowledge. Use the tools; explain results plainly."""
+pond data, and search curated knowledge. Use the tools; explain results plainly.
+
+ANSWERING FOLLOW-UPS:
+- First use the conversation so far and earlier tool results. If a number was already computed
+  (e.g. fish count) or a fact already stated, answer directly — do NOT re-run a tool or search.
+- To judge whether a value is safe (temperature, pH, DO), read the operating_envelope from the
+  prior sizing result; don't search the knowledge base for it.
+- Use search_knowledge_base only for qualitative husbandry/symptoms not already on hand.
+- Answer every part of the user's question."""
 
 _MAX_ITERS = 6
 

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -1,0 +1,124 @@
+"""AgronautAgent — the channel-agnostic, tool-calling brain.
+
+handle_message(channel, channel_user, text) is the single seam every channel adapter
+calls. The LLM orchestrates Agronaut's deterministic tools and explains their results; a
+bounded tool-loop runs the calls. The system prompt forbids inventing numbers — every
+figure must come from a tool result, with its cited coefficients and caveats passed through.
+"""
+
+from __future__ import annotations
+
+import os
+
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
+
+from agent.llm import get_chat_model
+from .tools import AGRONAUT_TOOLS
+from .store import _Db, ConversationStore, MemoryStore
+from . import memory_extract
+
+SYSTEM_PROMPT = """You are Agronaut, a personal aquaponics design and troubleshooting assistant.
+
+You speak with operators and farmers — be concrete, warm, and brief. Reply in the user's language.
+
+HARD RULES (these are your credibility):
+- NEVER state a sizing number, bill-of-materials quantity, or coefficient that did not come
+  from a tool result. For any sizing/optimization question, CALL the tool — do not estimate.
+- When a tool returns coefficients and "not modeled" caveats, surface them: cite the source of
+  key numbers and remind the user these are calibration seeds, not guarantees.
+- If the trust gate rejects an input (VALIDATION_FAILED), ask the user for a corrected value.
+  Never guess or work around it.
+- For qualitative troubleshooting (symptoms, water quality, husbandry), use the knowledge tool
+  and your general knowledge; say when you are reasoning from general knowledge.
+
+You can size systems, optimize fish/crop ratios, render full reports, cross-check against real
+pond data, and search curated knowledge. Use the tools; explain results plainly."""
+
+_MAX_ITERS = 6
+
+
+class AgronautAgent:
+    def __init__(self, llm_provider=None, llm_model=None, db_path=None, chat_model=None):
+        # chat_model injectable for tests (a fake bindable model); else build from config.
+        base = chat_model if chat_model is not None else get_chat_model(llm_provider, llm_model)
+        self._bound = base.bind_tools(AGRONAUT_TOOLS)
+        self._tools_by_name = {t.name: t for t in AGRONAUT_TOOLS}
+        db = _Db(db_path)
+        self._conv = ConversationStore(db)
+        self._mem = MemoryStore(db)
+
+    # --- context assembly -------------------------------------------------
+    def _build_context(self, user_id: str) -> list:
+        messages: list = [SystemMessage(content=SYSTEM_PROMPT)]
+        facts = self._mem.get_facts(user_id)
+        if facts:
+            known = "; ".join(f"{k}={v}" for k, v in facts.items())
+            messages.append(SystemMessage(content=f"Known facts about this user's system: {known}"))
+        for m in self._conv.recent_messages(user_id, limit=20):
+            if m["role"] == "user":
+                messages.append(HumanMessage(content=m["content"]))
+            elif m["role"] == "assistant":
+                messages.append(AIMessage(content=m["content"]))
+            # stored 'tool' rows are audit history; the live loop handles tool exchange
+        return messages
+
+    # --- the tool-calling loop -------------------------------------------
+    def _run_tool_loop(self, messages: list, user_id: str) -> str:
+        for _ in range(_MAX_ITERS):
+            ai = self._bound.invoke(messages)
+            messages.append(ai)
+            tool_calls = getattr(ai, "tool_calls", None)
+            if not tool_calls:
+                return (ai.content or "").strip() or "I'm not sure how to help with that yet."
+            for call in tool_calls:
+                tool = self._tools_by_name.get(call["name"])
+                if tool is None:
+                    result = f"TOOL_ERROR: unknown tool {call['name']!r}"
+                else:
+                    try:
+                        result = tool.invoke(call["args"])
+                    except Exception as exc:  # fed back so the model can correct; never hidden
+                        result = f"TOOL_ERROR: {exc}"
+                self._conv.append_message(user_id, "tool", result, tool_name=call["name"])
+                messages.append(ToolMessage(content=result, tool_call_id=call["id"]))
+        return ("I couldn't complete that reliably after several steps — "
+                "let's narrow it down. Could you restate the key details?")
+
+    # --- the single public seam ------------------------------------------
+    def handle_message(self, channel: str, channel_user: str, text: str, display_name: str | None = None) -> str:
+        user_id = self._conv.get_or_create_user(channel, channel_user, display_name)
+        self._mem.set_facts(user_id, memory_extract.extract_facts(text), source="parsed")
+        self._conv.append_message(user_id, "user", text)
+        messages = self._build_context(user_id)
+        reply = self._run_tool_loop(messages, user_id)
+        self._conv.append_message(user_id, "assistant", reply)
+        return reply
+
+    def reset(self, channel: str, channel_user: str) -> None:
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        self._conv.reset_conversation(user_id)
+
+
+def _repl() -> None:
+    """Local dry-run: talk to the agent from the terminal, no Telegram. Needs a configured
+    tool-calling provider (e.g. LLM_PROVIDER=nvidia NVIDIA_API_KEY=...)."""
+    import agent  # loads .env
+    agent_ = AgronautAgent()
+    print("Agronaut REPL — type 'quit' to exit, '/reset' to clear.")
+    while True:
+        try:
+            text = input("you> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            break
+        if text.lower() in {"quit", "exit"}:
+            break
+        if text == "/reset":
+            agent_.reset("cli", "local")
+            print("(conversation reset)")
+            continue
+        if text:
+            print("agronaut>", agent_.handle_message("cli", "local", text))
+
+
+if __name__ == "__main__":
+    _repl()

--- a/agronaut_agent/memory_extract.py
+++ b/agronaut_agent/memory_extract.py
@@ -7,6 +7,13 @@ captured deterministically. Imported lazily so this module stays light for unit 
 
 from __future__ import annotations
 
+import re
+
+# Only trust a pH reading when the text actually mentions pH. The shared _parse_ph has a
+# bare-number fallback (any value 4-10) that fabricates a pH from things like "10 m2" —
+# safe in the old form-driven chatbot, but a honesty hazard for free-form agent messages.
+_PH_CUE = re.compile(r"\bp\s*H\b", re.IGNORECASE)
+
 
 def extract_facts(text: str) -> dict[str, str]:
     """Pull system facts from free text. Returns only keys that were confidently found."""
@@ -16,9 +23,10 @@ def extract_facts(text: str) -> dict[str, str]:
     temp = _parse_temperature_c(text)
     if temp is not None:
         facts["temperature_c"] = str(temp)
-    ph = _parse_ph(text)
-    if ph is not None:
-        facts["ph"] = str(ph)
+    if _PH_CUE.search(text):
+        ph = _parse_ph(text)
+        if ph is not None:
+            facts["ph"] = str(ph)
     species = _parse_fish_species(text)
     if species:
         facts["fish_species"] = species

--- a/agronaut_agent/memory_extract.py
+++ b/agronaut_agent/memory_extract.py
@@ -1,0 +1,25 @@
+"""Deterministic extraction of durable user facts from a message.
+
+Reuses the battle-tested regex parsers in srcs/chatbot.py (temperature, pH, fish species)
+rather than asking the LLM to guess them — facts about the user's real system should be
+captured deterministically. Imported lazily so this module stays light for unit tests.
+"""
+
+from __future__ import annotations
+
+
+def extract_facts(text: str) -> dict[str, str]:
+    """Pull system facts from free text. Returns only keys that were confidently found."""
+    from srcs.chatbot import _parse_temperature_c, _parse_ph, _parse_fish_species
+
+    facts: dict[str, str] = {}
+    temp = _parse_temperature_c(text)
+    if temp is not None:
+        facts["temperature_c"] = str(temp)
+    ph = _parse_ph(text)
+    if ph is not None:
+        facts["ph"] = str(ph)
+    species = _parse_fish_species(text)
+    if species:
+        facts["fish_species"] = species
+    return facts

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -1,0 +1,41 @@
+"""Lazy knowledge-base retrieval, reusing the existing FAISS RAG in srcs/chatbot.py.
+
+The index (local knowledge/*.md + cited URLs, embedded once) is expensive to build, so
+it is constructed on first use and cached for the process. If it can't be built (offline,
+missing deps), retrieval degrades to an empty result rather than crashing the agent.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_INDEX = None          # cached FAISS index (or None if unavailable)
+_TRIED = False         # don't retry a failed/slow build every call
+
+
+def _get_index():
+    global _INDEX, _TRIED
+    if _TRIED:
+        return _INDEX
+    _TRIED = True
+    try:
+        import requests_cache
+        import srcs.chatbot as core
+
+        requests_cache.install_cache(core.CACHE_NAME, expire_after=core.CACHE_EXPIRE)
+        _INDEX = core.build_rag_index_from_urls()
+    except Exception as exc:  # offline, missing deps, fetch failure — degrade gracefully
+        logging.warning("Knowledge index unavailable: %s", exc)
+        _INDEX = None
+    return _INDEX
+
+
+def search(query: str, k: int = 3) -> str:
+    """Return retrieved knowledge passages for `query`, or a clear 'no context' note."""
+    index = _get_index()
+    if index is None:
+        return "KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general husbandry knowledge and say so."
+    import srcs.chatbot as core
+
+    context = core.retrieve_context(index, query, k=k)
+    return context.strip() or "No matching passages in the knowledge base for that query."

--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -1,0 +1,110 @@
+"""Serialize aqua_model dataclasses into compact, LLM-readable strings.
+
+Design rule (the honesty ethos, in code): a serialized result ALWAYS carries the
+provenance the model needs to be honest — the coefficients used (value/range/source),
+what is NOT modeled, and any warnings. The model is instructed to pass these through;
+a reviewer can trace every number back to a cited coefficient.
+"""
+
+from __future__ import annotations
+
+from aqua_model.types import DesignOutput
+from aqua_model.optimizer import OptimizeResult, Candidate
+
+
+def _g(x: float) -> str:
+    """Compact number formatting (drops trailing zeros), matching the UI's %g style."""
+    return f"{x:g}"
+
+
+def serialize_validation_error(errors: list[str]) -> str:
+    lines = ["VALIDATION_FAILED — inputs rejected by the trust gate (no design computed):"]
+    lines += [f"  - {e}" for e in errors]
+    lines.append("Ask the user for corrected values; do NOT guess or proceed.")
+    return "\n".join(lines)
+
+
+def serialize_design_output(out: DesignOutput) -> str:
+    lines: list[str] = []
+    if out.feasible:
+        lines.append("FEASIBLE design.")
+    else:
+        lines.append(f"NOT FEASIBLE — binding constraint: {out.binding_constraint}.")
+
+    lines.append(
+        "Sizing: "
+        f"feed={_g(out.feed_g_per_day)} g/day, fish={out.fish_count} head, "
+        f"biomass={_g(out.fish_biomass_kg)} kg, system_volume={_g(out.system_volume_l)} L, "
+        f"rearing_tank={_g(out.rearing_tank_volume_l)} L, pump={_g(out.pump_turnover_lph)} L/h, "
+        f"makeup_water={_g(out.makeup_water_lpd)} L/day"
+    )
+    if out.biofilter_media_m2 is not None:
+        lines.append(f"Biofilter media: ~{_g(out.biofilter_media_m2)} m2 surface")
+
+    if out.bill_of_materials:
+        lines.append("Bill of materials:")
+        for item in out.bill_of_materials:
+            parts = ", ".join(f"{k}={v}" for k, v in item.items())
+            lines.append(f"  - {parts}")
+
+    if out.operating_envelope:
+        lines.append(f"Operating envelope: {out.operating_envelope}")
+
+    if out.nitrogen_check:
+        nc = out.nitrogen_check
+        agrees = nc.get("agrees")
+        lines.append(
+            f"Nitrogen consistency check: agrees={agrees} "
+            f"(disagreement_fraction={nc.get('disagreement_fraction')})"
+        )
+
+    if out.coefficients_used:
+        lines.append("Coefficients used (cite these — every number traces here):")
+        for c in out.coefficients_used:
+            lines.append(
+                f"  - {c.name} = {_g(c.value)} {c.unit} "
+                f"(range {_g(c.low)}-{_g(c.high)}; source: {c.source})"
+            )
+
+    if out.warnings:
+        lines.append("Warnings: " + " | ".join(out.warnings))
+    if out.not_modeled:
+        lines.append("NOT modeled (surface these caveats to the user):")
+        lines += [f"  - {n}" for n in out.not_modeled]
+
+    return "\n".join(lines)
+
+
+def _fmt_mix(alloc: dict[str, float]) -> str:
+    return ", ".join(f"{int(round(frac * 100))}% {crop}" for crop, frac in alloc.items())
+
+
+def _fmt_candidate(c: Candidate) -> str:
+    return (
+        f"{c.fish_species} + [{_fmt_mix(c.crop_allocation)}] -> "
+        f"score={_g(c.score)}, food={_g(c.food_kg_yr)} kg/yr, "
+        f"protein={_g(c.protein_kg_yr)} kg/yr, makeup_water={_g(c.makeup_water_lpd)} L/day"
+    )
+
+
+def serialize_optimize_result(res: OptimizeResult, top_n: int = 5) -> str:
+    if res.best is None:
+        return (
+            f"NO FEASIBLE design within the water budget. Searched {res.searched} "
+            f"combinations, none fit. Suggest increasing the water budget or reducing grow area."
+        )
+    lines = [
+        f"Objective: {res.objective}.",
+        f"Best ratio: {_fmt_candidate(res.best)}",
+    ]
+    if res.improvement_vs_baseline_pct is not None:
+        lines.append(f"Improvement vs naive even-split: {res.improvement_vs_baseline_pct:+g}%")
+    lines.append(f"Searched {res.searched} combinations, {res.feasible_count} feasible.")
+    if res.ranked:
+        lines.append(f"Top {min(top_n, len(res.ranked))} alternatives:")
+        for c in res.ranked[:top_n]:
+            lines.append(f"  - {_fmt_candidate(c)}")
+    if res.not_modeled:
+        lines.append("NOT optimized (surface these caveats):")
+        lines += [f"  - {n}" for n in res.not_modeled]
+    return "\n".join(lines)

--- a/agronaut_agent/store.py
+++ b/agronaut_agent/store.py
@@ -1,0 +1,136 @@
+"""Per-user persistence (SQLite) — replaces the old single global ThreadState.
+
+Two stores over one SQLite file:
+  ConversationStore — identity (channel + native id -> stable user_id) and message history.
+  MemoryStore       — long-term facts about the user's actual system (tank, species, location).
+
+Concurrency: one laptop / one bot process. WAL mode + a per-connection lock keep the
+single-process event loop safe. Stdlib only — no ORM, no heavy deps.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+_DEFAULT_DB = Path(__file__).resolve().parent.parent / "data" / "agronaut.sqlite3"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    user_id      TEXT PRIMARY KEY,
+    channel      TEXT NOT NULL,
+    channel_user TEXT NOT NULL,
+    display_name TEXT,
+    created_at   TEXT NOT NULL,
+    UNIQUE(channel, channel_user)
+);
+CREATE TABLE IF NOT EXISTS messages (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id    TEXT NOT NULL,
+    role       TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    tool_name  TEXT,
+    created_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_messages_user ON messages(user_id, id);
+CREATE TABLE IF NOT EXISTS user_facts (
+    user_id    TEXT NOT NULL,
+    key        TEXT NOT NULL,
+    value      TEXT NOT NULL,
+    source     TEXT,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (user_id, key)
+);
+"""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class _Db:
+    """Shared connection + lock. One file, opened once per path."""
+
+    def __init__(self, path: str | os.PathLike | None = None):
+        self.path = Path(path) if path else Path(os.getenv("AGRONAUT_DB", _DEFAULT_DB))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        with self._lock:
+            self._conn.executescript(_SCHEMA)
+            self._conn.commit()
+
+    def execute(self, sql: str, params: tuple = ()):
+        with self._lock:
+            cur = self._conn.execute(sql, params)
+            self._conn.commit()
+            return cur
+
+    def query(self, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+        with self._lock:
+            return self._conn.execute(sql, params).fetchall()
+
+
+def user_id_for(channel: str, channel_user: str) -> str:
+    """Stable, namespaced id, e.g. 'telegram:123456789'."""
+    return f"{channel}:{channel_user}"
+
+
+class ConversationStore:
+    def __init__(self, db: _Db | None = None, path=None):
+        self.db = db or _Db(path)
+
+    def get_or_create_user(self, channel: str, channel_user: str, display_name: str | None = None) -> str:
+        uid = user_id_for(channel, channel_user)
+        self.db.execute(
+            "INSERT OR IGNORE INTO users(user_id, channel, channel_user, display_name, created_at) "
+            "VALUES (?,?,?,?,?)",
+            (uid, channel, str(channel_user), display_name, _now()),
+        )
+        return uid
+
+    def append_message(self, user_id: str, role: str, content: str, tool_name: str | None = None) -> None:
+        self.db.execute(
+            "INSERT INTO messages(user_id, role, content, tool_name, created_at) VALUES (?,?,?,?,?)",
+            (user_id, role, content, tool_name, _now()),
+        )
+
+    def recent_messages(self, user_id: str, limit: int = 20) -> list[dict]:
+        rows = self.db.query(
+            "SELECT role, content, tool_name FROM messages WHERE user_id=? ORDER BY id DESC LIMIT ?",
+            (user_id, limit),
+        )
+        return [dict(r) for r in reversed(rows)]
+
+    def reset_conversation(self, user_id: str) -> None:
+        self.db.execute("DELETE FROM messages WHERE user_id=?", (user_id,))
+
+
+class MemoryStore:
+    def __init__(self, db: _Db | None = None, path=None):
+        self.db = db or _Db(path)
+
+    def get_facts(self, user_id: str) -> dict[str, str]:
+        rows = self.db.query("SELECT key, value FROM user_facts WHERE user_id=?", (user_id,))
+        return {r["key"]: r["value"] for r in rows}
+
+    def set_fact(self, user_id: str, key: str, value: str, source: str = "user_stated") -> None:
+        self.db.execute(
+            "INSERT INTO user_facts(user_id, key, value, source, updated_at) VALUES (?,?,?,?,?) "
+            "ON CONFLICT(user_id, key) DO UPDATE SET value=excluded.value, source=excluded.source, "
+            "updated_at=excluded.updated_at",
+            (user_id, key, str(value), source, _now()),
+        )
+
+    def set_facts(self, user_id: str, facts: dict, source: str = "parsed") -> None:
+        for k, v in facts.items():
+            if v is not None:
+                self.set_fact(user_id, k, str(v), source)
+
+    def forget(self, user_id: str) -> None:
+        self.db.execute("DELETE FROM user_facts WHERE user_id=?", (user_id,))

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -1,0 +1,66 @@
+"""The tool-loop, exercised with a fake chat model (no network).
+
+Asserts the agent invokes the requested tool, feeds the result back as a ToolMessage,
+returns a final answer that carries the tool's numbers, persists an audit trail, and
+extracts user facts deterministically.
+"""
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+from agronaut_agent.core import AgronautAgent
+
+
+class _FakeChat:
+    """Turn 1 -> a tool call; turn 2 (after a ToolMessage) -> a final answer."""
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        tool_msgs = [m for m in messages if isinstance(m, ToolMessage)]
+        if tool_msgs:
+            saw_numbers = "fish=" in tool_msgs[-1].content
+            return AIMessage(content=f"Sized it (numbers_from_tool={saw_numbers}).")
+        return AIMessage(
+            content="",
+            tool_calls=[{
+                "name": "size_aquaponics_system",
+                "id": "call_1",
+                "args": {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 12,
+                         "temperature_c": 27, "water_budget_lpd": 300},
+            }],
+        )
+
+
+class _ChattyFake:
+    """Never calls a tool — just replies. Verifies the no-tool path."""
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        return AIMessage(content="Hello! Tell me about your system.")
+
+
+def test_tool_loop_calls_tool_and_returns_numbers(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_FakeChat())
+    reply = agent.handle_message("cli", "tester", "size a 12 m2 tilapia + lettuce at 27C, 300 L/day")
+    assert "numbers_from_tool=True" in reply
+
+    roles = [m["role"] for m in agent._conv.recent_messages("cli:tester", limit=10)]
+    assert roles == ["user", "tool", "assistant"]  # audit trail persisted
+    assert agent._mem.get_facts("cli:tester")["temperature_c"] == "27.0"
+
+
+def test_no_tool_path_returns_plain_reply(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_ChattyFake())
+    reply = agent.handle_message("cli", "u2", "hi there")
+    assert "Hello" in reply
+    assert [m["role"] for m in agent._conv.recent_messages("cli:u2")] == ["user", "assistant"]
+
+
+def test_reset_clears_history(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_ChattyFake())
+    agent.handle_message("cli", "u3", "hi")
+    agent.reset("cli", "u3")
+    assert agent._conv.recent_messages("cli:u3") == []

--- a/agronaut_agent/tests/test_store.py
+++ b/agronaut_agent/tests/test_store.py
@@ -49,3 +49,10 @@ def test_extract_facts_from_free_text():
     assert facts["temperature_c"] == "26.0"
     assert facts["ph"] == "7.2"
     assert facts["fish_species"].lower() == "tilapia"
+
+
+def test_extract_facts_does_not_fabricate_ph_from_bare_numbers():
+    # "10 m2" must NOT be read as pH 10 — only an explicit pH cue counts (honesty ethos).
+    facts = memory_extract.extract_facts("Size a 10 m2 tilapia and lettuce system at 26C with 250 L/day")
+    assert "ph" not in facts
+    assert facts["temperature_c"] == "26.0"

--- a/agronaut_agent/tests/test_store.py
+++ b/agronaut_agent/tests/test_store.py
@@ -1,0 +1,51 @@
+"""Per-user persistence: identity, history, memory — concurrency-safe by construction."""
+
+import pytest
+
+from agronaut_agent.store import _Db, ConversationStore, MemoryStore, user_id_for
+from agronaut_agent import memory_extract
+
+
+@pytest.fixture
+def stores(tmp_path):
+    db = _Db(tmp_path / "t.sqlite3")
+    return ConversationStore(db), MemoryStore(db)
+
+
+def test_user_id_namespacing():
+    assert user_id_for("telegram", "123") == "telegram:123"
+    assert user_id_for("discord", "123") != user_id_for("telegram", "123")
+
+
+def test_get_or_create_is_idempotent(stores):
+    conv, _ = stores
+    a = conv.get_or_create_user("telegram", "123", "Rachid")
+    b = conv.get_or_create_user("telegram", "123", "Rachid")
+    assert a == b == "telegram:123"
+
+
+def test_message_history_ordered_and_resettable(stores):
+    conv, _ = stores
+    uid = conv.get_or_create_user("telegram", "123")
+    conv.append_message(uid, "user", "hi")
+    conv.append_message(uid, "assistant", "hello")
+    assert [m["role"] for m in conv.recent_messages(uid)] == ["user", "assistant"]
+    conv.reset_conversation(uid)
+    assert conv.recent_messages(uid) == []
+
+
+def test_facts_upsert_and_survive_conversation_reset(stores):
+    conv, mem = stores
+    uid = conv.get_or_create_user("telegram", "123")
+    mem.set_facts(uid, {"temperature_c": "28", "fish_species": "tilapia"})
+    mem.set_fact(uid, "temperature_c", "30", source="user_stated")  # overwrite
+    assert mem.get_facts(uid) == {"temperature_c": "30", "fish_species": "tilapia"}
+    conv.reset_conversation(uid)
+    assert mem.get_facts(uid) == {"temperature_c": "30", "fish_species": "tilapia"}
+
+
+def test_extract_facts_from_free_text():
+    facts = memory_extract.extract_facts("water is 26C and pH 7.2, I keep tilapia")
+    assert facts["temperature_c"] == "26.0"
+    assert facts["ph"] == "7.2"
+    assert facts["fish_species"].lower() == "tilapia"

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -1,0 +1,58 @@
+"""Tools wrap the deterministic core, preserve the trust gate, and carry provenance."""
+
+from agronaut_agent.tools import (
+    size_aquaponics_system,
+    optimize_fish_crop_ratio,
+    list_supported_species_and_crops,
+    AGRONAUT_TOOLS,
+)
+
+
+def test_tool_registry():
+    names = {t.name for t in AGRONAUT_TOOLS}
+    assert "size_aquaponics_system" in names
+    assert "optimize_fish_crop_ratio" in names
+    assert "search_knowledge_base" in names
+    assert len(AGRONAUT_TOOLS) == 6
+
+
+def test_size_valid_carries_numbers_and_sources():
+    out = size_aquaponics_system.invoke(
+        {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 12,
+         "temperature_c": 27, "water_budget_lpd": 300}
+    )
+    assert "FEASIBLE" in out
+    assert "fish=" in out and "feed=" in out
+    # honesty layer: coefficients with sources and not-modeled caveats are present
+    assert "Coefficients used" in out and "source:" in out
+    assert "NOT modeled" in out
+
+
+def test_size_trust_gate_rejects_unknown_species():
+    out = size_aquaponics_system.invoke(
+        {"fish_species": "shark", "crop": "lettuce", "grow_area_m2": 12,
+         "temperature_c": 27, "water_budget_lpd": 300}
+    )
+    assert "VALIDATION_FAILED" in out
+    assert "shark" in out
+    assert "do NOT guess" in out
+
+
+def test_optimize_returns_ranked_best():
+    out = optimize_fish_crop_ratio.invoke(
+        {"grow_area_m2": 10, "temperature_c": 28, "water_budget_lpd": 5000, "objective": "food"}
+    )
+    assert "Best ratio:" in out
+    assert "alternatives" in out
+
+
+def test_optimize_rejects_bad_objective():
+    out = optimize_fish_crop_ratio.invoke(
+        {"grow_area_m2": 10, "temperature_c": 28, "water_budget_lpd": 5000, "objective": "money"}
+    )
+    assert "Unknown objective" in out
+
+
+def test_list_supported():
+    out = list_supported_species_and_crops.invoke({})
+    assert "tilapia" in out and "lettuce" in out and "water_efficiency" in out

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -26,6 +26,15 @@ from aqua_model import datasets, report
 from . import rag, serialize
 
 
+def _clean_optional(text: str | None) -> str | None:
+    """LLMs often pass the literal string 'null'/'none'/'' for an absent optional arg.
+    Coerce those back to None so they don't become a bogus note."""
+    if text is None:
+        return None
+    t = str(text).strip()
+    return None if t.lower() in {"", "null", "none", "n/a"} else t
+
+
 @tool
 def size_aquaponics_system(
     fish_species: str,
@@ -49,7 +58,8 @@ def size_aquaponics_system(
     """
     try:
         design = validate_design_input(
-            fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd, source_water_note
+            fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd,
+            _clean_optional(source_water_note),
         )
     except ValidationError as err:
         return serialize.serialize_validation_error(err.errors)

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -1,0 +1,143 @@
+"""Agronaut's LLM-callable tools — thin wrappers over the deterministic `aqua_model`
+core plus knowledge retrieval. Each tool returns a STRING (serialized result) so the
+agent loop is model-agnostic and every result stays auditable.
+
+The trust boundary is preserved: `size_aquaponics_system` routes through
+`validate_design_input` (the only door into the model), so a hallucinated argument is
+rejected loudly instead of producing a confidently-wrong design.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+from aqua_model import (
+    size_system,
+    optimize,
+    OptimizeInput,
+    validate_design_input,
+    ValidationError,
+    OBJECTIVES,
+)
+from aqua_model.species import SPECIES, get_species
+from aqua_model.crops import CROPS
+from aqua_model import datasets, report
+
+from . import rag, serialize
+
+
+@tool
+def size_aquaponics_system(
+    fish_species: str,
+    crop: str,
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    source_water_note: str | None = None,
+) -> str:
+    """Size ONE aquaponics system deterministically from fixed inputs. Returns tank,
+    biofilter and pump sizing, fish count/biomass/feed, bill of materials, operating
+    envelope, the nitrogen consistency check, the CITED coefficients used, and what is
+    NOT modeled. Use this for any sizing question — never state sizing numbers yourself.
+
+    fish_species: one of tilapia, clarias, channel_catfish, trout.
+    crop: one of lettuce, basil, tomato.
+    grow_area_m2: planted raft/DWC area (the anchor).
+    temperature_c: mean water temperature.
+    water_budget_lpd: makeup water available per day, litres.
+    source_water_note: optional salinity/quality caveat.
+    """
+    try:
+        design = validate_design_input(
+            fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd, source_water_note
+        )
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    return serialize.serialize_design_output(size_system(design))
+
+
+@tool
+def optimize_fish_crop_ratio(
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    objective: str = "water_efficiency",
+) -> str:
+    """Search fish species x crop-area allocations for the best ratio under a goal, by
+    bounded enumeration. Returns the best ratio, ranked alternatives, and improvement vs
+    a naive even split. objective: one of food, protein, water_efficiency.
+    """
+    obj = (objective or "water_efficiency").strip().lower()
+    if obj not in OBJECTIVES:
+        return f"Unknown objective {objective!r}. Use one of: {', '.join(OBJECTIVES)}."
+    res = optimize(
+        OptimizeInput(
+            grow_area_m2=grow_area_m2,
+            temperature_c=temperature_c,
+            water_budget_lpd=water_budget_lpd,
+            objective=obj,
+        )
+    )
+    return serialize.serialize_optimize_result(res)
+
+
+@tool
+def list_supported_species_and_crops() -> str:
+    """List the fish species, crops, and optimization objectives Agronaut supports. Call
+    this before sizing if unsure whether something the user named is supported."""
+    fish = ", ".join(sorted(SPECIES))
+    crops = ", ".join(sorted(CROPS))
+    objs = ", ".join(OBJECTIVES)
+    return f"Fish species: {fish}\nCrops: {crops}\nOptimization objectives: {objs}"
+
+
+@tool
+def design_envelope_reality_check(model_envelope: dict) -> str:
+    """Compare a computed operating envelope (the 'operating_envelope' dict from a prior
+    size_aquaponics_system result) against empirical field-pond data, if available, and
+    report where the design's target bands agree with or diverge from real ponds."""
+    result = datasets.envelope_reality_check(model_envelope)
+    if result is None:
+        return ("No empirical dataset available for cross-check "
+                "(raw pond data not fetched). Report the design envelope as-is.")
+    return str(result)
+
+
+@tool
+def render_design_report(
+    fish_species: str,
+    crop: str,
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    site: str | None = None,
+) -> str:
+    """Render a full Markdown build report (BOM, envelope, maintenance, cited coefficients,
+    not-modeled) for a system. Use when the user wants the complete writeup or a shareable
+    document. Same inputs as size_aquaponics_system."""
+    try:
+        design = validate_design_input(
+            fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd
+        )
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    out = size_system(design)
+    return report.to_markdown(design, out, site=site)
+
+
+@tool
+def search_knowledge_base(query: str) -> str:
+    """Retrieve passages from Agronaut's curated aquaponics knowledge (local docs + cited
+    sources) for qualitative troubleshooting and husbandry guidance (symptoms, water
+    quality, pests). Use for explanation — NOT for sizing numbers (use the sizing tool)."""
+    return rag.search(query)
+
+
+AGRONAUT_TOOLS = [
+    size_aquaponics_system,
+    optimize_fish_crop_ratio,
+    list_supported_species_and_crops,
+    design_envelope_reality_check,
+    render_design_report,
+    search_knowledge_base,
+]

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,27 @@
+"""Agronaut Telegram bot entrypoint.
+
+Run:  python bot.py
+Needs (in .env or the environment):
+  TELEGRAM_BOT_TOKEN   from @BotFather
+  AGRONAUT_ALLOWED_IDS comma-separated Telegram user IDs allowed to use the bot
+  LLM_PROVIDER=nvidia  NVIDIA_API_KEY=...   (tool-calling brain; free at build.nvidia.com)
+  LLM_MODEL            optional, e.g. meta/llama-3.1-70b-instruct
+"""
+
+from __future__ import annotations
+
+import logging
+
+import agent  # noqa: F401 — importing the package loads project-root .env (agent/__init__.py)
+from agronaut_agent.core import AgronautAgent
+from agronaut_agent.channels.telegram_adapter import TelegramAdapter
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    brain = AgronautAgent()
+    TelegramAdapter(brain).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = aqua_model/tests agent/tests
+testpaths = aqua_model/tests agent/tests agronaut_agent/tests
 python_files = test_*.py
 addopts = -v

--- a/requirement.txt
+++ b/requirement.txt
@@ -10,7 +10,10 @@ langchain_community
 # LLM backends (pluggable via LLM_PROVIDER). Install only the one(s) you use.
 langchain_ollama                  # local/offline via Ollama (default)
 langchain-huggingface             # hf (hosted, needs HUGGINGFACEHUB_API_TOKEN) OR hf_local (local transformers, no token)
-# langchain-nvidia-ai-endpoints   # hosted NVIDIA open models (needs NVIDIA_API_KEY)
+langchain-nvidia-ai-endpoints     # nvidia (hosted NIM, needs NVIDIA_API_KEY) — tool-calling brain for the bot
+
+# Messaging channels (the personal-assistant gateway)
+python-telegram-bot>=21           # Telegram bot (agronaut_agent/channels/telegram_adapter.py)
 faiss-cpu
 openpyxl
 streamlit


### PR DESCRIPTION
First step from a Streamlit tool toward a multi-channel personal agriculture assistant: a channel-agnostic, tool-calling agent reachable on Telegram. Verified live end to end.

## What's in it
- **agent/llm.py** — `get_chat_model()` returns a tool-bindable chat model (NVIDIA NIM / ChatNVIDIA); `get_llm()`/Streamlit path untouched.
- **agronaut_agent/** — the brain:
  - `core.AgronautAgent`: bounded tool-calling loop; system prompt forbids inventing numbers (every figure comes from a tool, with cited coefficients + "not modeled" caveats passed through) and answers follow-ups from context.
  - `tools.py`: 6 tools over the deterministic `aqua_model` core + knowledge search; the `validate_design_input` trust gate is preserved.
  - `store.py`: SQLite per-user sessions + long-term memory (replaces the old global single-user state).
  - `memory_extract.py`: reuses chatbot.py parsers; guarded so bare numbers can't fabricate a pH.
  - `channels/`: ChannelAdapter base + python-telegram-bot adapter with an allowlist, /start, /reset, typing indicator, 4096-char chunking. Discord/WhatsApp slot in behind the same base.
- **bot.py** — entrypoint. Brain = NVIDIA NIM via the pluggable agent/llm.py.

## Verified live (Telegram, NVIDIA llama-3.3-70b)
Sized a real system with engine numbers + the full honesty layer (flagged 26C below tilapia's optimal band, auto-scaled feed, listed caveats); follow-ups answer from memory; per-user state persists to SQLite.

## Tests
95 passing (14 new: tools, store, fake-model tool-loop dry run, pH-fabrication regression).

## Notes
- Secrets (NVIDIA key, bot token, Telegram ID) live only in gitignored `.env` — never committed.
- New deps: `langchain-nvidia-ai-endpoints`, `python-telegram-bot>=21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)