### PR TITLE
feat: headless CLI for the deterministic core (python -m agronaut)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Open the sidebar **Mode** switch. The **Design Calculator** and **Optimize Ratio
 work immediately (no model server). For **chat**, run Ollama locally or set a hosted
 provider (see above).
 
+### Command line (no Streamlit, no LLM)
+The deterministic modes also run headless — handy for scripting, CI, or a quick answer:
+
+```bash
+python3 -m agronaut design   --species tilapia --crop lettuce \
+                             --grow-area 20 --temp 26 --water-budget 200
+python3 -m agronaut optimize --grow-area 20 --temp 28 --water-budget 200 \
+                             --objective water_efficiency
+python3 -m agronaut species          # list supported fish
+python3 -m agronaut crops            # list supported crops
+```
+
+Add `--json` to any command for machine-readable output, or `design --report` for the full
+cited Markdown design report. The CLI uses the same validation gate as the app, so it can't
+feed the model a number the UI wouldn't.
+
 ### Run the tests
 ```bash
 python3 -m pytest        # the aqua_model core suite is pure (no model server needed)
@@ -126,6 +142,7 @@ agent/               # LLM-facing layer (imports aqua_model, never the reverse)
   llm.py             #   pluggable backend (ollama | nvidia | hf)
   facts.py           #   UI↔model seam
   calculator_ui.py optimizer_ui.py   # Streamlit views
+agronaut/            # headless CLI over the trust zone (stdlib only) — `python -m agronaut`
 app.py               # Streamlit app (chat | calculator | optimizer)
 srcs/chatbot.py      # the conversational/RAG troubleshooting flow
 knowledge/  urls.txt # reference content for RAG

--- a/agronaut/__init__.py
+++ b/agronaut/__init__.py
@@ -1,0 +1,18 @@
+"""Agronaut command-line interface.
+
+A thin, dependency-free (stdlib only) wrapper over the deterministic trust zone, so the
+Design Calculator and Ratio Optimizer run from a terminal or a script without Streamlit,
+an LLM, or a network. It reuses the SAME validation seam as the UI (`agent.facts`), so the
+CLI can never put a number into the model that the app wouldn't.
+
+    python -m agronaut design   --species tilapia --crop lettuce --grow-area 20 --temp 26 --water-budget 200
+    python -m agronaut optimize --grow-area 20 --temp 26 --water-budget 200 --objective water_efficiency
+    python -m agronaut species
+    python -m agronaut crops
+"""
+
+from __future__ import annotations
+
+from .cli import main
+
+__all__ = ["main"]

--- a/agronaut/__main__.py
+++ b/agronaut/__main__.py
@@ -1,0 +1,10 @@
+"""Enable `python -m agronaut ...`."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agronaut/cli.py
+++ b/agronaut/cli.py
@@ -1,0 +1,268 @@
+"""Headless CLI for Agronaut's deterministic core (issue #20).
+
+Subcommands:
+    design    size one system from fixed inputs -> sizing, BOM, envelope, honesty layer
+    optimize  search fish/crop ratios for the best score under the water budget
+    species   list supported fish species
+    crops     list supported crops
+
+Every command supports ``--json`` for machine-readable output. ``design --report`` emits the
+full cited Markdown report. The CLI imports only the standard library plus the pure
+``aqua_model`` trust zone and the ``agent.facts`` validation seam — no Streamlit, no LLM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import sys
+from typing import Sequence
+
+from agent.facts import ValidationError, available_crops, available_species, design_from_form
+from aqua_model.optimizer import OBJECTIVES, OptimizeInput, optimize
+from aqua_model.report import to_markdown
+from aqua_model.sizing import size_system
+
+_PROG = "agronaut"
+
+
+# --------------------------------------------------------------------------- parser
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=_PROG,
+        description="Design and optimize aquaponics systems from the command line "
+        "(deterministic — no LLM, no server).",
+    )
+    sub = parser.add_subparsers(dest="command", metavar="{design,optimize,species,crops}")
+
+    # design ---------------------------------------------------------------
+    d = sub.add_parser("design", help="size one system from fixed inputs")
+    d.add_argument("--species", required=True, help="fish species (see `agronaut species`)")
+    d.add_argument("--crop", required=True, help="crop (see `agronaut crops`)")
+    d.add_argument("--grow-area", type=float, required=True, metavar="M2",
+                   help="planted raft/DWC area in m² (the sizing anchor)")
+    d.add_argument("--temp", type=float, required=True, metavar="C",
+                   help="mean water temperature in °C")
+    d.add_argument("--water-budget", type=float, required=True, metavar="LPD",
+                   help="makeup water available per day, L/day")
+    d.add_argument("--source-water-note", default=None,
+                   help="optional salinity/quality caveat carried into the report")
+    d.add_argument("--site", default=None, help="site name for the --report header")
+    d.add_argument("--report", action="store_true",
+                   help="print the full cited Markdown design report")
+    d.add_argument("--json", action="store_true", help="emit the result as JSON")
+    d.set_defaults(func=cmd_design)
+
+    # optimize -------------------------------------------------------------
+    o = sub.add_parser("optimize", help="find the best fish/crop ratio under your constraint")
+    o.add_argument("--grow-area", type=float, required=True, metavar="M2",
+                   help="total planted area in m²")
+    o.add_argument("--temp", type=float, required=True, metavar="C",
+                   help="mean water temperature in °C")
+    o.add_argument("--water-budget", type=float, required=True, metavar="LPD",
+                   help="makeup water available per day, L/day (the binding constraint)")
+    o.add_argument("--objective", choices=OBJECTIVES, default="water_efficiency",
+                   help="what to maximize (default: water_efficiency)")
+    o.add_argument("--fish", nargs="+", default=None, metavar="SPECIES",
+                   help="restrict the fish palette (default: all)")
+    o.add_argument("--crops", nargs="+", default=None, metavar="CROP",
+                   help="restrict the crop palette (default: all)")
+    o.add_argument("--top", type=int, default=5, metavar="N",
+                   help="how many ranked candidates to show (default: 5)")
+    o.add_argument("--json", action="store_true", help="emit the full result as JSON")
+    o.set_defaults(func=cmd_optimize)
+
+    # species / crops ------------------------------------------------------
+    s = sub.add_parser("species", help="list supported fish species")
+    s.add_argument("--json", action="store_true", help="emit as a JSON array")
+    s.set_defaults(func=cmd_species)
+
+    c = sub.add_parser("crops", help="list supported crops")
+    c.add_argument("--json", action="store_true", help="emit as a JSON array")
+    c.set_defaults(func=cmd_crops)
+
+    return parser
+
+
+# --------------------------------------------------------------------------- commands
+def cmd_design(args: argparse.Namespace) -> int:
+    try:
+        design = design_from_form(
+            fish_species=args.species,
+            crop=args.crop,
+            grow_area_m2=args.grow_area,
+            temperature_c=args.temp,
+            water_budget_lpd=args.water_budget,
+            source_water_note=args.source_water_note,
+        )
+    except ValidationError as exc:
+        _fail(f"validation failed:\n  - " + "\n  - ".join(exc.errors))
+        return 2
+
+    out = size_system(design)
+
+    if args.report:
+        print(to_markdown(design, out, site=args.site))
+        return 0
+    if args.json:
+        _print_json(dataclasses.asdict(out))
+        return 0
+
+    _print_design(design, out)
+    return 0
+
+
+def cmd_optimize(args: argparse.Namespace) -> int:
+    fish = _resolve_palette(args.fish, available_species(), "fish species")
+    crops = _resolve_palette(args.crops, available_crops(), "crop")
+    if fish is _INVALID or crops is _INVALID:
+        return 2
+
+    kwargs = {
+        "grow_area_m2": args.grow_area,
+        "temperature_c": args.temp,
+        "water_budget_lpd": args.water_budget,
+        "objective": args.objective,
+    }
+    if fish is not None:
+        kwargs["fish_palette"] = tuple(fish)
+    if crops is not None:
+        kwargs["crop_palette"] = tuple(crops)
+
+    result = optimize(OptimizeInput(**kwargs))
+
+    if args.json:
+        _print_json(dataclasses.asdict(result))
+        return 0
+
+    _print_optimize(result, top=args.top)
+    return 0
+
+
+def cmd_species(args: argparse.Namespace) -> int:
+    return _print_list(available_species(), as_json=args.json)
+
+
+def cmd_crops(args: argparse.Namespace) -> int:
+    return _print_list(available_crops(), as_json=args.json)
+
+
+# --------------------------------------------------------------------------- palette helper
+_INVALID = object()  # sentinel: a palette name was unknown
+
+
+def _resolve_palette(names, known: Sequence[str], label: str):
+    """Lowercase + validate user-supplied palette names. Returns the list, None (use the
+    model default when no names were given), or the _INVALID sentinel after printing why."""
+    if not names:
+        return None
+    known_set = set(known)
+    resolved, unknown = [], []
+    for raw in names:
+        key = str(raw).strip().lower()
+        (resolved if key in known_set else unknown).append(key)
+    if unknown:
+        _fail(f"unknown {label}: {', '.join(unknown)}\n  known: {', '.join(known)}")
+        return _INVALID
+    return resolved
+
+
+# --------------------------------------------------------------------------- formatting
+def _print_design(design, out) -> None:
+    status = "FEASIBLE" if out.feasible else f"NOT FEASIBLE (binding: {out.binding_constraint})"
+    print(f"Aquaponics design — {status}")
+    print(f"  {design.fish_species} × {design.crop}, {design.grow_area_m2} m² grow area, "
+          f"{design.temperature_c} °C, {design.water_budget_lpd} L/day budget\n")
+
+    rows = [
+        ("Feed", f"{out.feed_g_per_day} g/day"),
+        ("Fish", f"{out.fish_count} head (~{out.fish_biomass_kg} kg biomass)"),
+        ("Rearing tank", f"{out.rearing_tank_volume_l} L"),
+        ("System volume", f"{out.system_volume_l} L"),
+        ("Pump turnover", f"{out.pump_turnover_lph} L/h"),
+        ("Biofilter media", f"{out.biofilter_media_m2} m²"),
+        ("Makeup water", f"{out.makeup_water_lpd} L/day"),
+    ]
+    width = max(len(label) for label, _ in rows)
+    for label, value in rows:
+        print(f"  {label.ljust(width)}  {value}")
+
+    if out.warnings:
+        print()
+        for w in out.warnings:
+            print(f"  ⚠ {w}")
+
+    print("\n  Coefficients are calibration SEEDS from published sources — calibrate against a")
+    print("  real system before building. This model does NOT account for pH/alkalinity,")
+    print("  micronutrients, salinity, solids, pests, cohort logic, or diel temperature.")
+    print("  Run with --report for the full cited breakdown, or --json for structured output.")
+
+
+def _print_optimize(result, top: int) -> None:
+    print(f"Optimize for {result.objective} — searched {result.searched}, "
+          f"{result.feasible_count} feasible")
+
+    if result.best is None:
+        print("\n  No configuration fits the water budget. Try a larger --water-budget or a "
+              "smaller --grow-area.")
+        return
+
+    unit = _objective_unit(result.objective)
+    best = result.best
+    print(f"\n  Best: {best.fish_species} | {_fmt_alloc(best.crop_allocation)}")
+    print(f"    score ({result.objective})  {best.score} {unit}")
+    print(f"    food                  {best.food_kg_yr} kg/yr")
+    print(f"    protein               {best.protein_kg_yr} kg/yr")
+    print(f"    makeup water          {best.makeup_water_lpd} L/day")
+    if result.improvement_vs_baseline_pct is not None:
+        print(f"  +{result.improvement_vs_baseline_pct}% vs the naive even-split baseline")
+
+    rest = [c for c in result.ranked if c is not best][: max(0, top - 1)]
+    if rest:
+        print("\n  Runner-up ratios:")
+        for i, c in enumerate(rest, start=2):
+            print(f"   {i}. {c.fish_species} | {_fmt_alloc(c.crop_allocation)}  "
+                  f"— {c.score} {unit}")
+
+    print("\n  Yields/protein are seed coefficients — calibrate before quoting outcomes. "
+          "--json for full output.")
+
+
+def _objective_unit(objective: str) -> str:
+    return {
+        "food": "kg/yr",
+        "protein": "kg/yr",
+        "water_efficiency": "kg per m³/yr",
+    }.get(objective, "")
+
+
+def _fmt_alloc(alloc: dict) -> str:
+    return ", ".join(f"{crop} {frac:g}" for crop, frac in alloc.items())
+
+
+def _print_list(items, as_json: bool) -> int:
+    if as_json:
+        _print_json(items)
+    else:
+        for item in items:
+            print(item)
+    return 0
+
+
+def _print_json(obj) -> None:
+    print(json.dumps(obj, indent=2, ensure_ascii=False))
+
+
+def _fail(message: str) -> None:
+    print(f"{_PROG}: error: {message}", file=sys.stderr)
+
+
+# --------------------------------------------------------------------------- entrypoint
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 1
+    return args.func(args)

--- a/agronaut/tests/test_cli.py
+++ b/agronaut/tests/test_cli.py
@@ -1,0 +1,107 @@
+"""The CLI is a thin wrapper over the deterministic core: arg parsing -> the same seam
+the UI uses, structured + human output, and the trust gate's rejections surfaced as a
+non-zero exit. No Streamlit, no LLM, no network."""
+
+import json
+
+import pytest
+
+from agronaut.cli import main
+
+# Valid inputs reused across cases (tilapia × lettuce, generous water budget).
+_DESIGN = ["design", "--species", "tilapia", "--crop", "lettuce",
+           "--grow-area", "20", "--temp", "26", "--water-budget", "200"]
+_OPT = ["optimize", "--grow-area", "20", "--temp", "28", "--water-budget", "200"]
+
+
+def test_species_and_crops_listing(capsys):
+    assert main(["species"]) == 0
+    assert "tilapia" in capsys.readouterr().out
+    assert main(["crops"]) == 0
+    assert "lettuce" in capsys.readouterr().out
+
+
+def test_species_json_is_a_parseable_array(capsys):
+    assert main(["species", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert isinstance(data, list) and "tilapia" in data
+
+
+def test_design_human_output(capsys):
+    assert main(_DESIGN) == 0
+    out = capsys.readouterr().out
+    assert "FEASIBLE" in out
+    assert "Feed" in out and "g/day" in out
+    # The honesty layer must always be present.
+    assert "calibration SEEDS" in out
+
+
+def test_design_json_carries_the_full_artifact(capsys):
+    assert main(_DESIGN + ["--json"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["feasible"] is True
+    assert out["fish_count"] > 0
+    assert len(out["coefficients_used"]) > 0      # provenance survives serialization
+    assert len(out["bill_of_materials"]) > 0
+    assert len(out["not_modeled"]) > 0            # honesty layer survives serialization
+
+
+def test_design_report_is_markdown(capsys):
+    assert main(_DESIGN + ["--report", "--site", "Pilot"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("# Aquaponics System Design — Pilot")
+    assert "## Coefficients Used (auditable)" in out
+    assert "## NOT Modeled" in out
+
+
+def test_validation_error_is_a_nonzero_exit(capsys):
+    # Unknown species must be rejected by the trust gate, not silently defaulted.
+    code = main(["design", "--species", "shark", "--crop", "lettuce",
+                 "--grow-area", "20", "--temp", "26", "--water-budget", "200"])
+    assert code == 2
+    assert "validation failed" in capsys.readouterr().err
+
+
+def test_infeasible_design_still_succeeds_but_says_so(capsys):
+    # A tiny water budget is a valid computed result (infeasible), not an error.
+    assert main(["design", "--species", "tilapia", "--crop", "lettuce",
+                 "--grow-area", "20", "--temp", "26", "--water-budget", "5"]) == 0
+    assert "NOT FEASIBLE" in capsys.readouterr().out
+
+
+def test_optimize_human_output(capsys):
+    assert main(_OPT + ["--objective", "food", "--top", "3"]) == 0
+    out = capsys.readouterr().out
+    assert "Optimize for food" in out
+    assert "Best:" in out
+
+
+def test_optimize_json_is_parseable(capsys):
+    assert main(_OPT + ["--json"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["objective"] == "water_efficiency"
+    assert out["best"]["fish_species"]
+    assert out["searched"] > 0
+
+
+def test_optimize_palette_restriction(capsys):
+    assert main(_OPT + ["--fish", "tilapia", "--crops", "lettuce", "--json"]) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["best"]["fish_species"] == "tilapia"
+
+
+def test_optimize_unknown_fish_is_a_nonzero_exit(capsys):
+    assert main(_OPT + ["--fish", "salmon"]) == 2
+    assert "unknown fish species" in capsys.readouterr().err
+
+
+def test_optimize_rejects_bad_objective_via_argparse():
+    # argparse `choices` enforcement exits 2 before our code runs.
+    with pytest.raises(SystemExit) as exc:
+        main(_OPT + ["--objective", "money"])
+    assert exc.value.code == 2
+
+
+def test_no_command_prints_help_and_returns_one(capsys):
+    assert main([]) == 1
+    assert "usage:" in capsys.readouterr().out.lower()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-testpaths = aqua_model/tests agent/tests agronaut_agent/tests
+testpaths = aqua_model/tests agent/tests agronaut_agent/tests agronaut/tests
 python_files = test_*.py
 addopts = -v


### PR DESCRIPTION
Closes #20. Runs the **Design Calculator** and **Ratio Optimizer** from a terminal or script — no Streamlit, no LLM, no network. Makes the deterministic core scriptable and easy to demo/trust.

## Design
A thin `argparse` wrapper (stdlib only — zero new dependencies) over the **same validation seam the UI uses** (`agent.facts.design_from_form` → the trust gate), then `size_system()` / `optimize()` / `to_markdown()`. The CLI therefore can't put a number into the model that the app wouldn't.

```bash
python -m agronaut design   --species tilapia --crop lettuce --grow-area 20 --temp 26 --water-budget 200
python -m agronaut optimize --grow-area 20 --temp 28 --water-budget 200 --objective water_efficiency
python -m agronaut species   # list supported fish
python -m agronaut crops     # list supported crops
```

- `--json` on every command (dataclasses serialized in full — coefficients, BOM, and the "not modeled" honesty layer all survive the round-trip).
- `design --report` emits the full cited Markdown design report.
- Exit codes: validation failure / unknown palette name → `2`; an **infeasible** design is a valid computed result → `0`, clearly flagged `NOT FEASIBLE` with the nearest-feasible hint.

## Tests
13 new tests (`agronaut/tests/test_cli.py`), registered in `pytest.ini`: arg-parsing → result, JSON parseability, the honesty layer surviving serialization, trust-gate rejection as a non-zero exit, palette restriction, and argparse `choices` enforcement. **Full suite: 115 passed** (was 102), CLI tests run in 0.03s.

## Verified
- All four subcommands + `--json` + `--report` exercised by hand and in tests.
- Import purity checked: `import agronaut.cli` pulls **no** langchain/streamlit/torch — so it also runs under the light `requirements.txt` from #29.

## Files
- `agronaut/` — new package: `cli.py`, `__main__.py`, `__init__.py`, `tests/`
- `README.md` — a "Command line" section + a layout entry
- `pytest.ini` — adds `agronaut/tests` to `testpaths`

🤖 Generated with [Claude Code](https://claude.com/claude-code)