### PR TITLE
feat(agent): enforce source citations in knowledge retrieval (PLAN 1.3)

### DIFF
--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -75,7 +75,9 @@ HARD RULES (these are your credibility):
 - If the trust gate rejects an input (VALIDATION_FAILED), ask the user for a corrected value.
   Never guess or work around it.
 - For qualitative troubleshooting, use the knowledge tool and your general knowledge; say when
-  you are reasoning from general knowledge.
+  you are reasoning from general knowledge. Knowledge passages arrive labeled "[source: ...]" —
+  when your advice uses one, NAME that source in your reply (e.g. "per FAO 589..."). Never
+  strip the attribution.
   Also check search_community_knowledge for real-world operator tips, and present anything it
   returns as "reported by other operators", never as verified fact or a number.
 

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -30,12 +30,37 @@ def _get_index():
     return _INDEX
 
 
+def _source_label(metadata: dict) -> str:
+    """Human-citable label for a retrieved passage. Local files are shown repo-relative
+    (knowledge/...), web docs prefer their curated label over the raw URL."""
+    label = metadata.get("url_label")
+    if label:
+        return str(label)
+    src = metadata.get("source") or metadata.get("source_path")
+    if not src:
+        return "unattributed"
+    src = str(src)
+    if "knowledge/" in src.replace("\\", "/"):
+        return "knowledge/" + src.replace("\\", "/").rsplit("knowledge/", 1)[1]
+    return src
+
+
 def search(query: str, k: int = 3) -> str:
-    """Return retrieved knowledge passages for `query`, or a clear 'no context' note."""
+    """Return retrieved knowledge passages for `query`, each labeled with its source —
+    citation is enforced here, not left to the model — or a clear 'no context' note."""
     index = _get_index()
     if index is None:
         return "KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general husbandry knowledge and say so."
     import srcs.chatbot as core
 
-    context = core.retrieve_context(index, query, k=k)
-    return context.strip() or "No matching passages in the knowledge base for that query."
+    try:
+        pairs = index.similarity_search_with_score(query, k=max(k * 2, k))
+    except Exception as exc:
+        logging.warning("knowledge search failed: %s", exc)
+        return "KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general husbandry knowledge and say so."
+    docs = [d for (d, _score) in pairs if not core._is_boilerplate_text(d.page_content)][:k]
+    if not docs:
+        return "No matching passages in the knowledge base for that query."
+    return "\n\n".join(
+        f"[source: {_source_label(d.metadata)}]\n{d.page_content.strip()}" for d in docs
+    )

--- a/agronaut_agent/tests/test_rag_citations.py
+++ b/agronaut_agent/tests/test_rag_citations.py
@@ -1,0 +1,91 @@
+"""Citations are mechanics, not prompt hope: every knowledge passage the agent retrieves
+carries its source label, so 'cited advice' is enforced by the retrieval layer itself.
+Tests inject a fake index — no FAISS build, no network, no embedding model.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from agronaut_agent import rag
+
+
+def _pad(text: str) -> str:
+    # retrieve_context drops passages < 200 chars as boilerplate; keep test docs realistic.
+    filler = (" This passage describes aquaponics husbandry practice in enough detail to "
+              "clear the knowledge-base length threshold for a real retrieved chunk.")
+    while len(text) < 220:
+        text += filler
+    return text
+
+
+class _Doc:
+    def __init__(self, text, **metadata):
+        self.page_content = _pad(text)
+        self.metadata = metadata
+
+
+class _FakeIndex:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def similarity_search_with_score(self, query, k=3):
+        return [(d, 0.5) for d in self._docs[:k]]
+
+
+@pytest.fixture
+def fake_index(monkeypatch):
+    def _install(docs):
+        monkeypatch.setattr(rag, "_INDEX", _FakeIndex(docs))
+        monkeypatch.setattr(rag, "_TRIED", True)
+    return _install
+
+
+def test_every_passage_carries_its_source(fake_index):
+    fake_index([
+        _Doc("Nitrite above 1 mg/L stresses tilapia gills.",
+             source_type="local_file", source_path="/repo/knowledge/water_quality.md"),
+        _Doc("Raft spacing for lettuce is typically 20-25 cm.",
+             source_type="web", source="https://doi.org/10.3390/w9030182"),
+    ])
+    out = rag.search("nitrite stress")
+    assert "[source: knowledge/water_quality.md]" in out   # local file → repo-relative label
+    assert "[source: https://doi.org/10.3390/w9030182]" in out
+    assert "Nitrite above 1 mg/L" in out
+    # every passage block is labeled — no orphan passages without a source
+    blocks = [b for b in out.split("\n\n") if b.strip()]
+    assert all("[source:" in b for b in blocks)
+
+
+def test_web_label_preferred_over_raw_url(fake_index):
+    fake_index([
+        _Doc("Backup aeration prevents DO crashes during power cuts.",
+             source_type="web", source="https://example.org/x",
+             url_label="FAO 589 small-scale aquaponic food production"),
+    ])
+    out = rag.search("aeration")
+    assert "[source: FAO 589 small-scale aquaponic food production]" in out
+
+
+def test_missing_source_metadata_labeled_unattributed(fake_index):
+    fake_index([_Doc("Some orphan passage.")])
+    out = rag.search("anything")
+    assert "[source: unattributed]" in out
+
+
+def test_unavailable_index_message_unchanged(monkeypatch):
+    monkeypatch.setattr(rag, "_INDEX", None)
+    monkeypatch.setattr(rag, "_TRIED", True)
+    assert "KNOWLEDGE_UNAVAILABLE" in rag.search("anything")
+
+
+def test_urls_txt_has_no_duplicates():
+    lines = [ln.strip().rstrip("/").lower() for ln in
+             Path(__file__).resolve().parents[2].joinpath("urls.txt").read_text().splitlines()
+             if ln.strip()]
+    assert len(lines) == len(set(lines)), "urls.txt contains duplicate entries"
+
+
+def test_system_prompt_requires_naming_sources():
+    from agronaut_agent.core import SYSTEM_PROMPT
+    assert "[source:" in SYSTEM_PROMPT

--- a/urls.txt
+++ b/urls.txt
@@ -1,8 +1,6 @@
-https://doi.org/10.3390/SU7044199 
-https://doi.org/10.1016/J.COMPAG.2022.106785 
-https://doi.org/10.1109/ICMI60790.2024.10586162
 https://doi.org/10.3390/SU7044199
-https://doi.org/10.1007/S10462-024-11003-X
+https://doi.org/10.1016/J.COMPAG.2022.106785
+https://doi.org/10.1109/ICMI60790.2024.10586162
 https://doi.org/10.1007/S10462-024-11003-X
 https://doi.org/10.3390/w9030182
 https://doi.org/10.1016/j.jclepro.2019.04.290


### PR DESCRIPTION
Task 1.3 of docs/PLAN.md (Phase 1).

'Cited advice' is now a property of the retrieval layer, not something we hope the model does. `rag.search` prefixes every passage with `[source: <label>]`:
- local knowledge docs → repo-relative (`knowledge/water_quality.md`)
- web docs → curated `url_label` when present, else the URL
- missing metadata → `unattributed` (never silently dropped)

The system prompt now requires naming that source when the reply uses a passage. Also deduped `urls.txt` (16 → 14 unique; two DOIs were listed twice).

Metadata was already attached to docs at index time (`source_path`/`source`/`url_label`); this surfaces it. Graceful-degradation and boilerplate-filter behavior preserved.

TDD: 6 tests written first (per-passage labeling, label-over-URL preference, unattributed fallback, unavailable-index message unchanged, urls.txt dedup, prompt requirement). One test initially failed because retrieved chunks under 200 chars are dropped as boilerplate — fixed the test to use realistic-length docs rather than weaken the filter. Full suite: 263 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak