### PR TITLE
fix(telegram): run follow-up poller via JobQueue, not create_task

### DIFF
--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -134,23 +134,21 @@ class TelegramAdapter(ChannelAdapter):
             f"(yours is {update.effective_user.id})." if update.effective_user else "Access restricted."
         )
 
-    async def _followup_loop(self, app: Application) -> None:
-        """Deliver due outcome follow-ups. Runs for the app's lifetime; best-effort — a
+    async def _followup_tick(self, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        """Deliver due outcome follow-ups. Runs once per JobQueue tick; best-effort — a
         failed poll or send never affects live message handling."""
-        while True:
-            try:
-                due = await asyncio.to_thread(self.agent.due_followups, self.channel_name)
-                for fu in due:
-                    try:
-                        await app.bot.send_message(chat_id=int(fu["channel_user"]),
-                                                   text=fu["question"])
-                        await asyncio.to_thread(self.agent.mark_followup_sent, fu["id"])
-                    except Exception:
-                        log.warning("follow-up send failed for %s", fu["id"], exc_info=True)
-                        await asyncio.to_thread(self.agent.followup_send_failed, fu["id"])
-            except Exception:  # never let the poller die
-                log.debug("follow-up poll failed", exc_info=True)
-            await asyncio.sleep(POLL_SECONDS)
+        try:
+            due = await asyncio.to_thread(self.agent.due_followups, self.channel_name)
+            for fu in due:
+                try:
+                    await ctx.bot.send_message(chat_id=int(fu["channel_user"]),
+                                               text=fu["question"])
+                    await asyncio.to_thread(self.agent.mark_followup_sent, fu["id"])
+                except Exception:
+                    log.warning("follow-up send failed for %s", fu["id"], exc_info=True)
+                    await asyncio.to_thread(self.agent.followup_send_failed, fu["id"])
+        except Exception:  # never let the poller die
+            log.debug("follow-up poll failed", exc_info=True)
 
     def _command_specs(self):
         """Single source of (command, handler, menu description) — drives both handler
@@ -173,7 +171,9 @@ class TelegramAdapter(ChannelAdapter):
             await app.bot.set_my_commands(commands)
         except Exception:  # transient network etc. — commands still work by typing
             log.warning("set_my_commands failed; commands still work by typing", exc_info=True)
-        app.create_task(self._followup_loop(app))
+        # JobQueue owns the poller's lifecycle: it starts after the app is running and is
+        # cancelled cleanly on shutdown (unlike app.create_task in post_init, which warns).
+        app.job_queue.run_repeating(self._followup_tick, interval=POLL_SECONDS, first=5)
 
     def run(self) -> None:
         app = Application.builder().token(self.token).post_init(self._post_init).build()

--- a/agronaut_agent/tests/test_telegram_adapter.py
+++ b/agronaut_agent/tests/test_telegram_adapter.py
@@ -34,6 +34,6 @@ def test_mode_handlers_exist():
 
 def test_adapter_has_followup_poller():
     a = _adapter()
-    assert hasattr(a, "_followup_loop")
+    assert hasattr(a, "_followup_tick")
     import inspect
-    assert inspect.iscoroutinefunction(a._followup_loop)
+    assert inspect.iscoroutinefunction(a._followup_tick)

--- a/requirement.txt
+++ b/requirement.txt
@@ -13,7 +13,7 @@ langchain-huggingface             # hf (hosted, needs HUGGINGFACEHUB_API_TOKEN) 
 langchain-nvidia-ai-endpoints     # nvidia (hosted NIM, needs NVIDIA_API_KEY) — tool-calling brain for the bot
 
 # Messaging channels (the personal-assistant gateway)
-python-telegram-bot>=21           # Telegram bot (agronaut_agent/channels/telegram_adapter.py)
+python-telegram-bot[job-queue]>=21  # Telegram bot (agronaut_agent/channels/telegram_adapter.py); job-queue extra powers the follow-up poller
 faiss-cpu
 openpyxl
 streamlit


### PR DESCRIPTION
## What

The follow-up poller was launched with `app.create_task` in `post_init`, which runs *before* the app is started — PTB warns the task won't be awaited on shutdown (`PTBUserWarning: Tasks created via Application.create_task while the application is not running won't be automatically awaited!`).

This moves the poller onto PTB's **JobQueue**, which starts the job after the app is running and cancels it cleanly on shutdown.

## Changes

- `_followup_loop` (self-scheduling `while True`) → `_followup_tick` (single pass), scheduled via `job_queue.run_repeating(interval=60, first=5)`. `first=5` preserves prompt delivery of any backlog due during downtime on restart.
- `requirement.txt`: `python-telegram-bot` → `python-telegram-bot[job-queue]` (pulls APScheduler, which powers the JobQueue).
- Test updated to assert `_followup_tick`.

## Verification

- `pytest agronaut_agent/tests/test_telegram_adapter.py` → 5 passed
- Restarted the live systemd service: startup log now shows `Scheduler started` + `_followup_tick ... executed successfully`, and **no more `PTBUserWarning`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)