### PR TITLE
feat(agent): photo input on Telegram via pluggable vision (PLAN 1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The consultative agent is reachable over Telegram. Set these (in `.env` or the e
 | `AGRONAUT_ALLOWED_IDS` | comma-separated Telegram user IDs allowed to use the bot (empty = open to anyone, discouraged) |
 | `LLM_PROVIDER` / `NVIDIA_API_KEY` | the tool-calling brain — e.g. `nvidia` (free at [build.nvidia.com](https://build.nvidia.com)) |
 | `LLM_MODEL` | optional, e.g. `meta/llama-3.1-70b-instruct` |
+| `VLM_PROVIDER` / `VLM_MODEL` | optional photo understanding — send a picture of a sick fish or yellowing leaf and the bot describes it, then diagnoses through the same cited flow. Defaults to a hosted NVIDIA vision model; `AGRONAUT_VISION=off` disables. The vision model only *observes* — it never feeds numbers into the design tools. |
 
 ```bash
 source .venv/bin/activate

--- a/agent/tests/test_vision.py
+++ b/agent/tests/test_vision.py
@@ -1,0 +1,47 @@
+"""Pluggable vision layer: turn a photo into a plain-language visual observation that feeds
+the normal agent turn. The describer is provider-agnostic and lazily built; these tests
+inject a fake so there's no model or network.
+"""
+
+import base64
+
+from agent import vision
+
+
+def test_resolve_defaults_and_env(monkeypatch):
+    monkeypatch.delenv("VLM_PROVIDER", raising=False)
+    monkeypatch.delenv("VLM_MODEL", raising=False)
+    assert vision.resolve()[0] == "nvidia"          # sensible hosted default
+    monkeypatch.setenv("VLM_PROVIDER", "nvidia")
+    monkeypatch.setenv("VLM_MODEL", "some/vlm")
+    assert vision.resolve() == ("nvidia", "some/vlm")
+
+
+def test_unknown_provider_rejected(monkeypatch):
+    monkeypatch.setenv("VLM_PROVIDER", "does-not-exist")
+    import pytest
+    with pytest.raises(ValueError):
+        vision.resolve()
+
+
+def test_describe_uses_backend_and_passes_data_uri():
+    seen = {}
+
+    def _fake_backend(data_uri, prompt):
+        seen["data_uri"] = data_uri
+        seen["prompt"] = prompt
+        return "Older leaves show interveinal yellowing; fish look normal."
+
+    describe = vision.make_describer(backend=_fake_backend)
+    out = describe(b"\x89PNG\r\n\x1a\n fake image bytes", "what's wrong with my plant?")
+    assert "interveinal yellowing" in out
+    assert seen["data_uri"].startswith("data:image/")
+    # the raw image bytes are base64-encoded into the data URI (never sent as-is)
+    assert base64.b64encode(b"\x89PNG\r\n\x1a\n fake image bytes").decode() in seen["data_uri"]
+    assert "what's wrong" in seen["prompt"]
+
+
+def test_describer_none_when_unavailable(monkeypatch):
+    # No provider library installed / build fails -> None, so callers degrade gracefully.
+    monkeypatch.setattr(vision, "_build_vlm_backend", lambda *a, **k: (_ for _ in ()).throw(ImportError("no vlm")))
+    assert vision.default_describer() is None

--- a/agent/vision.py
+++ b/agent/vision.py
@@ -1,0 +1,87 @@
+"""Pluggable vision (VLM) backend — turns a photo into a plain-language visual observation.
+
+Design rule (see docs/PLAN.md 1.1): the VLM only OBSERVES. Its text description feeds the
+normal agent turn as user-provided context; it never calls tools or emits sizing numbers.
+Diagnosis stays with the agent + cited knowledge base, so the honesty/citation guarantees
+hold for anything derived from an image.
+
+Provider-agnostic, mirroring agent/llm.py: select with VLM_PROVIDER / VLM_MODEL. The
+backend library is imported lazily, so importing this module needs nothing installed.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MODELS = {
+    # NVIDIA hosts OpenAI-compatible vision models on the same free tier as the chat brain.
+    "nvidia": "meta/llama-3.2-11b-vision-instruct",
+}
+SUPPORTED = tuple(DEFAULT_MODELS)
+
+_OBSERVE_PROMPT = (
+    "You are helping an aquaponics assistant. Describe ONLY what you can see in this photo "
+    "that is relevant to fish or plant health — leaf colour and patterning, visible pests or "
+    "algae, water clarity, fish appearance or behaviour, equipment. Be specific and concise. "
+    "Do NOT diagnose, prescribe, or state any numbers; another system does that. If the image "
+    "is unclear or unrelated to aquaponics, say so."
+)
+
+
+def resolve(provider: str | None = None, model: str | None = None) -> tuple[str, str]:
+    provider = (provider or os.getenv("VLM_PROVIDER") or "nvidia").strip().lower()
+    if provider not in SUPPORTED:
+        raise ValueError(f"Unknown VLM_PROVIDER {provider!r}. Supported: {', '.join(SUPPORTED)}.")
+    model = model or os.getenv("VLM_MODEL") or DEFAULT_MODELS[provider]
+    return provider, model
+
+
+def _data_uri(image_bytes: bytes, mime: str = "image/jpeg") -> str:
+    return f"data:{mime};base64,{base64.b64encode(image_bytes).decode()}"
+
+
+def _build_vlm_backend(provider: str, model: str):
+    """Return a callable(data_uri, prompt) -> str for the resolved provider. Lazy imports."""
+    if provider == "nvidia":
+        from langchain_nvidia_ai_endpoints import ChatNVIDIA
+        from langchain_core.messages import HumanMessage
+        client = ChatNVIDIA(model=model, temperature=1e-3)
+
+        def _call(data_uri: str, prompt: str) -> str:
+            msg = HumanMessage(content=[
+                {"type": "text", "text": prompt},
+                {"type": "image_url", "image_url": {"url": data_uri}},
+            ])
+            out = client.invoke([msg])
+            return (getattr(out, "content", "") or "").strip()
+
+        return _call
+    raise ValueError(f"Unhandled VLM provider {provider!r}")  # pragma: no cover
+
+
+def make_describer(backend):
+    """Wrap a backend callable into describe(image_bytes, user_prompt) -> observation str."""
+    def _describe(image_bytes: bytes, user_prompt: str | None = None) -> str:
+        prompt = _OBSERVE_PROMPT
+        if user_prompt:
+            prompt += f"\n\nThe user asked: {user_prompt}"
+        return backend(_data_uri(image_bytes), prompt)
+    return _describe
+
+
+def default_describer():
+    """A lazily-built describer for the configured provider, or None when unavailable
+    (no library installed, build fails, or vision disabled). Never raises."""
+    if os.getenv("AGRONAUT_VISION", "").lower() in {"off", "0", "false"}:
+        return None
+    try:
+        provider, model = resolve()
+        backend = _build_vlm_backend(provider, model)
+    except Exception:
+        log.debug("vision backend unavailable", exc_info=True)
+        return None
+    return make_describer(backend)

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -63,6 +63,7 @@ class TelegramAdapter(ChannelAdapter):
             "• *Size* a system (species, grow area, water temp, water budget)\n"
             "• *Optimize* the fish/crop ratio for a goal\n"
             "• *Troubleshoot* problems (e.g. \"fish gasping at dawn\")\n"
+            "• *See* a photo you send (sick fish, yellowing leaves, algae)\n"
             "• *Remember* your setup across chats\n\n"
             "Commands:\n"
             "/design — size a new system\n"
@@ -128,6 +129,53 @@ class TelegramAdapter(ChannelAdapter):
         for part in chunk(reply):
             await update.message.reply_text(part)
 
+    async def _on_photo(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        chat_id = str(update.effective_chat.id)
+        await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
+        try:
+            photo = update.message.photo[-1]              # largest available size
+            tg_file = await photo.get_file()
+            image_bytes = bytes(await tg_file.download_as_bytearray())
+            reply = await asyncio.to_thread(
+                self.agent.handle_image,
+                self.channel_name, chat_id, image_bytes, update.message.caption,
+                update.effective_user.full_name if update.effective_user else None,
+            )
+        except Exception:
+            log.exception("agent.handle_image failed")
+            reply = "Something went wrong reading that photo. Try again, or describe what you see?"
+        for part in chunk(reply):
+            await update.message.reply_text(part)
+
+    async def _on_document(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        doc = update.message.document
+        mime = (getattr(doc, "mime_type", "") or "")
+        if mime.startswith("image/"):
+            # An image sent as an uncompressed file (not a Telegram "photo"): treat it as one.
+            chat_id = str(update.effective_chat.id)
+            try:
+                tg_file = await doc.get_file()
+                image_bytes = bytes(await tg_file.download_as_bytearray())
+                reply = await asyncio.to_thread(
+                    self.agent.handle_image, self.channel_name, chat_id, image_bytes,
+                    update.message.caption,
+                    update.effective_user.full_name if update.effective_user else None,
+                )
+            except Exception:
+                log.exception("agent.handle_image (document) failed")
+                reply = "Something went wrong reading that image. Try again, or describe what you see?"
+            for part in chunk(reply):
+                await update.message.reply_text(part)
+            return
+        await update.message.reply_text(
+            "I can't read files like that yet — I work with text and photos. Send a photo of "
+            "your fish, plants, or water, or just tell me what's going on."
+        )
+
     async def _deny(self, update: Update) -> None:
         await update.message.reply_text(
             "This is a private Agronaut assistant. Ask the owner to add your Telegram ID "
@@ -179,6 +227,8 @@ class TelegramAdapter(ChannelAdapter):
         app = Application.builder().token(self.token).post_init(self._post_init).build()
         for name, handler, _desc in self._command_specs():
             app.add_handler(CommandHandler(name, handler))
+        app.add_handler(MessageHandler(filters.PHOTO, self._on_photo))
+        app.add_handler(MessageHandler(filters.Document.ALL, self._on_document))
         app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))
         scope = f"{len(self.allowed_ids)} allowed id(s)" if self.allowed_ids else "OPEN (no allowlist)"
         log.info("Agronaut Telegram bot starting — %s", scope)

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -92,7 +92,7 @@ _TOOL_REPLAY_MAX_CHARS = 2000
 
 class AgronautAgent:
     def __init__(self, llm_provider=None, llm_model=None, db_path=None, chat_model=None,
-                 fallback_model=None, embed_fn=None):
+                 fallback_model=None, embed_fn=None, describe_fn=None):
         # chat_model injectable for tests (a fake bindable model); else build from config.
         base = chat_model if chat_model is not None else get_chat_model(llm_provider, llm_model)
         # Resilience: if the primary errors/times out, fall back to a fast model so a turn is
@@ -116,6 +116,12 @@ class AgronautAgent:
         if embed_fn is None and chat_model is None:
             embed_fn = semantic.default_embedder()
         self._semantic = semantic.SemanticMemory(db, embed_fn)
+        # Vision: turn a photo into a visual observation that feeds the normal turn. The VLM
+        # only observes — diagnosis stays with the agent + cited KB. None -> images declined.
+        if describe_fn is None and chat_model is None:
+            from agent import vision
+            describe_fn = vision.default_describer()
+        self._describe = describe_fn
 
     # --- context assembly -------------------------------------------------
     def _build_context(self, user_id: str, query: str | None = None) -> list:
@@ -245,6 +251,28 @@ class AgronautAgent:
         self._conv.append_message(user_id, "assistant", reply)
         self._schedule_summary(user_id)
         return reply
+
+    def handle_image(self, channel: str, channel_user: str, image_bytes: bytes,
+                     caption: str | None = None, display_name: str | None = None) -> str:
+        """A photo arrives: the VLM produces a plain-language visual observation, which is
+        then run through the NORMAL text turn — so memory, the trust-gated tools, and cited
+        knowledge all still apply. The vision model never calls tools or emits numbers."""
+        if self._describe is None:
+            return ("I can't look at images yet — but describe what you see (leaf colour, "
+                    "fish behaviour, water look) and I'll help from there.")
+        try:
+            observation = (self._describe(image_bytes, caption) or "").strip()
+        except Exception:
+            log.warning("vision describe failed", exc_info=True)
+            return ("I couldn't read that photo just now — try again, or describe what you "
+                    "see and I'll help from there.")
+        if not observation:
+            return ("I couldn't make anything out in that photo — try a clearer, closer shot, "
+                    "or describe what you see.")
+        ask = (caption or "").strip() or "What's going on here?"
+        composed = (f"[The user sent a photo. A vision model observed: {observation}]\n\n"
+                    f"{ask}")
+        return self.handle_message(channel, channel_user, composed, display_name)
 
     def profile_text(self, channel: str, channel_user: str) -> str:
         """Human-readable view of what the agent remembers — backs the /whoami command."""

--- a/agronaut_agent/tests/test_image_turn.py
+++ b/agronaut_agent/tests/test_image_turn.py
@@ -1,0 +1,73 @@
+"""The agent's image seam: a photo becomes a visual observation that runs through the
+NORMAL text turn — so memory, the trust-gated tools, and cited RAG all still apply. The
+vision model observes; it never feeds numbers into tools.
+"""
+
+from langchain_core.messages import AIMessage
+
+from agronaut_agent.core import AgronautAgent
+
+
+class _EchoContext:
+    """Records the composed text the agent turn receives, and replies plainly."""
+
+    def __init__(self):
+        self.last_human = None
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import HumanMessage
+        humans = [m for m in messages if isinstance(m, HumanMessage)]
+        if humans:
+            self.last_human = humans[-1].content
+        return AIMessage(content="Looks like a nitrogen issue — tell me your water readings.")
+
+
+def _describer(observation="Older leaves show interveinal chlorosis; new growth is green."):
+    def _d(image_bytes, prompt):
+        return observation
+    return _d
+
+
+def test_handle_image_feeds_visual_observation_into_the_turn(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat,
+                          describe_fn=_describer())
+    reply = agent.handle_image("telegram", "img1", b"fakebytes", caption="what's wrong?")
+
+    assert "nitrogen issue" in reply
+    # the composed user turn carried BOTH the caption and the model's visual observation
+    assert "what's wrong?" in chat.last_human
+    assert "interveinal chlorosis" in chat.last_human
+    # and it was persisted as a normal user turn (audit trail + memory continuity)
+    roles = [m["role"] for m in agent._conv.recent_messages("telegram:img1")]
+    assert roles[0] == "user" and roles[-1] == "assistant"
+
+
+def test_handle_image_without_caption_still_works(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat,
+                          describe_fn=_describer())
+    agent.handle_image("telegram", "img2", b"fakebytes", caption=None)
+    assert "interveinal chlorosis" in chat.last_human
+
+
+def test_handle_image_degrades_when_no_describer(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat, describe_fn=None)
+    reply = agent.handle_image("telegram", "img3", b"fakebytes", caption="help")
+    assert "can't look at images" in reply.lower() or "can't see images" in reply.lower()
+    # nothing about the image was fabricated into the turn
+    assert chat.last_human is None
+
+
+def test_handle_image_survives_a_describer_error(tmp_path):
+    def _boom(image_bytes, prompt):
+        raise RuntimeError("vlm timeout")
+
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat, describe_fn=_boom)
+    reply = agent.handle_image("telegram", "img4", b"fakebytes", caption="help")
+    assert "couldn't" in reply.lower() or "try again" in reply.lower()

--- a/agronaut_agent/tests/test_telegram_adapter.py
+++ b/agronaut_agent/tests/test_telegram_adapter.py
@@ -37,3 +37,97 @@ def test_adapter_has_followup_poller():
     assert hasattr(a, "_followup_tick")
     import inspect
     assert inspect.iscoroutinefunction(a._followup_tick)
+
+
+# --- media handlers -----------------------------------------------------------
+
+import asyncio
+
+
+class _FakePhoto:
+    async def get_file(self):
+        class _F:
+            async def download_as_bytearray(self_inner):
+                return bytearray(b"imgbytes")
+        return _F()
+
+
+class _FakeDoc:
+    def __init__(self, mime):
+        self.mime_type = mime
+
+    async def get_file(self):
+        class _F:
+            async def download_as_bytearray(self_inner):
+                return bytearray(b"imgbytes")
+        return _F()
+
+
+class _Recorder:
+    def __init__(self):
+        self.replies = []
+
+    async def reply_text(self, text, **kw):
+        self.replies.append(text)
+
+
+class _FakeUpdate:
+    def __init__(self, message, user_id=1, chat_id=99):
+        self.message = message
+        self.effective_user = type("U", (), {"id": user_id, "full_name": "Tester"})()
+        self.effective_chat = type("C", (), {"id": chat_id})()
+
+
+class _FakeMessage:
+    def __init__(self, photo=None, document=None, caption=None):
+        self.photo = photo
+        self.document = document
+        self.caption = caption
+        self.recorder = _Recorder()
+
+    async def reply_text(self, text, **kw):
+        await self.recorder.reply_text(text, **kw)
+
+
+class _FakeCtx:
+    class _Bot:
+        async def send_chat_action(self, *a, **k):
+            return None
+    bot = _Bot()
+
+
+class _ImgAgent:
+    channel = None
+
+    def handle_image(self, channel, chat_id, image_bytes, caption, display_name=None):
+        assert image_bytes == b"imgbytes"
+        return f"saw image (caption={caption})"
+
+
+def test_photo_handler_routes_to_handle_image():
+    a = TelegramAdapter(agent=_ImgAgent(), token="x:y", allowed_ids=[])
+    msg = _FakeMessage(photo=[_FakePhoto()], caption="what's wrong?")
+    upd = _FakeUpdate(msg)
+    asyncio.run(a._on_photo(upd, _FakeCtx()))
+    assert any("saw image" in r and "what's wrong?" in r for r in msg.recorder.replies)
+
+
+def test_document_image_routes_to_handle_image():
+    a = TelegramAdapter(agent=_ImgAgent(), token="x:y", allowed_ids=[])
+    msg = _FakeMessage(document=_FakeDoc("image/png"))
+    asyncio.run(a._on_document(_FakeUpdate(msg), _FakeCtx()))
+    assert any("saw image" in r for r in msg.recorder.replies)
+
+
+def test_non_image_document_declined_gracefully():
+    a = TelegramAdapter(agent=_ImgAgent(), token="x:y", allowed_ids=[])
+    msg = _FakeMessage(document=_FakeDoc("application/pdf"))
+    asyncio.run(a._on_document(_FakeUpdate(msg), _FakeCtx()))
+    assert any("can't read files like that yet" in r.lower() for r in msg.recorder.replies)
+
+
+def test_media_handlers_registered_in_run():
+    import inspect
+    src = inspect.getsource(TelegramAdapter.run)
+    assert "filters.PHOTO" in src
+    assert "Document" in src


### PR DESCRIPTION
Task 1.1 of docs/PLAN.md (Phase 1) — the highest-leverage adoption feature.

A farmer can send a photo of a sick fish, yellowing leaf, or algae bloom (the most natural troubleshooting input) and get a cited diagnosis.

**Design — the VLM only observes.** `agent/vision.py` is a provider-agnostic vision backend (`VLM_PROVIDER`/`VLM_MODEL`, lazy import, NVIDIA hosted default on the same free tier as the chat brain). `AgronautAgent.handle_image` runs the VLM to get a plain-language visual observation, then feeds that observation through the **normal text turn** — so System Profile memory, the trust-gated deterministic tools, and `[source:]`-cited RAG all still apply. The vision model never calls a tool or emits a number; image-derived advice inherits the same honesty/citation guarantees as text.

**Telegram:** `filters.PHOTO` handler (downloads the largest size) + a document handler that treats `image/*` uploads as photos and declines other file types gracefully ("I can't read files like that yet"). Help text + README updated.

**Degradation:** no VLM configured → friendly "describe what you see" message, nothing fabricated into the turn; a describe error → "couldn't read that photo, try again"; `AGRONAUT_VISION=off` kill switch. The turn is never lost.

TDD: 12 tests written first (vision resolve/describe/data-URI/unavailable; handle_image feeds observation, no-caption, no-describer, describer-error; adapter photo routing, document-image routing, non-image decline, handler registration). Full suite: 275 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak