### PR TITLE
feat(channels): channel abstraction + group-identity fix (PLAN 2.1)

### DIFF
--- a/agronaut_agent/channels/base.py
+++ b/agronaut_agent/channels/base.py
@@ -24,6 +24,24 @@ class ChannelAdapter(ABC):
         raise NotImplementedError
 
 
+def room_identity(chat_id, chat_type: str | None, user_id) -> str:
+    """Stable per-PERSON identity for memory/profile keying.
+
+    In a 1:1 chat (chat_id == user_id, or type 'private') this is just the chat id — so
+    existing single-user memory keys are preserved byte-for-byte. In a shared room (group/
+    supergroup/channel) it becomes '<chat>:<user>', so members never collapse into one
+    profile. Delivery still targets the room — see delivery_chat_id."""
+    shared = (chat_type or "").lower() in {"group", "supergroup", "channel"} \
+        and str(chat_id) != str(user_id)
+    return f"{chat_id}:{user_id}" if shared else str(chat_id)
+
+
+def delivery_chat_id(channel_user: str):
+    """The address to deliver a proactive message (follow-up) to, derived from an identity.
+    For a composite room key '<chat>:<user>' this is the room; for a plain id it's itself."""
+    return int(str(channel_user).split(":", 1)[0])
+
+
 def chunk(text: str, size: int = 4000) -> list[str]:
     """Split a long reply to fit platform message-size caps (Telegram's is 4096)."""
     if len(text) <= size:

--- a/agronaut_agent/channels/repl.py
+++ b/agronaut_agent/channels/repl.py
@@ -1,0 +1,35 @@
+"""ReplChannel — a terminal channel, and the proof that ChannelAdapter isn't Telegram-shaped.
+
+A second, dependency-free implementation of the same contract the Telegram adapter uses:
+translate a platform's input into agent.handle_message and print the reply. Needs a
+configured tool-calling provider (e.g. LLM_PROVIDER=nvidia).
+"""
+
+from __future__ import annotations
+
+from ..core import AgronautAgent
+from .base import ChannelAdapter
+
+
+class ReplChannel(ChannelAdapter):
+    channel_name = "cli"
+
+    def __init__(self, agent: AgronautAgent, user: str = "local"):
+        super().__init__(agent)
+        self.user = user
+
+    def run(self) -> None:
+        print("Agronaut REPL — type 'quit' to exit, '/reset' to clear.")
+        while True:
+            try:
+                text = input("you> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                break
+            if text.lower() in {"quit", "exit"}:
+                break
+            if text == "/reset":
+                self.agent.reset(self.channel_name, self.user)
+                print("(conversation reset)")
+                continue
+            if text:
+                print("agronaut>", self.agent.handle_message(self.channel_name, self.user, text))

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -16,7 +16,7 @@ from telegram.constants import ChatAction
 from telegram.ext import Application, CommandHandler, MessageHandler, ContextTypes, filters
 
 from ..core import AgronautAgent
-from .base import ChannelAdapter, chunk
+from .base import ChannelAdapter, chunk, room_identity, delivery_chat_id
 
 log = logging.getLogger(__name__)
 
@@ -44,6 +44,14 @@ class TelegramAdapter(ChannelAdapter):
             return True
         user = update.effective_user
         return bool(user and str(user.id) in self.allowed_ids)
+
+    def _identity(self, update: Update) -> str:
+        """Per-person memory key. Private chats -> the chat id (unchanged); group rooms ->
+        '<chat>:<user>' so members don't share one profile."""
+        chat = update.effective_chat
+        user = update.effective_user
+        return room_identity(chat.id, getattr(chat, "type", None),
+                             user.id if user else chat.id)
 
     async def _on_start(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
@@ -80,27 +88,27 @@ class TelegramAdapter(ChannelAdapter):
         if not self._allowed(update):
             return await self._deny(update)
         text = await asyncio.to_thread(
-            self.agent.profile_text, self.channel_name, str(update.effective_chat.id)
+            self.agent.profile_text, self.channel_name, self._identity(update)
         )
         await update.message.reply_text("Here's what I remember:\n\n" + text)
 
     async def _on_forget(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
             return await self._deny(update)
-        await asyncio.to_thread(self.agent.forget_everything, self.channel_name, str(update.effective_chat.id))
+        await asyncio.to_thread(self.agent.forget_everything, self.channel_name, self._identity(update))
         await update.message.reply_text("Done — I've wiped everything I knew about your system. Clean slate.")
 
     async def _on_reset(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
             return await self._deny(update)
-        await asyncio.to_thread(self.agent.reset, self.channel_name, str(update.effective_chat.id))
+        await asyncio.to_thread(self.agent.reset, self.channel_name, self._identity(update))
         await update.message.reply_text("Cleared this conversation (I still remember your setup). What's next?")
 
     async def _set_mode(self, update: Update, goal: str) -> None:
         if not self._allowed(update):
             return await self._deny(update)
         msg = await asyncio.to_thread(
-            self.agent.set_goal, self.channel_name, str(update.effective_chat.id), goal
+            self.agent.set_goal, self.channel_name, self._identity(update), goal
         )
         await update.message.reply_text(msg)
 
@@ -116,7 +124,7 @@ class TelegramAdapter(ChannelAdapter):
     async def _on_text(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
             return await self._deny(update)
-        chat_id = str(update.effective_chat.id)
+        chat_id = self._identity(update)
         await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
         try:
             reply = await asyncio.to_thread(
@@ -133,7 +141,7 @@ class TelegramAdapter(ChannelAdapter):
     async def _on_photo(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
             return await self._deny(update)
-        chat_id = str(update.effective_chat.id)
+        chat_id = self._identity(update)
         await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
         try:
             photo = update.message.photo[-1]              # largest available size
@@ -157,7 +165,7 @@ class TelegramAdapter(ChannelAdapter):
         mime = (getattr(doc, "mime_type", "") or "")
         if mime.startswith("image/"):
             # An image sent as an uncompressed file (not a Telegram "photo"): treat it as one.
-            chat_id = str(update.effective_chat.id)
+            chat_id = self._identity(update)
             try:
                 tg_file = await doc.get_file()
                 image_bytes = bytes(await tg_file.download_as_bytearray())
@@ -180,7 +188,7 @@ class TelegramAdapter(ChannelAdapter):
     async def _on_voice(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
             return await self._deny(update)
-        chat_id = str(update.effective_chat.id)
+        chat_id = self._identity(update)
         await ctx.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
         try:
             voice = update.message.voice or update.message.audio
@@ -211,7 +219,7 @@ class TelegramAdapter(ChannelAdapter):
             due = await asyncio.to_thread(self.agent.due_followups, self.channel_name)
             for fu in due:
                 try:
-                    await ctx.bot.send_message(chat_id=int(fu["channel_user"]),
+                    await ctx.bot.send_message(chat_id=delivery_chat_id(fu["channel_user"]),
                                                text=fu["question"])
                     await asyncio.to_thread(self.agent.mark_followup_sent, fu["id"])
                 except Exception:

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -369,21 +369,8 @@ def _repl() -> None:
     """Local dry-run: talk to the agent from the terminal, no Telegram. Needs a configured
     tool-calling provider (e.g. LLM_PROVIDER=nvidia NVIDIA_API_KEY=...)."""
     import agent  # loads .env
-    agent_ = AgronautAgent()
-    print("Agronaut REPL — type 'quit' to exit, '/reset' to clear.")
-    while True:
-        try:
-            text = input("you> ").strip()
-        except (EOFError, KeyboardInterrupt):
-            break
-        if text.lower() in {"quit", "exit"}:
-            break
-        if text == "/reset":
-            agent_.reset("cli", "local")
-            print("(conversation reset)")
-            continue
-        if text:
-            print("agronaut>", agent_.handle_message("cli", "local", text))
+    from .channels.repl import ReplChannel
+    ReplChannel(AgronautAgent()).run()
 
 
 if __name__ == "__main__":

--- a/agronaut_agent/tests/test_channels.py
+++ b/agronaut_agent/tests/test_channels.py
@@ -1,0 +1,66 @@
+"""Channel abstraction: the agent brain is platform-agnostic (no python-telegram-bot
+import anywhere in agronaut_agent except the Telegram adapter), a group chat gives each
+member their own memory, and the REPL is a second ChannelAdapter instance proving the
+contract isn't Telegram-shaped.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+from agronaut_agent.channels import base
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _imports(pyfile: pathlib.Path):
+    tree = ast.parse(pyfile.read_text())
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+    return names
+
+
+def test_agent_brain_imports_no_telegram():
+    # Every module under agronaut_agent EXCEPT the telegram adapter must be free of
+    # python-telegram-bot — the brain never depends on a channel.
+    offenders = []
+    for py in (ROOT / "agronaut_agent").rglob("*.py"):
+        if py.name == "telegram_adapter.py" or "/tests/" in py.as_posix():
+            continue
+        if any(m == "telegram" or m.startswith("telegram.") for m in _imports(py)):
+            offenders.append(py.relative_to(ROOT).as_posix())
+    assert offenders == [], f"telegram imported in brain modules: {offenders}"
+
+
+def test_private_chat_identity_unchanged():
+    # private chat: chat.id == user.id -> identity is just the chat id (byte-identical
+    # to the pre-abstraction behaviour, so existing memory keys are preserved)
+    assert base.room_identity(chat_id=555, chat_type="private", user_id=555) == "555"
+    assert base.room_identity(chat_id=555, chat_type="private", user_id=555) == str(555)
+
+
+def test_group_chat_gives_each_member_distinct_identity():
+    a = base.room_identity(chat_id=-100, chat_type="supergroup", user_id=111)
+    b = base.room_identity(chat_id=-100, chat_type="supergroup", user_id=222)
+    assert a != b, "two members of one group must not share a profile"
+    assert a == "-100:111" and b == "-100:222"
+
+
+def test_delivery_chat_id_handles_plain_and_composite():
+    # follow-up delivery target: plain private id, or the room part of a composite key
+    assert base.delivery_chat_id("555") == 555
+    assert base.delivery_chat_id("-100:222") == -100   # deliver to the room it happened in
+
+
+def test_repl_channel_is_a_channel_adapter():
+    from agronaut_agent.channels.repl import ReplChannel
+    assert issubclass(ReplChannel, base.ChannelAdapter)
+    import inspect
+    assert not any("telegram" in m for m in _imports(
+        ROOT / "agronaut_agent" / "channels" / "repl.py"))


### PR DESCRIPTION
Task 2.1 of docs/PLAN.md (Phase 2 — DPG platform-independence).

- **Group-identity bug fixed:** `room_identity()` keys memory per-person. A group room becomes `<chat>:<user>` so members don't share a profile; private chats stay byte-identical (existing memory keys preserved); `delivery_chat_id()` keeps follow-up delivery targeting the room.
- **REPL is now a real second channel:** `channels/repl.py ReplChannel(ChannelAdapter)`, proving the contract isn't Telegram-shaped. `core._repl` delegates to it.
- **Boundary locked by test:** an AST scan asserts no module under `agronaut_agent` except the Telegram adapter imports `python-telegram-bot` (DPG indicator 4).

TDD: 5 tests first. Full suite: 290 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak