### PR TITLE
fix(agent): tool results survive into next-turn context (PLAN 0.1)

### DIFF
--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -85,6 +85,7 @@ tool. To judge whether a value is safe (temperature, pH, DO), read the operating
 the prior sizing result; don't search the knowledge base for it."""
 
 _MAX_ITERS = 6
+_TOOL_REPLAY_MAX_CHARS = 2000
 
 
 class AgronautAgent:
@@ -117,12 +118,21 @@ class AgronautAgent:
         if recall:
             messages.append(SystemMessage(content=recall))
 
-        for m in self._conv.recent_messages(user_id, limit=20):
+        for m in self._conv.recent_context_messages(user_id, limit=20):
             if m["role"] == "user":
                 messages.append(HumanMessage(content=m["content"]))
             elif m["role"] == "assistant":
                 messages.append(AIMessage(content=m["content"]))
-            # stored 'tool' rows are audit history; the live loop handles tool exchange
+            elif m["role"] == "tool":
+                # Replay past tool results as assistant-side context (a bare tool role with
+                # no matching tool_call is rejected by OpenAI-compatible APIs). Without this,
+                # every computed number vanishes on the next turn and follow-ups re-run
+                # tools or guess.
+                content = m["content"] or ""
+                if len(content) > _TOOL_REPLAY_MAX_CHARS:
+                    content = content[:_TOOL_REPLAY_MAX_CHARS] + " …[truncated]"
+                messages.append(AIMessage(
+                    content=f"[earlier result from {m['tool_name']}]\n{content}"))
         return messages
 
     def _recall_block(self, user_id: str) -> str:

--- a/agronaut_agent/store.py
+++ b/agronaut_agent/store.py
@@ -168,6 +168,24 @@ class ConversationStore:
         )
         return [dict(r) for r in reversed(rows)]
 
+    def recent_context_messages(self, user_id: str, limit: int = 20) -> list[dict]:
+        """Like recent_messages, but `limit` budgets only user/assistant rows; tool rows
+        inside that window ride along without consuming it — a tool-heavy turn must not
+        evict real conversation from the model's context."""
+        convo = self.db.query(
+            "SELECT id FROM messages WHERE user_id=? AND role IN ('user','assistant') "
+            "ORDER BY id DESC LIMIT ?",
+            (user_id, limit),
+        )
+        if not convo:
+            return []
+        cutoff = convo[-1]["id"]
+        rows = self.db.query(
+            "SELECT role, content, tool_name FROM messages WHERE user_id=? AND id>=? ORDER BY id",
+            (user_id, cutoff),
+        )
+        return [dict(r) for r in rows]
+
     def reset_conversation(self, user_id: str) -> None:
         self.db.execute("DELETE FROM messages WHERE user_id=?", (user_id,))
 

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -345,3 +345,59 @@ def test_measurement_reaches_calibration_store(tmp_path):
 def test_system_prompt_mentions_record_measurement():
     from agronaut_agent.core import SYSTEM_PROMPT
     assert "record_measurement" in SYSTEM_PROMPT.lower()
+
+
+class _ContextProbe:
+    """Sizes a system on the first invoke, then only replies — and records every message
+    list it is invoked with, so tests can assert what the model actually sees."""
+
+    def __init__(self):
+        self.seen = []
+        self._sized = False
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        self.seen.append(list(messages))
+        if any(isinstance(m, ToolMessage) for m in messages):
+            return AIMessage(content="Sized it — details above.")
+        if not self._sized:
+            self._sized = True
+            return AIMessage(content="", tool_calls=[{
+                "name": "size_aquaponics_system", "id": "call_1",
+                "args": {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 12,
+                         "temperature_c": 27, "water_budget_lpd": 300},
+            }])
+        return AIMessage(content="Answering from what I have.")
+
+
+def test_prior_tool_results_survive_into_next_turn_context(tmp_path):
+    # Turn 1 runs the sizing tool. On turn 2 the numbers it computed must be visible in the
+    # model's context, so follow-ups are answerable without re-running tools or guessing.
+    probe = _ContextProbe()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=probe)
+    agent.handle_message("cli", "ctx", "size a 12 m2 tilapia + lettuce at 27C, 300 L/day")
+    agent.handle_message("cli", "ctx", "what tank volume did you give me?")
+
+    turn2_context = probe.seen[-1]
+    blob = "\n".join(str(getattr(m, "content", "")) for m in turn2_context)
+    assert "fish=" in blob  # the sizing tool's output, not just prose about it
+    assert "size_aquaponics_system" in blob  # labeled with its origin
+
+
+def test_tool_rows_do_not_shrink_conversation_window(tmp_path):
+    # A tool-heavy turn must not evict real conversation from the context window: the
+    # history limit counts user/assistant rows only.
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_ChattyFake())
+    uid = agent._conv.get_or_create_user("cli", "win")
+    agent._conv.append_message(uid, "user", "FIRST_QUESTION")
+    for i in range(18):
+        agent._conv.append_message(uid, "tool", f"noise {i}", tool_name="list_supported_species_and_crops")
+    agent._conv.append_message(uid, "assistant", "first answer")
+    for i in range(3):
+        agent._conv.append_message(uid, "user", f"q{i}")
+        agent._conv.append_message(uid, "assistant", f"a{i}")
+
+    blob = "\n".join(str(getattr(m, "content", "")) for m in agent._build_context(uid))
+    assert "FIRST_QUESTION" in blob  # 18 tool rows must not push it out of a 20-row window


### PR DESCRIPTION
Task 0.1 of docs/PLAN.md (Phase 0).

**Bug:** `_build_context` discarded stored `tool` rows, so every number the agent computed vanished from context on the next turn — follow-ups re-ran tools or guessed, despite the system prompt telling the model to answer from earlier tool results. Compounding it, `recent_messages(limit=20)` counted tool rows inside the SQL window, so a tool-heavy turn shrank effective conversation memory.

**Fix:**
- Stored tool rows are replayed as labeled assistant-side messages (`[earlier result from <tool>]`), truncated at 2000 chars. Assistant-side because a bare `tool`-role message with no matching `tool_calls` is rejected by OpenAI-compatible APIs.
- New `recent_context_messages`: the 20-row budget counts only user/assistant rows; interleaved tool rows ride along free. The audit-facing `recent_messages` is unchanged.

**Tests** (written first, watched fail): turn-2 context contains the turn-1 sizing output and its origin label; 18 tool rows between conversation rows no longer evict the oldest user message. Full suite: 248 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak