### PR TITLE
feat(llm): self-hostable open-weights tool-calling provider (PLAN 2.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ The chat layer is model-agnostic — pick a backend with one env var, no code ch
 | Ollama (local) | `ollama` | Offline, default (`llama3`). Best for low-connectivity / field use. |
 | NVIDIA (hosted) | `nvidia` | OpenAI-compatible open models; free tier. Needs `NVIDIA_API_KEY`. |
 | Hugging Face | `hf` | Default `Qwen/Qwen2.5-7B-Instruct` (Apache-2.0, strong at JSON). Needs `HUGGINGFACEHUB_API_TOKEN`. |
+| Self-hosted (OpenAI-compatible) | `openai_compat` | **Zero proprietary API** — point `OPENAI_COMPAT_BASE_URL` at your own vLLM / llama.cpp / LM Studio / TGI server. Drives the full tool-calling agent with an open-weights model you host. |
+
+### Self-hosted, no vendor (the open-weights path)
+
+For a deployment with no hosted API at all, serve an open-weights model with an
+OpenAI-compatible server and point Agronaut at it:
+
+```bash
+# example: vLLM serving a tool-calling-capable open model
+python -m vllm.entrypoints.openai.api_server --model Qwen/Qwen2.5-7B-Instruct
+# then:
+export LLM_PROVIDER=openai_compat
+export OPENAI_COMPAT_BASE_URL=http://localhost:8000/v1
+python bot.py
+```
+
+This runs the deterministic core **and** the tool-calling assistant with no proprietary
+dependency — the configuration Agronaut submits for [Digital Public Good](docs/dpg/)
+platform-independence.
 
 Override the model with `LLM_MODEL`. Provider libraries are imported lazily — install only
 the one you use. The design/optimizer modes run with **no LLM dependency at all.**

--- a/agent/llm.py
+++ b/agent/llm.py
@@ -11,6 +11,9 @@ Select with the LLM_PROVIDER env var (or pass `provider=`):
     hf_local  -> Hugging Face open model run LOCALLY via transformers (no token, offline
                  after the first download). The simplest way to test the assistant with no
                  hosted backend or Ollama install — just `pip install -r requirement.txt`.
+    openai_compat -> any self-hosted OpenAI-compatible server (vLLM, llama.cpp --server,
+                 LM Studio, TGI). The zero-proprietary-API path for the tool-calling agent:
+                 set OPENAI_COMPAT_BASE_URL (and OPENAI_COMPAT_API_KEY if your server needs one).
 
 Override the model with LLM_MODEL (or pass `model=`).
 
@@ -39,6 +42,11 @@ DEFAULT_MODELS = {
     # Local default kept small (~3 GB) so it downloads + runs on a laptop CPU/MPS.
     # Bump via LLM_MODEL (e.g. Qwen/Qwen2.5-7B-Instruct) for stronger output.
     "hf_local": "Qwen/Qwen2.5-1.5B-Instruct",
+    # Self-hostable OpenAI-compatible server (vLLM, llama.cpp --server, LM Studio, TGI...).
+    # The zero-proprietary-API tool-calling path: point OPENAI_COMPAT_BASE_URL at your own
+    # box and the agent runs with no hosted vendor. Tool-calling works (ChatOpenAI.bind_tools)
+    # as long as the served model supports it (Qwen2.5, Llama-3.1, Hermes, etc.).
+    "openai_compat": "Qwen/Qwen2.5-7B-Instruct",
 }
 
 SUPPORTED = tuple(DEFAULT_MODELS)
@@ -93,6 +101,16 @@ def _build_backend(provider: str, model: str, temperature: float):
             task="text-generation",
         )
         return ChatHuggingFace(llm=endpoint)
+    if provider == "openai_compat":
+        # Any OpenAI-compatible endpoint. base_url + api_key from env; a non-empty api_key
+        # is sent even for keyless local servers (many 401 on a blank Authorization header).
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model,
+            base_url=os.getenv("OPENAI_COMPAT_BASE_URL", "http://localhost:8000/v1"),
+            api_key=os.getenv("OPENAI_COMPAT_API_KEY") or "not-needed",
+            temperature=temperature,
+        )
     if provider == "hf_local":
         # Local transformers pipeline. No API token; downloads the model on first use
         # (cached in ~/.cache/huggingface) then runs offline. ChatHuggingFace applies the

--- a/agent/tests/test_llm.py
+++ b/agent/tests/test_llm.py
@@ -48,6 +48,55 @@ def test_normalize_handles_str_and_message_and_none():
     assert L.normalize(_Msg()) == "from a chat model"
 
 
+def test_openai_compat_provider_resolves(monkeypatch):
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    provider, model = L.resolve(provider="openai_compat")
+    assert provider == "openai_compat"
+    assert model == L.DEFAULT_MODELS["openai_compat"]
+
+
+def _stub_langchain_openai(monkeypatch, recorder):
+    import sys
+    import types
+
+    mod = types.ModuleType("langchain_openai")
+
+    class _ChatOpenAI:
+        def __init__(self, **kwargs):
+            recorder.update(kwargs)
+
+        def bind_tools(self, tools):
+            return self
+
+    mod.ChatOpenAI = _ChatOpenAI
+    monkeypatch.setitem(sys.modules, "langchain_openai", mod)
+
+
+def test_openai_compat_builds_tool_calling_backend_from_env(monkeypatch):
+    # A self-hostable OpenAI-compatible server (vLLM / llama.cpp-server): zero proprietary
+    # API, and it drives the tool-calling agent (has .bind_tools). Endpoint from env.
+    monkeypatch.setenv("OPENAI_COMPAT_BASE_URL", "http://my-vllm:8000/v1")
+    monkeypatch.setenv("OPENAI_COMPAT_API_KEY", "local-key")
+    seen = {}
+    _stub_langchain_openai(monkeypatch, seen)
+
+    backend = L.get_chat_model(provider="openai_compat", model="Qwen/Qwen2.5-7B-Instruct")
+    assert hasattr(backend, "bind_tools")               # can drive the agent loop
+    assert seen["base_url"] == "http://my-vllm:8000/v1"
+    assert seen["api_key"] == "local-key"
+    assert seen["model"] == "Qwen/Qwen2.5-7B-Instruct"
+
+
+def test_openai_compat_defaults_to_localhost(monkeypatch):
+    monkeypatch.delenv("OPENAI_COMPAT_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_COMPAT_API_KEY", raising=False)
+    seen = {}
+    _stub_langchain_openai(monkeypatch, seen)
+    L.get_chat_model(provider="openai_compat")
+    assert "localhost" in seen["base_url"]              # sensible local default
+    assert seen["api_key"]                              # never empty (servers 401 on blank)
+
+
 def test_stringllm_always_returns_str():
     class _FakeBackend:
         def invoke(self, prompt):

--- a/requirement.txt
+++ b/requirement.txt
@@ -15,6 +15,7 @@ langchain-nvidia-ai-endpoints     # nvidia (hosted NIM, needs NVIDIA_API_KEY) â€
 # Messaging channels (the personal-assistant gateway)
 python-telegram-bot[job-queue]>=21  # Telegram bot (agronaut_agent/channels/telegram_adapter.py); job-queue extra powers the follow-up poller
 # faster-whisper                    # OPTIONAL: local speech-to-text for voice notes (ASR_PROVIDER=local). Install only for voice; offline after first model download.
+# langchain-openai                  # OPTIONAL: self-hosted OpenAI-compatible tool-calling backend (LLM_PROVIDER=openai_compat, e.g. vLLM/llama.cpp). Zero-proprietary-API path.
 faiss-cpu
 openpyxl
 streamlit


### PR DESCRIPTION
Task 2.3 of docs/PLAN.md (Phase 2 — DPG platform-independence).

Closes the open-weights hole: previously the only reliable tool-calling brain was hosted NVIDIA (Ollama can't bind tools). New `LLM_PROVIDER=openai_compat` drives the full agent against any OpenAI-compatible server you host (vLLM, llama.cpp --server, LM Studio, TGI) via `ChatOpenAI`, endpoint from `OPENAI_COMPAT_BASE_URL`/`OPENAI_COMPAT_API_KEY`. Tool-calling works with any served model that supports it (Qwen2.5, Llama-3.1, Hermes).

- `langchain-openai` is an optional, commented dep — lazily imported, nothing forced on existing installs.
- README gains a 'self-hosted, no vendor' quick start; this is the zero-proprietary-API config Agronaut will cite for DPG platform-independence.

TDD: 3 tests first, stubbing `langchain_openai` via `sys.modules` so the binding is CI-tested with no install or network — asserts base_url/api_key/model flow through and the backend exposes `bind_tools`. Full suite: 293 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak