### PR TITLE
Expand species & crop tables (common carp + 5 crops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ crop yield), Agronaut tunes *your* future sizings toward your system — bounded
 published empirical ranges, so a measurement can only move a coefficient within what the
 literature allows, and every calibrated number is labeled.
 
+The deterministic sizing model now covers five fish (tilapia, clarias, channel catfish, trout,
+common carp) and eight crops (lettuce, basil, tomato, kale, swiss chard, spinach, cucumber,
+pepper) — each with cited, calibratable seed coefficients.
+
 ### Honesty by design
 Every result lists the coefficients it used (value + range + **source**: FAO 589,
 UVI/Rakocy, literature) and an explicit list of what it does **not** model

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -59,6 +59,14 @@ def test_list_supported():
     assert "tilapia" in out and "lettuce" in out and "water_efficiency" in out
 
 
+def test_list_supported_includes_new_species_and_crops():
+    from agronaut_agent.tools import list_supported_species_and_crops
+    out = list_supported_species_and_crops.invoke({})
+    assert "carp" in out
+    for c in ("kale", "swiss_chard", "spinach", "cucumber", "pepper"):
+        assert c in out
+
+
 def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}

--- a/aqua_model/calibration.py
+++ b/aqua_model/calibration.py
@@ -149,31 +149,31 @@ def _calibrations() -> list[SizingCalibration]:
             "kale.frr", "Kale feeding-rate ratio",
             kale.frr_g_per_m2_day, 45.0, 90.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
-            "Leafy band; seed 65 is mid.",
+            "Leafy band; seed 65 sits just below mid (range 45–90).",
         ),
         SizingCalibration(
             "swiss_chard.frr", "Swiss chard feeding-rate ratio",
             swiss_chard.frr_g_per_m2_day, 40.0, 85.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
-            "Leafy band; seed 60 is mid.",
+            "Leafy band; seed 60 is near mid (range 40–85).",
         ),
         SizingCalibration(
             "spinach.frr", "Spinach feeding-rate ratio",
             spinach.frr_g_per_m2_day, 40.0, 80.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
-            "Cool-season leafy; seed 55 is mid.",
+            "Cool-season leafy; seed 55 is toward the low end (range 40–80).",
         ),
         SizingCalibration(
             "cucumber.frr", "Cucumber feeding-rate ratio",
             cucumber.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
-            "Fruiting band; seed 100 is mid.",
+            "Fruiting band; seed 100 is near mid (range 80–130).",
         ),
         SizingCalibration(
             "pepper.frr", "Pepper feeding-rate ratio",
             pepper.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
-            "Fruiting band; seed 100 is mid.",
+            "Fruiting band; seed 100 is near mid (range 80–130).",
         ),
         # ---- Yield and harvest weight ----
         SizingCalibration(

--- a/aqua_model/calibration.py
+++ b/aqua_model/calibration.py
@@ -76,6 +76,9 @@ def _calibrations() -> list[SizingCalibration]:
     tilapia, trout = get_species("tilapia"), get_species("trout")
     clarias, channel = get_species("clarias"), get_species("channel_catfish")
     lettuce, basil, tomato = get_crop("lettuce"), get_crop("basil"), get_crop("tomato")
+    carp = get_species("carp")
+    kale, swiss_chard, spinach = get_crop("kale"), get_crop("swiss_chard"), get_crop("spinach")
+    cucumber, pepper = get_crop("cucumber"), get_crop("pepper")
 
     return [
         # ---- Feed conversion ratios (g feed / g live-weight gain) ----
@@ -109,6 +112,12 @@ def _calibrations() -> list[SizingCalibration]:
             ("Rainbow trout (Oncorhynchus mykiss) literature FCR ~0.8–1.5 (trials report 0.99–1.49)",),
             "Cold-water, efficient. Seed 1.2 is mid-range.",
         ),
+        SizingCalibration(
+            "carp.fcr", "Common carp feed conversion ratio",
+            carp.fcr, 1.5, 2.5, "g feed / g gain",
+            ("Common carp (Cyprinus carpio) pond/RAS grow-out FCR ~1.5–2.5",),
+            "One of the most-farmed fish worldwide; seed 2.0 is mid-range.",
+        ),
         # ---- Feeding-rate ratio (g feed / m² plant / day) — the load-bearing sizing rule ----
         SizingCalibration(
             "lettuce.frr", "Lettuce feeding-rate ratio",
@@ -135,6 +144,36 @@ def _calibrations() -> list[SizingCalibration]:
             tomato.frr_g_per_m2_day, 80.0, 140.0, "g feed / m² / day",
             ("Somerville et al. (2014), FAO 589: fruiting raft ~100+ g/m²/day",),
             "Fruiting crops carry a higher feed load than leafy. Seed 110 is mid-band.",
+        ),
+        SizingCalibration(
+            "kale.frr", "Kale feeding-rate ratio",
+            kale.frr_g_per_m2_day, 45.0, 90.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Leafy band; seed 65 is mid.",
+        ),
+        SizingCalibration(
+            "swiss_chard.frr", "Swiss chard feeding-rate ratio",
+            swiss_chard.frr_g_per_m2_day, 40.0, 85.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Leafy band; seed 60 is mid.",
+        ),
+        SizingCalibration(
+            "spinach.frr", "Spinach feeding-rate ratio",
+            spinach.frr_g_per_m2_day, 40.0, 80.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Cool-season leafy; seed 55 is mid.",
+        ),
+        SizingCalibration(
+            "cucumber.frr", "Cucumber feeding-rate ratio",
+            cucumber.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
+            "Fruiting band; seed 100 is mid.",
+        ),
+        SizingCalibration(
+            "pepper.frr", "Pepper feeding-rate ratio",
+            pepper.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
+            "Fruiting band; seed 100 is mid.",
         ),
         # ---- Yield and harvest weight ----
         SizingCalibration(

--- a/aqua_model/crops.py
+++ b/aqua_model/crops.py
@@ -54,7 +54,48 @@ TOMATO = Crop(
     ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589",
 )
 
-CROPS: dict[str, Crop] = {c.name: c for c in (LETTUCE, BASIL, TOMATO)}
+# More leafy greens (UVI/FAO leafy feeding-rate band ~40-100 g/m2/day).
+KALE = Crop(
+    name="kale", category="leafy",
+    frr_g_per_m2_day=65.0, frr_low=45.0, frr_high=90.0,
+    n_uptake_g_per_m2_day=0.9,
+    yield_kg_per_m2_year=20.0, edible_protein_pct=3.3,
+    ph_min=5.5, ph_max=7.0, temp_min_c=7.0, temp_max_c=24.0, source="FAO589/UVI (leafy band)",
+)
+SWISS_CHARD = Crop(
+    name="swiss_chard", category="leafy",
+    frr_g_per_m2_day=60.0, frr_low=40.0, frr_high=85.0,
+    n_uptake_g_per_m2_day=0.85,
+    yield_kg_per_m2_year=22.0, edible_protein_pct=1.8,
+    ph_min=5.5, ph_max=7.0, temp_min_c=10.0, temp_max_c=27.0, source="FAO589/UVI (leafy band)",
+)
+SPINACH = Crop(
+    name="spinach", category="leafy",
+    frr_g_per_m2_day=55.0, frr_low=40.0, frr_high=80.0,
+    n_uptake_g_per_m2_day=0.8,
+    yield_kg_per_m2_year=15.0, edible_protein_pct=2.9,
+    ph_min=6.0, ph_max=7.0, temp_min_c=7.0, temp_max_c=24.0, source="FAO589/UVI (leafy band)",
+)
+
+# More fruiting crops (FAO fruiting feeding-rate band ~80-140 g/m2/day).
+CUCUMBER = Crop(
+    name="cucumber", category="fruiting",
+    frr_g_per_m2_day=100.0, frr_low=80.0, frr_high=130.0,
+    n_uptake_g_per_m2_day=1.5,
+    yield_kg_per_m2_year=35.0, edible_protein_pct=0.7,
+    ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589 (fruiting band)",
+)
+PEPPER = Crop(
+    name="pepper", category="fruiting",
+    frr_g_per_m2_day=100.0, frr_low=80.0, frr_high=130.0,
+    n_uptake_g_per_m2_day=1.4,
+    yield_kg_per_m2_year=20.0, edible_protein_pct=1.0,
+    ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589 (fruiting band)",
+)
+
+CROPS: dict[str, Crop] = {
+    c.name: c for c in (LETTUCE, BASIL, TOMATO, KALE, SWISS_CHARD, SPINACH, CUCUMBER, PEPPER)
+}
 
 
 def get_crop(name: str) -> Crop:

--- a/aqua_model/species.py
+++ b/aqua_model/species.py
@@ -64,8 +64,18 @@ TROUT = FishSpecies(
     source="LIT",
 )
 
+# Common carp (Cyprinus carpio): among the most-farmed fish worldwide. Hardy, omnivorous,
+# very cold-tolerant warm-water fish; moderate feed efficiency.
+CARP = FishSpecies(
+    name="carp",
+    feeding_rate_pct_bw=1.5, fcr=2.0, feed_protein_pct=32.0,
+    body_protein_pct=16.0, harvest_weight_kg=1.0, stocking_density_kg_m3=25.0,
+    temp_min_c=8.0, temp_opt_low_c=23.0, temp_opt_high_c=30.0, temp_max_c=34.0,
+    source="LIT (carp aquaculture)",
+)
+
 SPECIES: dict[str, FishSpecies] = {
-    s.name: s for s in (TILAPIA, CLARIAS, CHANNEL_CATFISH, TROUT)
+    s.name: s for s in (TILAPIA, CLARIAS, CHANNEL_CATFISH, TROUT, CARP)
 }
 
 

--- a/aqua_model/tests/test_calibration.py
+++ b/aqua_model/tests/test_calibration.py
@@ -45,3 +45,16 @@ def test_reference_system_is_feasible_or_flags_why_not(system):
     # explain why (a signal our coefficients need calibration).
     result = rs.check(system)
     assert result["feasible"] or result["warnings"]
+
+
+def test_new_coefficients_present_and_within_range():
+    from aqua_model import calibration
+    keys = {c.key for c in calibration.all_calibrations()}
+    for k in ("carp.fcr", "kale.frr", "swiss_chard.frr", "spinach.frr",
+              "cucumber.frr", "pepper.frr"):
+        assert k in keys
+    # every new seed sits inside its own cited range -> not flagged as a discrepancy
+    disc = {c.key for c in calibration.discrepancies()}
+    for k in ("carp.fcr", "kale.frr", "swiss_chard.frr", "spinach.frr",
+              "cucumber.frr", "pepper.frr"):
+        assert k not in disc

--- a/aqua_model/tests/test_optimizer.py
+++ b/aqua_model/tests/test_optimizer.py
@@ -94,3 +94,10 @@ def test_optimize_no_override_is_unchanged():
     from aqua_model import optimize, OptimizeInput
     inp = OptimizeInput(grow_area_m2=10, temperature_c=27, water_budget_lpd=5000, objective="food")
     assert optimize(inp, overrides=None).best.score == optimize(inp).best.score
+
+
+def test_optimize_default_palette_includes_new_entries():
+    from aqua_model import optimize, OptimizeInput
+    inp = OptimizeInput(grow_area_m2=10, temperature_c=25, water_budget_lpd=5000, objective="food")
+    res = optimize(inp)                      # default palettes = all species/crops
+    assert res.best is not None              # a feasible best exists with the expanded palette

--- a/aqua_model/tests/test_sizing.py
+++ b/aqua_model/tests/test_sizing.py
@@ -93,3 +93,31 @@ def test_size_system_rejects_out_of_range_override():
     import pytest
     with pytest.raises(ValidationError):
         size_system(design, overrides={"tilapia.harvest_weight": 5.0})  # far above range
+
+
+import pytest
+from aqua_model.species import SPECIES
+from aqua_model.crops import CROPS
+
+
+@pytest.mark.parametrize("fish", ["tilapia", "clarias", "channel_catfish", "trout", "carp"])
+def test_every_species_sizes(fish):
+    from aqua_model import size_system
+    from aqua_model.validate import validate_design_input
+    out = size_system(validate_design_input(fish, "lettuce", 20, 24, 5000))
+    assert out.fish_count >= 1 and out.feed_g_per_day > 0
+
+
+@pytest.mark.parametrize("crop", ["lettuce", "basil", "tomato", "kale", "swiss_chard",
+                                  "spinach", "cucumber", "pepper"])
+def test_every_crop_sizes(crop):
+    from aqua_model import size_system
+    from aqua_model.validate import validate_design_input
+    out = size_system(validate_design_input("tilapia", crop, 20, 24, 5000))
+    assert out.fish_count >= 1 and out.feed_g_per_day > 0
+
+
+def test_new_keys_registered():
+    assert "carp" in SPECIES
+    for c in ("kale", "swiss_chard", "spinach", "cucumber", "pepper"):
+        assert c in CROPS

--- a/docs/superpowers/plans/2026-07-04-species-crop-expansion.md
+++ b/docs/superpowers/plans/2026-07-04-species-crop-expansion.md
@@ -1,0 +1,348 @@
+# Species & Crop Table Expansion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add sourced seed entries to the deterministic model — common carp + kale, swiss chard, spinach, cucumber, pepper — with calibration ranges and tests, purely additively.
+
+**Architecture:** Add frozen-dataclass rows to `species.py`/`crops.py` (auto-registered in the `SPECIES`/`CROPS` dicts and thus the optimizer palettes and trust gate), extend `calibration.py`'s seed-vs-range honesty layer for the new load-bearing coefficients, and add parametrized coverage tests. No formula, trust-gate, or architecture change.
+
+**Tech Stack:** Python 3.12, `aqua_model` (frozen dataclasses), pytest. No new dependencies.
+
+## Global Constraints
+
+- Coefficient values are EXACTLY as specified in the spec tables — do not alter them.
+- Canonical keys (the `name` field / dict key): `carp`, `kale`, `swiss_chard`, `spinach`, `cucumber`, `pepper`.
+- Every new seed must sit INSIDE its calibration empirical range, so `discrepancies()` stays clean.
+- Additive only: existing species/crops, formulas, the trust gate (`validate_design_input`), and the no-new-entry behavior are untouched.
+- `FishSpecies` field order: name, feeding_rate_pct_bw, fcr, feed_protein_pct, body_protein_pct, harvest_weight_kg, stocking_density_kg_m3, temp_min_c, temp_opt_low_c, temp_opt_high_c, temp_max_c, source.
+- `Crop` field order: name, category, frr_g_per_m2_day, frr_low, frr_high, n_uptake_g_per_m2_day, yield_kg_per_m2_year, edible_protein_pct, ph_min, ph_max, temp_min_c, temp_max_c, source.
+- Work on branch `feat/species-crop-expansion` (already checked out). Commit after every task.
+
+---
+
+### Task 1: Add the new species and crops (data rows + coverage tests)
+
+**Files:**
+- Modify: `aqua_model/species.py` (add `CARP`, register in `SPECIES`)
+- Modify: `aqua_model/crops.py` (add `KALE`, `SWISS_CHARD`, `SPINACH`, `CUCUMBER`, `PEPPER`, register in `CROPS`)
+- Test: `aqua_model/tests/test_sizing.py`, `aqua_model/tests/test_optimizer.py`
+
+**Interfaces:**
+- Consumes: `FishSpecies`, `Crop`, `size_system`, `validate_design_input`, `optimize`, `OptimizeInput`.
+- Produces: `SPECIES` gains key `carp`; `CROPS` gains keys `kale`, `swiss_chard`, `spinach`, `cucumber`, `pepper`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `aqua_model/tests/test_sizing.py`:
+
+```python
+import pytest
+from aqua_model.species import SPECIES
+from aqua_model.crops import CROPS
+
+
+@pytest.mark.parametrize("fish", ["tilapia", "clarias", "channel_catfish", "trout", "carp"])
+def test_every_species_sizes(fish):
+    from aqua_model import size_system
+    from aqua_model.validate import validate_design_input
+    out = size_system(validate_design_input(fish, "lettuce", 20, 24, 5000))
+    assert out.fish_count >= 1 and out.feed_g_per_day > 0
+
+
+@pytest.mark.parametrize("crop", ["lettuce", "basil", "tomato", "kale", "swiss_chard",
+                                  "spinach", "cucumber", "pepper"])
+def test_every_crop_sizes(crop):
+    from aqua_model import size_system
+    from aqua_model.validate import validate_design_input
+    out = size_system(validate_design_input("tilapia", crop, 20, 24, 5000))
+    assert out.fish_count >= 1 and out.feed_g_per_day > 0
+
+
+def test_new_keys_registered():
+    assert "carp" in SPECIES
+    for c in ("kale", "swiss_chard", "spinach", "cucumber", "pepper"):
+        assert c in CROPS
+```
+
+Append to `aqua_model/tests/test_optimizer.py`:
+
+```python
+def test_optimize_default_palette_includes_new_entries():
+    from aqua_model import optimize, OptimizeInput
+    inp = OptimizeInput(grow_area_m2=10, temperature_c=25, water_budget_lpd=5000, objective="food")
+    res = optimize(inp)                      # default palettes = all species/crops
+    assert res.best is not None              # a feasible best exists with the expanded palette
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest aqua_model/tests/test_sizing.py -k "carp or every_crop or new_keys" aqua_model/tests/test_optimizer.py -k "new_entries" -v`
+Expected: FAIL — `KeyError: Unknown fish species 'carp'` (and unknown crops)
+
+- [ ] **Step 3: Add the species row**
+
+In `aqua_model/species.py`, add after `TROUT` (before the `SPECIES` dict):
+
+```python
+# Common carp (Cyprinus carpio): among the most-farmed fish worldwide. Hardy, omnivorous,
+# very cold-tolerant warm-water fish; moderate feed efficiency.
+CARP = FishSpecies(
+    name="carp",
+    feeding_rate_pct_bw=1.5, fcr=2.0, feed_protein_pct=32.0,
+    body_protein_pct=16.0, harvest_weight_kg=1.0, stocking_density_kg_m3=25.0,
+    temp_min_c=8.0, temp_opt_low_c=23.0, temp_opt_high_c=30.0, temp_max_c=34.0,
+    source="LIT (carp aquaculture)",
+)
+```
+
+Update the `SPECIES` dict to include it:
+
+```python
+SPECIES: dict[str, FishSpecies] = {
+    s.name: s for s in (TILAPIA, CLARIAS, CHANNEL_CATFISH, TROUT, CARP)
+}
+```
+
+- [ ] **Step 4: Add the crop rows**
+
+In `aqua_model/crops.py`, add after `TOMATO` (before the `CROPS` dict):
+
+```python
+# More leafy greens (UVI/FAO leafy feeding-rate band ~40-100 g/m2/day).
+KALE = Crop(
+    name="kale", category="leafy",
+    frr_g_per_m2_day=65.0, frr_low=45.0, frr_high=90.0,
+    n_uptake_g_per_m2_day=0.9,
+    yield_kg_per_m2_year=20.0, edible_protein_pct=3.3,
+    ph_min=5.5, ph_max=7.0, temp_min_c=7.0, temp_max_c=24.0, source="FAO589/UVI (leafy band)",
+)
+SWISS_CHARD = Crop(
+    name="swiss_chard", category="leafy",
+    frr_g_per_m2_day=60.0, frr_low=40.0, frr_high=85.0,
+    n_uptake_g_per_m2_day=0.85,
+    yield_kg_per_m2_year=22.0, edible_protein_pct=1.8,
+    ph_min=5.5, ph_max=7.0, temp_min_c=10.0, temp_max_c=27.0, source="FAO589/UVI (leafy band)",
+)
+SPINACH = Crop(
+    name="spinach", category="leafy",
+    frr_g_per_m2_day=55.0, frr_low=40.0, frr_high=80.0,
+    n_uptake_g_per_m2_day=0.8,
+    yield_kg_per_m2_year=15.0, edible_protein_pct=2.9,
+    ph_min=6.0, ph_max=7.0, temp_min_c=7.0, temp_max_c=24.0, source="FAO589/UVI (leafy band)",
+)
+
+# More fruiting crops (FAO fruiting feeding-rate band ~80-140 g/m2/day).
+CUCUMBER = Crop(
+    name="cucumber", category="fruiting",
+    frr_g_per_m2_day=100.0, frr_low=80.0, frr_high=130.0,
+    n_uptake_g_per_m2_day=1.5,
+    yield_kg_per_m2_year=35.0, edible_protein_pct=0.7,
+    ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589 (fruiting band)",
+)
+PEPPER = Crop(
+    name="pepper", category="fruiting",
+    frr_g_per_m2_day=100.0, frr_low=80.0, frr_high=130.0,
+    n_uptake_g_per_m2_day=1.4,
+    yield_kg_per_m2_year=20.0, edible_protein_pct=1.0,
+    ph_min=5.5, ph_max=6.5, temp_min_c=18.0, temp_max_c=30.0, source="FAO589 (fruiting band)",
+)
+```
+
+Update the `CROPS` dict:
+
+```python
+CROPS: dict[str, Crop] = {
+    c.name: c for c in (LETTUCE, BASIL, TOMATO, KALE, SWISS_CHARD, SPINACH, CUCUMBER, PEPPER)
+}
+```
+
+- [ ] **Step 4b: Run the model suite to verify pass + no regressions**
+
+Run: `.venv/bin/python -m pytest aqua_model/tests/ -q`
+Expected: PASS (all — the new parametrized cases pass; every pre-existing test is unchanged)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aqua_model/species.py aqua_model/crops.py aqua_model/tests/test_sizing.py aqua_model/tests/test_optimizer.py
+git commit -m "feat(aqua_model): add common carp + 5 crops (kale, chard, spinach, cucumber, pepper)"
+```
+
+---
+
+### Task 2: Calibration ranges for the new load-bearing coefficients
+
+**Files:**
+- Modify: `aqua_model/calibration.py`
+- Test: `aqua_model/tests/test_calibration.py`
+
+**Interfaces:**
+- Consumes: `SPECIES`/`CROPS` (Task 1) via `get_species`/`get_crop`; `SizingCalibration`, `discrepancies`, `get`.
+- Produces: `CALIBRATIONS` gains keys `carp.fcr`, `kale.frr`, `swiss_chard.frr`, `spinach.frr`, `cucumber.frr`, `pepper.frr`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `aqua_model/tests/test_calibration.py`:
+
+```python
+def test_new_coefficients_present_and_within_range():
+    from aqua_model import calibration
+    keys = {c.key for c in calibration.all_calibrations()}
+    for k in ("carp.fcr", "kale.frr", "swiss_chard.frr", "spinach.frr",
+              "cucumber.frr", "pepper.frr"):
+        assert k in keys
+    # every new seed sits inside its own cited range -> not flagged as a discrepancy
+    disc = {c.key for c in calibration.discrepancies()}
+    for k in ("carp.fcr", "kale.frr", "swiss_chard.frr", "spinach.frr",
+              "cucumber.frr", "pepper.frr"):
+        assert k not in disc
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest aqua_model/tests/test_calibration.py -k new_coefficients -v`
+Expected: FAIL — `assert 'carp.fcr' in keys` (KeyError/AssertionError — not yet registered)
+
+- [ ] **Step 3: Add the calibration entries**
+
+In `aqua_model/calibration.py`, inside `_calibrations()`, extend the local lookups (after the existing `lettuce, basil, tomato = ...` line):
+
+```python
+    carp = get_species("carp")
+    kale, swiss_chard, spinach = get_crop("kale"), get_crop("swiss_chard"), get_crop("spinach")
+    cucumber, pepper = get_crop("cucumber"), get_crop("pepper")
+```
+
+Then add these entries to the returned list (place the FCR entry with the other `*.fcr` entries, and the FRR entries with the other `*.frr` entries):
+
+```python
+        SizingCalibration(
+            "carp.fcr", "Common carp feed conversion ratio",
+            carp.fcr, 1.5, 2.5, "g feed / g gain",
+            ("Common carp (Cyprinus carpio) pond/RAS grow-out FCR ~1.5–2.5",),
+            "One of the most-farmed fish worldwide; seed 2.0 is mid-range.",
+        ),
+        SizingCalibration(
+            "kale.frr", "Kale feeding-rate ratio",
+            kale.frr_g_per_m2_day, 45.0, 90.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Leafy band; seed 65 is mid.",
+        ),
+        SizingCalibration(
+            "swiss_chard.frr", "Swiss chard feeding-rate ratio",
+            swiss_chard.frr_g_per_m2_day, 40.0, 85.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Leafy band; seed 60 is mid.",
+        ),
+        SizingCalibration(
+            "spinach.frr", "Spinach feeding-rate ratio",
+            spinach.frr_g_per_m2_day, 40.0, 80.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589; UVI leafy feeding-rate band ~40–100 g/m²/day",),
+            "Cool-season leafy; seed 55 is mid.",
+        ),
+        SizingCalibration(
+            "cucumber.frr", "Cucumber feeding-rate ratio",
+            cucumber.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
+            "Fruiting band; seed 100 is mid.",
+        ),
+        SizingCalibration(
+            "pepper.frr", "Pepper feeding-rate ratio",
+            pepper.frr_g_per_m2_day, 80.0, 130.0, "g feed / m² / day",
+            ("Somerville et al. (2014), FAO 589: fruiting raft ~80–140 g/m²/day",),
+            "Fruiting band; seed 100 is mid.",
+        ),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest aqua_model/tests/test_calibration.py -v`
+Expected: PASS (all — new keys present, none in `discrepancies()`; existing calibration tests unchanged)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aqua_model/calibration.py aqua_model/tests/test_calibration.py
+git commit -m "feat(aqua_model): calibration ranges for carp.fcr + new crop FRRs"
+```
+
+---
+
+### Task 3: Agent-facing check + live smoke + README
+
+**Files:**
+- Modify: `README.md`
+- Test: `agronaut_agent/tests/test_tools.py`
+
+**Interfaces:**
+- Consumes: `list_supported_species_and_crops` tool (already lists `SPECIES`/`CROPS`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `agronaut_agent/tests/test_tools.py`:
+
+```python
+def test_list_supported_includes_new_species_and_crops():
+    from agronaut_agent.tools import list_supported_species_and_crops
+    out = list_supported_species_and_crops.invoke({})
+    assert "carp" in out
+    for c in ("kale", "swiss_chard", "spinach", "cucumber", "pepper"):
+        assert c in out
+```
+
+- [ ] **Step 2: Run it — this is a coverage test, expected GREEN**
+
+`list_supported_species_and_crops` enumerates `SPECIES`/`CROPS` live, so once Task 1 landed the new
+names are already listed — no production code changes in this task. This test locks that in (it would
+only go red if a future change dropped an entry).
+
+Run: `.venv/bin/python -m pytest agronaut_agent/tests/test_tools.py -k list_supported -v`
+Expected: PASS (both the existing `test_list_supported` and the new one)
+
+- [ ] **Step 4: Live smoke — size and optimize with a new species/crop**
+
+Run:
+
+```bash
+PYTHONPATH=/home/rekin226/Desktop/code_space/Agronaut .venv/bin/python -c "
+from aqua_model import size_system, optimize, OptimizeInput
+from aqua_model.validate import validate_design_input
+d = validate_design_input('carp', 'kale', 20, 24, 5000)
+out = size_system(d)
+print('carp+kale: feasible=%s fish=%d feed=%.0f g/day' % (out.feasible, out.fish_count, out.feed_g_per_day))
+best = optimize(OptimizeInput(grow_area_m2=10, temperature_c=24, water_budget_lpd=5000, objective='food')).best
+print('optimizer best fish:', best.fish_species, 'crops:', best.crop_allocation)
+"
+```
+Expected: a feasible carp+kale sizing with positive fish/feed, and the optimizer returns a best (its palette now spans all 5 fish / 8 crops).
+
+- [ ] **Step 5: Add the README note**
+
+In `README.md`, find the line listing supported species/crops (near the model/features description). If a short "supported" list exists, update it to mention the broader set; otherwise append under the "### Consultative agent" subsection:
+
+```markdown
+The deterministic sizing model now covers five fish (tilapia, clarias, channel catfish, trout,
+common carp) and eight crops (lettuce, basil, tomato, kale, swiss chard, spinach, cucumber,
+pepper) — each with cited, calibratable seed coefficients.
+```
+
+- [ ] **Step 6: Run the full suite one last time**
+
+Run: `.venv/bin/python -m pytest aqua_model/tests/ agronaut_agent/tests/ -q`
+Expected: PASS (all).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md agronaut_agent/tests/test_tools.py
+git commit -m "docs: broaden documented species/crop coverage; test list_supported"
+```
+
+---
+
+## Notes for the implementer
+
+- **Run tests with the venv:** always `.venv/bin/python -m pytest ...`.
+- **Values are fixed by the spec** — copy the coefficient numbers exactly; they were reviewed and approved.
+- **Ordering matters:** Task 2 (`calibration.py`) reads the new seeds via `get_species`/`get_crop`, so Task 1 must land first.
+- **Nothing else changes** — the sizing/optimize formulas, the trust gate, and existing seeds are untouched; this is purely new, sourced data plus its honesty-layer ranges.

--- a/docs/superpowers/specs/2026-07-04-species-crop-expansion-design.md
+++ b/docs/superpowers/specs/2026-07-04-species-crop-expansion-design.md
@@ -1,0 +1,162 @@
+# Agronaut — Species & Crop Table Expansion (Design)
+
+**Date:** 2026-07-04
+**Status:** Approved for planning
+**Scope:** Add sourced seed entries to the deterministic model: 1 fish (common carp) + 5 crops
+(kale, swiss chard, spinach, cucumber, pepper), with calibration ranges and tests.
+
+---
+
+## 1. Problem
+
+The knowledge-base audit found the deterministic model narrow: 4 fish, 3 crops. The Tier-1/2
+knowledge docs now cover many more fish/crops *qualitatively*, but the sizing/optimize **math**
+can only handle the 4/3 it has seed coefficients for. This adds well-sourced seed entries so the
+model can size and optimize a broader, common set.
+
+These coefficients enter the **trust zone** (they drive deterministic sizing/optimize math), so
+they are sourced and ranged like the existing seeds, and are honest *seed estimates* — anchored
+to FAO 589 bands and the existing seeds, meant to be Phase-5-calibrated, not per-cultivar truth.
+
+### What makes this purely additive (verified)
+
+- `OptimizeInput.fish_palette`/`crop_palette` default to `tuple(sorted(SPECIES))`/`sorted(CROPS)`
+  — new entries auto-join the optimizer search.
+- `validate_design_input` accepts any key present in `SPECIES`/`CROPS`.
+- No test hardcodes the species/crop counts; `test_list_supported` only checks that tilapia /
+  lettuce / water_efficiency appear (still true).
+
+So the change is: add data rows (`species.py`, `crops.py`) + calibration ranges (`calibration.py`)
++ tests. No architecture change; the trust gate, sizing formulas, and no-new-entry behavior are
+untouched.
+
+---
+
+## 2. New fish — Common carp (`Cyprinus carpio`)
+
+`FishSpecies` fields (anchored to the existing tilapia/catfish seeds):
+
+| field | value | rationale |
+|-------|-------|-----------|
+| name | `carp` | canonical key |
+| feeding_rate_pct_bw | 1.5 | grow-out omnivore (matches tilapia/catfish) |
+| fcr | 2.0 | carp pond FCR ~1.5–2.5; 2.0 mid |
+| feed_protein_pct | 32.0 | carp grow-out feed ~30–35% |
+| body_protein_pct | 16.0 | typical freshwater fish wet body |
+| harvest_weight_kg | 1.0 | common 0.5–2 kg target |
+| stocking_density_kg_m3 | 25.0 | hardy, moderate–high density |
+| temp_min_c | 8.0 | very cold-tolerant |
+| temp_opt_low_c | 23.0 | |
+| temp_opt_high_c | 30.0 | |
+| temp_max_c | 34.0 | |
+| source | `"LIT (carp aquaculture)"` | among the most-farmed fish globally |
+
+---
+
+## 3. New leafy crops (UVI/FAO leafy FRR band 40–100 g/m²/day; category `leafy`)
+
+| field | kale | swiss chard | spinach |
+|-------|------|-------------|---------|
+| name | `kale` | `swiss_chard` | `spinach` |
+| frr_g_per_m2_day | 65.0 | 60.0 | 55.0 |
+| frr_low | 45.0 | 40.0 | 40.0 |
+| frr_high | 90.0 | 85.0 | 80.0 |
+| n_uptake_g_per_m2_day | 0.9 | 0.85 | 0.8 |
+| yield_kg_per_m2_year | 20.0 | 22.0 | 15.0 |
+| edible_protein_pct | 3.3 | 1.8 | 2.9 |
+| ph_min | 5.5 | 5.5 | 6.0 |
+| ph_max | 7.0 | 7.0 | 7.0 |
+| temp_min_c | 7.0 | 10.0 | 7.0 |
+| temp_max_c | 24.0 | 27.0 | 24.0 |
+| source | `"FAO589/UVI (leafy band)"` | same | same |
+
+---
+
+## 4. New fruiting crops (FAO tomato band 80–140 g/m²/day; category `fruiting`)
+
+| field | cucumber | pepper (bell) |
+|-------|----------|---------------|
+| name | `cucumber` | `pepper` |
+| frr_g_per_m2_day | 100.0 | 100.0 |
+| frr_low | 80.0 | 80.0 |
+| frr_high | 130.0 | 130.0 |
+| n_uptake_g_per_m2_day | 1.5 | 1.4 |
+| yield_kg_per_m2_year | 35.0 | 20.0 |
+| edible_protein_pct | 0.7 | 1.0 |
+| ph_min | 5.5 | 5.5 |
+| ph_max | 6.5 | 6.5 |
+| temp_min_c | 18.0 | 18.0 |
+| temp_max_c | 30.0 | 30.0 |
+| source | `"FAO589 (fruiting band)"` | same |
+
+---
+
+## 5. Calibration ranges (`calibration.py`)
+
+Extend the seed-vs-empirical-range honesty layer with the new **load-bearing** coefficients, so
+`discrepancies()` covers them and Phase-5 calibration can bound them:
+
+- `carp.fcr` — empirical range **1.5–2.5** g feed / g gain (carp pond/RAS aquaculture).
+- `kale.frr` — **45–90**, `swiss_chard.frr` — **40–85**, `spinach.frr` — **40–80** (each = its seed
+  low–high, UVI/FAO leafy feeding-rate band).
+- `cucumber.frr` — **80–130**, `pepper.frr` — **80–130** (FAO fruiting feeding-rate band).
+
+Each new `SizingCalibration` cites at the band level (Somerville et al. 2014, FAO 589; UVI/Rakocy
+for leafy). The seed values above all sit **inside** these ranges by construction (so
+`discrepancies()` stays clean).
+
+---
+
+## 6. Honesty framing (unchanged posture)
+
+The new coefficients are **seed defaults**, sourced at the FAO 589 / band level exactly like the
+existing lettuce/tomato seeds — not precise per-cultivar measurements. The model already surfaces
+every coefficient with its source and "calibration seeds, not guarantees" caveat, and Phase-5
+per-operator calibration lets a grower tune these toward their real system. No change to the
+honesty layer is needed beyond registering the sources.
+
+---
+
+## 7. Error handling / edge cases
+
+- **Naming:** `swiss_chard` and `pepper` are the canonical keys; the LLM/user may say "chard" or
+  "bell pepper" — the consultative layer maps synonyms; the model key stays canonical. (No
+  synonym table in the model; out of scope.)
+- **Temperature feasibility:** carp's wide band and the crops' bands are set so a sensible design
+  (e.g. carp + lettuce at 25 °C) is feasible; cold/hot mismatches are handled by the existing
+  temperature-feed-factor logic, unchanged.
+- Adding entries cannot break existing designs — existing keys and their coefficients are untouched.
+
+---
+
+## 8. Testing
+
+- **Model (`aqua_model`):**
+  - Every species in `SPECIES` sizes a valid system (`size_system` → feasible, `fish_count >= 1`,
+    positive volumes) with a compatible crop; every crop in `CROPS` sizes with tilapia.
+  - `optimize` runs with the default (expanded) palettes and returns a feasible best.
+  - The new calibration seeds sit within their ranges: `discrepancies()` does not include any new
+    key.
+- **Agent (`agronaut_agent`):** `list_supported_species_and_crops` includes the new names;
+  `validate_design_input` accepts `carp`/`kale`/…; existing tests unchanged.
+
+---
+
+## 9. Files touched
+
+| File | Change |
+|------|--------|
+| `aqua_model/species.py` | add `CARP` + register in `SPECIES` |
+| `aqua_model/crops.py` | add `KALE`, `SWISS_CHARD`, `SPINACH`, `CUCUMBER`, `PEPPER` + register in `CROPS` |
+| `aqua_model/calibration.py` | add `SizingCalibration` entries for `carp.fcr` + the 5 new `*.frr` |
+| `aqua_model/tests/` | parametrized size/optimize coverage + discrepancies-clean check |
+| `agronaut_agent/tests/` | (if needed) confirm `list_supported` includes the new names |
+
+---
+
+## 10. Out of scope (YAGNI)
+
+- Synonym/alias mapping in the model (the consultative LLM layer handles "chard" → `swiss_chard`).
+- Ornamental fish (koi/goldfish) — no food harvest weight, doesn't fit the food/protein objectives.
+- Thinly-sourced fish (largemouth bass, yellow perch) — deferred until better-sourced.
+- Re-sizing media-bed/NFT configurations (still raft/DWC only).


### PR DESCRIPTION
## What
Broadens the deterministic sizing model from 4 fish / 3 crops to 5 fish / 8 crops (audit gap):
common carp; leafy: kale, swiss chard, spinach; fruiting: cucumber, pepper. Each has a full cited
seed-coefficient set (FAO 589 bands + existing seeds) plus calibration.py ranges for the new
load-bearing coefficients (carp.fcr + five new *.frr).

## Why it's safe (trust zone)
- Purely additive — existing rows, sizing/optimize formulas, and the trust gate are untouched;
  new entries auto-join the optimizer palettes and validation (membership-based, no hardcoded counts).
- Every new seed sits inside its cited calibration range -> discrepancies() stays clean (tested).
- Honest posture unchanged — cited seed estimates, Phase-5-calibratable per operator.

## How it was built
3 TDD tasks, each reviewed (coefficients verified field-by-field vs the approved spec); final
whole-branch review READY TO MERGE. Live smoke: carp+kale sizes feasibly; optimizer spans 5x8.
193 tests pass. No new dependencies.

Spec: docs/superpowers/specs/2026-07-04-species-crop-expansion-design.md
Plan: docs/superpowers/plans/2026-07-04-species-crop-expansion.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)