### PR TITLE
chore: add CI + contributor on-ramp (CONTRIBUTING, templates, badges)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Something in Agronaut isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What happened**
+A clear description of the bug.
+
+**What you expected**
+What you thought would happen instead.
+
+**How to reproduce**
+1. Mode / command you ran (Design / Optimize / chat / CLI):
+2. Inputs:
+3. ...
+
+**Output / error**
+Paste the traceback or wrong result. If it's a sizing/optimizer result, include the
+coefficients and caveats it reported.
+
+**Environment**
+- Python version:
+- LLM backend (if chat): `LLM_PROVIDER=` (or "n/a — deterministic mode")
+- OS:

--- a/.github/ISSUE_TEMPLATE/contribute_pond_data.md
+++ b/.github/ISSUE_TEMPLATE/contribute_pond_data.md
@@ -1,0 +1,30 @@
+---
+name: "📊 Contribute pond data"
+about: Share data from a real aquaponics system to help validate the model
+title: "Pond data: <your system, location>"
+labels: calibration-data
+assignees: ""
+---
+
+Thank you — real-system data is the most valuable thing you can give Agronaut. No coding
+required; we'll help you map it to the logging standard (`aqua_model/logging_schema.py`).
+
+**Your system (fill in what you have — partial is fine)**
+- System type (media bed / DWC raft / NFT / hybrid):
+- Tank + sump volume:
+- Grow-bed or raft area, plant count:
+- Fish species, count, average weight:
+- Feed per day:
+
+**Water quality over time (if logged)**
+- Temperature, pH, DO, ammonia / nitrite / nitrate — a CSV or sheet is perfect.
+
+**Outcomes (if known)**
+- Harvest weight, water top-up volume, any failures or fish loss.
+
+**How you'd like to share it**
+- [ ] I'll attach a CSV/sheet here
+- [ ] I'd like help formatting it first
+- [ ] Anonymize before use
+
+Anything sensitive? Say so and we'll keep it aggregated/anonymized.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Propose a capability or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**The grower problem**
+What real operator pain does this solve? Agronaut is built backward from that — describe it
+before the implementation.
+
+**Proposed solution**
+What you'd like to see.
+
+**Which layer**
+- [ ] `aqua_model/` (deterministic core — must stay pure, every number cited)
+- [ ] agent / chat layer
+- [ ] UI (Streamlit) or CLI
+- [ ] docs / infra
+- [ ] not sure
+
+**Alternatives considered**
+Anything else you weighed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What this changes
+
+<!-- One or two sentences. Link the issue: Closes #NN -->
+
+## Checklist
+
+- [ ] `python -m pytest` is green locally
+- [ ] Touched `aqua_model/`? Added/extended a test (the trust zone stays covered)
+- [ ] `aqua_model/` still imports no LLM / agent / UI / network code
+- [ ] Any new coefficient carries a **value + range + unit + source**
+- [ ] No secrets, API keys, or `.env` committed
+- [ ] Commit messages are clear and scoped
+
+## Notes for the reviewer
+
+<!-- Anything non-obvious: a tradeoff, a follow-up, a thing you're unsure about. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirement.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirement.txt
+          pip install pytest
+
+      - name: Run the test suite
+        # The aqua_model trust zone is pure; the agent/UI suites import
+        # langchain_core + streamlit but hit no network or model server
+        # (agent tests are dry-run — no live LLM backend is constructed).
+        run: python -m pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to Agronaut
+
+Thanks for helping build an honest agronomy agent for aquaponics. Whether you write
+Python or run a fish-and-plant system, there's a way in. This guide gets you from clone
+to a green test suite to your first PR.
+
+New here? The pinned **[👋 Start here](https://github.com/Rekin226/Agronaut/issues/27)**
+issue lists current good-first-issues and where help is most valuable.
+
+---
+
+## The one rule that defines this project
+
+`aqua_model/` is a **trust zone**: pure Python, no LLM, no network, fully tested. It is the
+part of Agronaut you can audit without trusting a model.
+
+```
+agent / agronaut_agent / app.py   ──imports──▶   aqua_model/   (never the reverse)
+   (LLM, Streamlit, channels)                  (pure, tested, cited)
+```
+
+Two invariants that every PR must preserve:
+
+1. **`aqua_model/` never imports the LLM, agent, UI, or network layers.** Its only
+   dependencies are the standard library and `pandas` (pure compute — no I/O). If you
+   find yourself wanting to import `langchain`, `streamlit`, or `requests` into
+   `aqua_model/`, the logic belongs in the agent layer instead.
+2. **Every number carries a source.** No bare coefficient. A value ships with its range,
+   unit, and a citation (FAO 589, UVI/Rakocy, peer-reviewed literature). A
+   confidently-wrong design must never masquerade as complete — that's the whole point.
+
+If a change can't satisfy both, it's probably in the wrong layer. Ask in the issue.
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/Rekin226/Agronaut.git
+cd Agronaut
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirement.txt
+```
+
+Python **3.11 or 3.12** (what CI runs).
+
+## Run the tests
+
+```bash
+python -m pytest
+```
+
+You should see **102 passed** (and growing). The suite covers three areas:
+
+- `aqua_model/tests/` — the pure engineering core (no model server, no network)
+- `agent/tests/` — the Streamlit UI seam
+- `agronaut_agent/tests/` — the tool-calling agent (dry-run; no live LLM calls)
+
+If your PR touches `aqua_model/`, add or extend a test. The core is the trust zone — it
+stays covered.
+
+---
+
+## How to add a cited coefficient
+
+This is one of the most valuable contributions (see issue
+[#23](https://github.com/Rekin226/Agronaut/issues/23)). Follow the existing shape:
+
+1. Add the species/crop entry in `aqua_model/species.py` or `aqua_model/crops.py` with a
+   **value + range + unit + source**, matching the surrounding entries.
+2. If the source is new, register it in `data/coefficient_sources.json`.
+3. Run `python -m pytest` — keep it green; add a row to any parametrized coverage test.
+
+No source, no merge. Good sources: FAO 589, UVI/Rakocy publications, peer-reviewed
+aquaponics literature.
+
+## How to contribute real-world data (no coding required)
+
+If you run an aquaponics system, your logs are the project's moat — they're what lets us
+*validate* the model against reality. See issue
+[#22](https://github.com/Rekin226/Agronaut/issues/22) and the logging standard in
+`aqua_model/logging_schema.py`. Comment on the issue and we'll help you map your data.
+
+---
+
+## Pull requests
+
+- **Branch** off `main`; keep the PR focused on one issue.
+- **Tests pass**: `python -m pytest` is green locally and in CI.
+- **Commits**: clear, present-tense messages (`feat:`, `fix:`, `docs:`, `chore:` prefixes
+  are appreciated, matching the existing history).
+- **New coefficients carry a source** (see above).
+- **No secrets**: never commit API keys, `.env`, or tokens.
+- Link the issue your PR closes (`Closes #NN`).
+
+CI runs the full suite on every PR across Python 3.11 and 3.12. A red build blocks merge.
+
+## Reporting bugs & proposing features
+
+Open an issue. For bugs, include: what you ran, what you expected, what happened, and your
+Python version. For features, describe the grower problem it solves before the
+implementation — Agronaut is built backward from real operator pain.
+
+## License
+
+By contributing, you agree your contributions are licensed under the project's
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # 🌱 Agronaut
 
+[![CI](https://github.com/Rekin226/Agronaut/actions/workflows/ci.yml/badge.svg)](https://github.com/Rekin226/Agronaut/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/)
+
 **A personal agronomy agent — chat with it to design, optimize, and maintain aquaponics systems.**
 
 Agronaut is a conversational agent (in the spirit of Hermes / OpenClaw) specialized for
@@ -146,6 +150,15 @@ it reproduces a real running system within tolerance — that calibration step i
 milestone (`aqua_model/tests/test_calibration.py`).
 
 ---
+
+## Contributing
+
+Contributions welcome — whether you write Python or run a real system. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup, the trust-zone rule, and how to add a cited
+coefficient, and the pinned [👋 Start here](https://github.com/Rekin226/Agronaut/issues/27)
+issue for good first issues and where help is most valuable. If you operate an aquaponics
+system, [your data](https://github.com/Rekin226/Agronaut/issues/22) is the most valuable
+thing you can give the project.
 
 ## License
 


### PR DESCRIPTION
Lands the two foundational pieces that make every other open issue easier to pick up: automated tests on every PR, and a real contributor on-ramp.

## What's here

**CI (`#18`)**
- `.github/workflows/ci.yml` runs the full `pytest` suite on push & PR across Python **3.11 / 3.12**
- pip caching + concurrency cancellation to keep runs fast and cheap
- CI / license / python badges added to the README

**Contributor on-ramp (`#21`)**
- `CONTRIBUTING.md` — venv setup, running the suite, **the trust-zone invariant** (`aqua_model/` stays pure — no LLM/UI/network imports, verified; every number carries a source), how to add a cited coefficient, and PR expectations
- Issue templates: bug report, feature request, and a **"📊 contribute pond data"** template that feeds the calibration-data flywheel (`#22`)
- `PULL_REQUEST_TEMPLATE.md` with a checklist that enforces the invariants
- README gains a Contributing section linking the pinned start-here issue

## Verification
- `python -m pytest` → **102 passed** locally
- `ci.yml` validated as well-formed YAML
- Confirmed `aqua_model/` imports only stdlib + `pandas` (no LLM/agent/network) — the documented trust-zone rule is real, not aspirational

Closes #18
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)