### PR TITLE
fix(agent): honest reply when a measurement has no calibration coverage (PLAN 0.3)

### DIFF
--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -220,6 +220,30 @@ def test_record_measurement_maps_metric_to_qualified_key():
         runtime.clear_current()
 
 
+def test_record_measurement_is_honest_when_no_calibration_coverage():
+    # trout.harvest_weight has no published range in aqua_model.calibration: the value must
+    # still be stored (for when coverage lands), but the reply must say it can't calibrate —
+    # never the silent "I'll use your measurements to calibrate" lie.
+    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
+    from agronaut_agent import runtime
+    from agronaut_agent.tools import record_measurement
+
+    db = _Db(":memory:")
+    mem, cal = MemoryStore(db), CalibrationStore(db)
+    mem.set_facts("telegram:2", {"fish_species": "trout", "crop": "kale"})
+    runtime.set_current(mem, "telegram:2", None, None, cal)
+    try:
+        out = record_measurement.invoke({"metric": "harvest_weight", "value": 1.1})
+        assert "can't calibrate" in out.lower()
+        assert "no published range" in out.lower()
+        assert cal._by_coefficient("telegram:2") == {"trout.harvest_weight": [1.1]}  # kept
+        # covered metrics keep the confident wording
+        out2 = record_measurement.invoke({"metric": "fcr", "value": 1.6})
+        assert "calibrate future sizings" in out2.lower()
+    finally:
+        runtime.clear_current()
+
+
 def test_record_measurement_rejects_unknown_metric_and_bad_value():
     from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -346,6 +346,15 @@ def record_measurement(metric: str, value: float) -> str:
         return f"Tell me your {need} first so I can record that measurement."
     coefficient = f"{str(subject).strip().lower()}.{suffix}"
     cal.record(user_id, coefficient, v)
+    from aqua_model import calibration as _calibration
+    try:
+        _calibration.get(coefficient)
+    except KeyError:
+        # Stored but inert: overrides_for skips coefficients without a published empirical
+        # range. Say so — the confident wording here would be a lie.
+        return (f"Stored your {coefficient} measurement, but I can't calibrate with it yet — "
+                f"no published range on file for that metric. I'll keep it in case coverage "
+                f"is added later.")
     return f"Recorded — I'll use your measurements to calibrate future sizings ({coefficient})."
 
 


### PR DESCRIPTION
Task 0.3 of docs/PLAN.md (Phase 0).

Only 15 coefficients have published empirical ranges (5×fcr, 8×frr, lettuce.yield, tilapia.harvest_weight). A measurement for anything else — a trout operator's harvest weight, a kale grower's yield — was stored and then silently skipped by `overrides_for`, while the tool reply promised it would calibrate future sizings.

Now: the value is still stored (kept for when coverage is added), but the reply says plainly that calibration can't use it yet — no published range on file. Covered metrics keep the confident wording.

TDD: test written first and watched fail. Full suite: 247 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak