### PR TITLE
feat(agent): voice-note input on Telegram via pluggable ASR (PLAN 1.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ The consultative agent is reachable over Telegram. Set these (in `.env` or the e
 | `LLM_PROVIDER` / `NVIDIA_API_KEY` | the tool-calling brain — e.g. `nvidia` (free at [build.nvidia.com](https://build.nvidia.com)) |
 | `LLM_MODEL` | optional, e.g. `meta/llama-3.1-70b-instruct` |
 | `VLM_PROVIDER` / `VLM_MODEL` | optional photo understanding — send a picture of a sick fish or yellowing leaf and the bot describes it, then diagnoses through the same cited flow. Defaults to a hosted NVIDIA vision model; `AGRONAUT_VISION=off` disables. The vision model only *observes* — it never feeds numbers into the design tools. |
+| `ASR_PROVIDER` / `ASR_MODEL` | optional voice notes — a spoken message is transcribed then answered in the same language. Defaults to a **local** faster-whisper model (works offline — best for low-connectivity field use; needs `pip install faster-whisper`). Set `ASR_PROVIDER=nvidia` for a hosted endpoint; `AGRONAUT_VOICE=off` disables. |
 
 ```bash
 source .venv/bin/activate

--- a/agent/tests/test_transcribe.py
+++ b/agent/tests/test_transcribe.py
@@ -1,0 +1,48 @@
+"""Pluggable speech-to-text (ASR) layer: a voice note becomes text that feeds the normal
+agent turn. The backend is provider-agnostic and lazily built; tests inject a fake.
+"""
+
+from agent import transcribe
+
+
+def test_resolve_defaults_and_env(monkeypatch):
+    monkeypatch.delenv("ASR_PROVIDER", raising=False)
+    monkeypatch.delenv("ASR_MODEL", raising=False)
+    prov, _model = transcribe.resolve()
+    assert prov in transcribe.SUPPORTED
+    monkeypatch.setenv("ASR_PROVIDER", prov)
+    monkeypatch.setenv("ASR_MODEL", "some/asr")
+    assert transcribe.resolve() == (prov, "some/asr")
+
+
+def test_unknown_provider_rejected(monkeypatch):
+    monkeypatch.setenv("ASR_PROVIDER", "does-not-exist")
+    import pytest
+    with pytest.raises(ValueError):
+        transcribe.resolve()
+
+
+def test_transcribe_uses_backend():
+    seen = {}
+
+    def _fake_backend(audio_bytes, mime):
+        seen["audio"] = audio_bytes
+        seen["mime"] = mime
+        return "  mes tilapias sont malades  "
+
+    tx = transcribe.make_transcriber(backend=_fake_backend)
+    out = tx(b"oggbytes", "audio/ogg")
+    assert out == "mes tilapias sont malades"   # trimmed
+    assert seen["audio"] == b"oggbytes"
+    assert seen["mime"] == "audio/ogg"
+
+
+def test_transcriber_none_when_unavailable(monkeypatch):
+    monkeypatch.setattr(transcribe, "_build_asr_backend",
+                        lambda *a, **k: (_ for _ in ()).throw(ImportError("no asr")))
+    assert transcribe.default_transcriber() is None
+
+
+def test_disabled_by_env(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_VOICE", "off")
+    assert transcribe.default_transcriber() is None

--- a/agent/transcribe.py
+++ b/agent/transcribe.py
@@ -1,0 +1,83 @@
+"""Pluggable speech-to-text (ASR) backend — turns a voice note into text.
+
+The transcript feeds the normal agent turn, so a voice note gets the full consultation
+(memory, trust-gated tools, cited knowledge) and — via the system prompt's "reply in the
+user's language" rule — an answer in the language the note was spoken in.
+
+Provider-agnostic, mirroring agent/llm.py and agent/vision.py: select with ASR_PROVIDER /
+ASR_MODEL. Backends are imported lazily, so importing this module needs nothing installed.
+
+Default is a LOCAL faster-whisper model — voice is most valuable exactly where connectivity
+is worst (last-mile field use), and a local model keeps it working offline. Set
+ASR_PROVIDER=nvidia to use a hosted endpoint instead.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MODELS = {
+    "local": "base",                       # faster-whisper size: tiny/base/small/medium/large-v3
+    "nvidia": "openai/whisper-large-v3",   # hosted, OpenAI-compatible ASR
+}
+SUPPORTED = tuple(DEFAULT_MODELS)
+
+
+def resolve(provider: str | None = None, model: str | None = None) -> tuple[str, str]:
+    provider = (provider or os.getenv("ASR_PROVIDER") or "local").strip().lower()
+    if provider not in SUPPORTED:
+        raise ValueError(f"Unknown ASR_PROVIDER {provider!r}. Supported: {', '.join(SUPPORTED)}.")
+    model = model or os.getenv("ASR_MODEL") or DEFAULT_MODELS[provider]
+    return provider, model
+
+
+def _build_asr_backend(provider: str, model: str):
+    """Return a callable(audio_bytes, mime) -> transcript str for the provider. Lazy imports."""
+    if provider == "local":
+        from faster_whisper import WhisperModel  # heavy, optional
+        wm = WhisperModel(model, device="auto", compute_type="int8")
+
+        def _call(audio_bytes: bytes, mime: str) -> str:
+            segments, _info = wm.transcribe(io.BytesIO(audio_bytes))
+            return " ".join(seg.text for seg in segments)
+
+        return _call
+    if provider == "nvidia":
+        # Hosted OpenAI-compatible ASR. Kept minimal; needs NVIDIA_API_KEY.
+        from openai import OpenAI
+        client = OpenAI(base_url=os.getenv("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1"),
+                        api_key=os.environ["NVIDIA_API_KEY"])
+
+        def _call(audio_bytes: bytes, mime: str) -> str:
+            buf = io.BytesIO(audio_bytes)
+            buf.name = "note.ogg"
+            out = client.audio.transcriptions.create(model=model, file=buf)
+            return getattr(out, "text", "") or ""
+
+        return _call
+    raise ValueError(f"Unhandled ASR provider {provider!r}")  # pragma: no cover
+
+
+def make_transcriber(backend):
+    """Wrap a backend callable into transcribe(audio_bytes, mime) -> trimmed transcript."""
+    def _transcribe(audio_bytes: bytes, mime: str | None = None) -> str:
+        return (backend(audio_bytes, mime or "audio/ogg") or "").strip()
+    return _transcribe
+
+
+def default_transcriber():
+    """A lazily-built transcriber for the configured provider, or None when unavailable
+    (no library installed, build fails, or voice disabled). Never raises."""
+    if os.getenv("AGRONAUT_VOICE", "").lower() in {"off", "0", "false"}:
+        return None
+    try:
+        provider, model = resolve()
+        backend = _build_asr_backend(provider, model)
+    except Exception:
+        log.debug("ASR backend unavailable", exc_info=True)
+        return None
+    return make_transcriber(backend)

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -64,6 +64,7 @@ class TelegramAdapter(ChannelAdapter):
             "• *Optimize* the fish/crop ratio for a goal\n"
             "• *Troubleshoot* problems (e.g. \"fish gasping at dawn\")\n"
             "• *See* a photo you send (sick fish, yellowing leaves, algae)\n"
+            "• *Hear* a voice note and reply in your language\n"
             "• *Remember* your setup across chats\n\n"
             "Commands:\n"
             "/design — size a new system\n"
@@ -176,6 +177,27 @@ class TelegramAdapter(ChannelAdapter):
             "your fish, plants, or water, or just tell me what's going on."
         )
 
+    async def _on_voice(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        chat_id = str(update.effective_chat.id)
+        await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
+        try:
+            voice = update.message.voice or update.message.audio
+            tg_file = await voice.get_file()
+            audio_bytes = bytes(await tg_file.download_as_bytearray())
+            mime = getattr(voice, "mime_type", None) or "audio/ogg"
+            reply = await asyncio.to_thread(
+                self.agent.handle_voice,
+                self.channel_name, chat_id, audio_bytes, mime,
+                update.effective_user.full_name if update.effective_user else None,
+            )
+        except Exception:
+            log.exception("agent.handle_voice failed")
+            reply = "Something went wrong with that voice note. Try again, or type your message?"
+        for part in chunk(reply):
+            await update.message.reply_text(part)
+
     async def _deny(self, update: Update) -> None:
         await update.message.reply_text(
             "This is a private Agronaut assistant. Ask the owner to add your Telegram ID "
@@ -228,6 +250,7 @@ class TelegramAdapter(ChannelAdapter):
         for name, handler, _desc in self._command_specs():
             app.add_handler(CommandHandler(name, handler))
         app.add_handler(MessageHandler(filters.PHOTO, self._on_photo))
+        app.add_handler(MessageHandler(filters.VOICE | filters.AUDIO, self._on_voice))
         app.add_handler(MessageHandler(filters.Document.ALL, self._on_document))
         app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))
         scope = f"{len(self.allowed_ids)} allowed id(s)" if self.allowed_ids else "OPEN (no allowlist)"

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -92,7 +92,7 @@ _TOOL_REPLAY_MAX_CHARS = 2000
 
 class AgronautAgent:
     def __init__(self, llm_provider=None, llm_model=None, db_path=None, chat_model=None,
-                 fallback_model=None, embed_fn=None, describe_fn=None):
+                 fallback_model=None, embed_fn=None, describe_fn=None, transcribe_fn=None):
         # chat_model injectable for tests (a fake bindable model); else build from config.
         base = chat_model if chat_model is not None else get_chat_model(llm_provider, llm_model)
         # Resilience: if the primary errors/times out, fall back to a fast model so a turn is
@@ -122,6 +122,12 @@ class AgronautAgent:
             from agent import vision
             describe_fn = vision.default_describer()
         self._describe = describe_fn
+        # Voice: transcribe a note, then run it as a normal turn. The system prompt's
+        # "reply in the user's language" rule answers in the note's language. None -> declined.
+        if transcribe_fn is None and chat_model is None:
+            from agent import transcribe
+            transcribe_fn = transcribe.default_transcriber()
+        self._transcribe = transcribe_fn
 
     # --- context assembly -------------------------------------------------
     def _build_context(self, user_id: str, query: str | None = None) -> list:
@@ -273,6 +279,24 @@ class AgronautAgent:
         composed = (f"[The user sent a photo. A vision model observed: {observation}]\n\n"
                     f"{ask}")
         return self.handle_message(channel, channel_user, composed, display_name)
+
+    def handle_voice(self, channel: str, channel_user: str, audio_bytes: bytes,
+                     mime: str | None = None, display_name: str | None = None) -> str:
+        """A voice note arrives: transcribe it, then run the transcript through the NORMAL
+        text turn. The transcript IS the user's message, so everything (memory, tools, cited
+        knowledge, reply-in-user-language) applies unchanged."""
+        if self._transcribe is None:
+            return ("I can't listen to voice notes yet — type your message and I'll help "
+                    "right away.")
+        try:
+            transcript = (self._transcribe(audio_bytes, mime) or "").strip()
+        except Exception:
+            log.warning("voice transcription failed", exc_info=True)
+            return ("I couldn't make out that voice note — try again, or type it and I'll "
+                    "help from there.")
+        if not transcript:
+            return "I didn't catch anything in that voice note — try again, or type it out?"
+        return self.handle_message(channel, channel_user, transcript, display_name)
 
     def profile_text(self, channel: str, channel_user: str) -> str:
         """Human-readable view of what the agent remembers — backs the /whoami command."""

--- a/agronaut_agent/tests/test_telegram_adapter.py
+++ b/agronaut_agent/tests/test_telegram_adapter.py
@@ -78,11 +78,24 @@ class _FakeUpdate:
         self.effective_chat = type("C", (), {"id": chat_id})()
 
 
+class _FakeVoice:
+    def __init__(self, mime="audio/ogg"):
+        self.mime_type = mime
+
+    async def get_file(self):
+        class _F:
+            async def download_as_bytearray(self_inner):
+                return bytearray(b"oggbytes")
+        return _F()
+
+
 class _FakeMessage:
-    def __init__(self, photo=None, document=None, caption=None):
+    def __init__(self, photo=None, document=None, caption=None, voice=None, audio=None):
         self.photo = photo
         self.document = document
         self.caption = caption
+        self.voice = voice
+        self.audio = audio
         self.recorder = _Recorder()
 
     async def reply_text(self, text, **kw):
@@ -102,6 +115,10 @@ class _ImgAgent:
     def handle_image(self, channel, chat_id, image_bytes, caption, display_name=None):
         assert image_bytes == b"imgbytes"
         return f"saw image (caption={caption})"
+
+    def handle_voice(self, channel, chat_id, audio_bytes, mime, display_name=None):
+        assert audio_bytes == b"oggbytes"
+        return f"heard voice (mime={mime})"
 
 
 def test_photo_handler_routes_to_handle_image():
@@ -126,8 +143,16 @@ def test_non_image_document_declined_gracefully():
     assert any("can't read files like that yet" in r.lower() for r in msg.recorder.replies)
 
 
+def test_voice_handler_routes_to_handle_voice():
+    a = TelegramAdapter(agent=_ImgAgent(), token="x:y", allowed_ids=[])
+    msg = _FakeMessage(voice=_FakeVoice("audio/ogg"))
+    asyncio.run(a._on_voice(_FakeUpdate(msg), _FakeCtx()))
+    assert any("heard voice" in r for r in msg.recorder.replies)
+
+
 def test_media_handlers_registered_in_run():
     import inspect
     src = inspect.getsource(TelegramAdapter.run)
     assert "filters.PHOTO" in src
     assert "Document" in src
+    assert "filters.VOICE" in src

--- a/agronaut_agent/tests/test_voice_turn.py
+++ b/agronaut_agent/tests/test_voice_turn.py
@@ -1,0 +1,66 @@
+"""The agent's voice seam: a voice note is transcribed, then run through the NORMAL text
+turn — so memory, trust-gated tools, and cited RAG apply, and the existing "reply in the
+user's language" prompt rule already answers a French note in French.
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from agronaut_agent.core import AgronautAgent
+
+
+class _EchoContext:
+    def __init__(self):
+        self.last_human = None
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        humans = [m for m in messages if isinstance(m, HumanMessage)]
+        if humans:
+            self.last_human = humans[-1].content
+        return AIMessage(content="Depuis quand sont-ils malades ?")
+
+
+def _transcriber(text="mes tilapias sont malades"):
+    def _t(audio_bytes, mime):
+        return text
+    return _t
+
+
+def test_handle_voice_feeds_transcript_into_the_turn(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat,
+                          transcribe_fn=_transcriber())
+    reply = agent.handle_voice("telegram", "v1", b"oggbytes", "audio/ogg")
+    assert "malades" in reply
+    assert chat.last_human == "mes tilapias sont malades"   # transcript IS the user turn
+    roles = [m["role"] for m in agent._conv.recent_messages("telegram:v1")]
+    assert roles[0] == "user" and roles[-1] == "assistant"
+
+
+def test_handle_voice_degrades_when_no_transcriber(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat, transcribe_fn=None)
+    reply = agent.handle_voice("telegram", "v2", b"oggbytes", "audio/ogg")
+    assert "voice" in reply.lower() and ("type" in reply.lower() or "text" in reply.lower())
+    assert chat.last_human is None
+
+
+def test_handle_voice_survives_a_transcriber_error(tmp_path):
+    def _boom(audio_bytes, mime):
+        raise RuntimeError("asr timeout")
+
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat, transcribe_fn=_boom)
+    reply = agent.handle_voice("telegram", "v3", b"oggbytes", "audio/ogg")
+    assert "couldn't" in reply.lower() or "try again" in reply.lower()
+
+
+def test_handle_voice_handles_empty_transcript(tmp_path):
+    chat = _EchoContext()
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=chat,
+                          transcribe_fn=_transcriber(text="   "))
+    reply = agent.handle_voice("telegram", "v4", b"oggbytes", "audio/ogg")
+    assert "didn't catch" in reply.lower() or "couldn't make out" in reply.lower()
+    assert chat.last_human is None

--- a/requirement.txt
+++ b/requirement.txt
@@ -14,6 +14,7 @@ langchain-nvidia-ai-endpoints     # nvidia (hosted NIM, needs NVIDIA_API_KEY) â€
 
 # Messaging channels (the personal-assistant gateway)
 python-telegram-bot[job-queue]>=21  # Telegram bot (agronaut_agent/channels/telegram_adapter.py); job-queue extra powers the follow-up poller
+# faster-whisper                    # OPTIONAL: local speech-to-text for voice notes (ASR_PROVIDER=local). Install only for voice; offline after first model download.
 faiss-cpu
 openpyxl
 streamlit


### PR DESCRIPTION
Task 1.4 of docs/PLAN.md (Phase 1) — the voice-input half.

A spoken message is transcribed and run through the **normal text turn**, so voice notes get the full consultation (memory, trust-gated tools, cited knowledge). The existing system-prompt rule 'reply in the user's language' means a French voice note already gets a French reply — no extra work.

- `agent/transcribe.py`: provider-agnostic ASR (`ASR_PROVIDER`/`ASR_MODEL`, lazy import). **Local faster-whisper default** — voice matters most where connectivity is worst, so offline-capable is the right default; `ASR_PROVIDER=nvidia` for a hosted endpoint. `AGRONAUT_VOICE=off` kill switch.
- `AgronautAgent.handle_voice` + a Telegram `VOICE|AUDIO` handler. Degrades cleanly: no ASR configured → 'type your message'; transcription error → 'try again'; empty transcript → 'didn't catch that'. The turn is never lost.
- `faster-whisper` added to requirement.txt as an **optional/commented** dep (not forced on every install).

**Scope call — flagging for your decision:** the plan's 1.4 also asks for one non-English language *out* with localized artifacts (translated design report/BOM + localized `/` command menu). I deliberately did NOT build that here: the plan itself says 'pick ONE target language with a real deployment story (partner-driven, not speculative)'. Voice-in + the LLM's existing language-matching covers conversational use in any language today; the deeper artifact localization should wait for a named pilot partner and their language. Happy to do it the moment you name one.

TDD: 10 tests first (ASR resolve/transcribe/unavailable/disabled; handle_voice feeds transcript, no-transcriber, transcriber-error, empty-transcript; adapter voice routing + registration). Full suite: 285 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak