### PR TITLE
feat(dpg): data rights + DPG compliance pack (PLAN 2.4)

### DIFF
--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -79,8 +79,10 @@ class TelegramAdapter(ChannelAdapter):
             "/optimize — best fish/crop ratio\n"
             "/troubleshoot — diagnose a problem\n"
             "/whoami — what I remember about you\n"
+            "/export — download all your data (open JSON)\n"
             "/reset — clear this conversation (keeps long-term memory)\n"
-            "/forget — wipe everything I know about you",
+            "/forget — wipe everything I know about you\n"
+            "/delete\\_me — permanently erase all your data",
             parse_mode="Markdown",
         )
 
@@ -97,6 +99,28 @@ class TelegramAdapter(ChannelAdapter):
             return await self._deny(update)
         await asyncio.to_thread(self.agent.forget_everything, self.channel_name, self._identity(update))
         await update.message.reply_text("Done — I've wiped everything I knew about your system. Clean slate.")
+
+    async def _on_export(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        import io
+        import json
+        data = await asyncio.to_thread(
+            self.agent.export_user_data, self.channel_name, self._identity(update))
+        buf = io.BytesIO(json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8"))
+        buf.name = "agronaut_my_data.json"
+        await update.message.reply_document(
+            document=buf,
+            caption="Everything I hold about you, in open JSON. /delete_me erases it all.")
+
+    async def _on_delete_me(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        if not self._allowed(update):
+            return await self._deny(update)
+        await asyncio.to_thread(
+            self.agent.delete_me, self.channel_name, self._identity(update))
+        await update.message.reply_text(
+            "Done — I've permanently erased all your data: conversation, profile, notes, and "
+            "measurements. Nothing about you remains.")
 
     async def _on_reset(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
@@ -238,8 +262,10 @@ class TelegramAdapter(ChannelAdapter):
             ("optimize", self._on_optimize, "Mode: best fish/crop ratio"),
             ("troubleshoot", self._on_troubleshoot, "Mode: diagnose a problem"),
             ("whoami", self._on_whoami, "What I remember about you"),
+            ("export", self._on_export, "Download all my data (JSON)"),
             ("reset", self._on_reset, "Clear this conversation"),
             ("forget", self._on_forget, "Wipe everything I know"),
+            ("delete_me", self._on_delete_me, "Permanently erase all my data"),
         ]
 
     async def _post_init(self, app: Application) -> None:

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -315,6 +315,29 @@ class AgronautAgent:
         self._conv.reset_conversation(user_id)
         self._mem.forget(user_id)
 
+    # --- data rights (DPG indicators 6 & do-no-harm) ------------------------
+    def export_user_data(self, channel: str, channel_user: str) -> dict:
+        """Everything Agronaut holds about this user, as a portable JSON-serializable dict
+        (the DPG non-proprietary-export requirement). Scoped strictly to this user."""
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        return {
+            "identity": {"user_id": user_id, "channel": channel, "channel_user": str(channel_user)},
+            "profile": self._mem.get_facts(user_id),
+            "memories": self._mem.all_memories(user_id),
+            "summary": self._mem.get_summary(user_id),
+            "messages": self._conv.recent_messages(user_id, limit=100000),
+            "measurements": self._calibration.export(user_id),
+            "exported_at": _now(),
+        }
+
+    def delete_me(self, channel: str, channel_user: str) -> None:
+        """Erase ALL of this user's data — conversation, profile, memories, summary, and
+        calibration measurements. The chat-reachable right-to-erasure."""
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        self._conv.reset_conversation(user_id)
+        self._mem.forget(user_id)
+        self._calibration.purge(user_id)
+
     # --- follow-up delivery API (called by a channel poller) ----------------
     def due_followups(self, channel: str) -> list:
         """Follow-ups due for delivery on `channel` right now."""

--- a/agronaut_agent/store.py
+++ b/agronaut_agent/store.py
@@ -219,9 +219,20 @@ class MemoryStore:
                 self.set_fact(user_id, k, str(v), source)
 
     def forget(self, user_id: str) -> None:
+        # also drop any semantic-recall vectors for this user's memories (by memory_id)
+        self.db.execute(
+            "DELETE FROM memory_embeddings WHERE memory_id IN "
+            "(SELECT id FROM memories WHERE user_id=?)", (user_id,))
         self.db.execute("DELETE FROM user_facts WHERE user_id=?", (user_id,))
         self.db.execute("DELETE FROM memories WHERE user_id=?", (user_id,))
         self.db.execute("DELETE FROM session_summary WHERE user_id=?", (user_id,))
+
+    def all_memories(self, user_id: str) -> list[dict]:
+        """Every memory (not the recency-capped view) — for a full data export."""
+        rows = self.db.query(
+            "SELECT category, content, created_at FROM memories WHERE user_id=? ORDER BY id",
+            (user_id,))
+        return [dict(r) for r in rows]
 
     # --- agent-curated memories ------------------------------------------
     _MEMORY_CATEGORIES = ("profile", "event", "preference", "learning")
@@ -401,6 +412,15 @@ class CalibrationStore:
             "INSERT INTO measurements(user_id, coefficient, value, recorded_at) VALUES (?,?,?,?)",
             (user_id, coefficient, float(value), _now()),
         )
+
+    def export(self, user_id: str) -> list[dict]:
+        rows = self.db.query(
+            "SELECT coefficient, value, recorded_at FROM measurements WHERE user_id=? ORDER BY id",
+            (user_id,))
+        return [dict(r) for r in rows]
+
+    def purge(self, user_id: str) -> None:
+        self.db.execute("DELETE FROM measurements WHERE user_id=?", (user_id,))
 
     def _by_coefficient(self, user_id: str) -> dict[str, list[float]]:
         rows = self.db.query(

--- a/agronaut_agent/tests/test_data_rights.py
+++ b/agronaut_agent/tests/test_data_rights.py
@@ -1,0 +1,75 @@
+"""DPG data-rights: a user can export everything Agronaut holds about them in a portable,
+non-proprietary format (indicator 6), and delete all of it (do-no-harm / privacy). Both are
+reachable from chat commands via the agent seam.
+"""
+
+import json
+
+from langchain_core.messages import AIMessage
+
+from agronaut_agent.core import AgronautAgent
+
+
+class _Chatty:
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        return AIMessage(content="ok")
+
+
+def _seed(agent, ch="telegram", u="1"):
+    uid = agent._conv.get_or_create_user(ch, u)
+    agent._mem.set_facts(uid, {"goal": "design", "fish_species": "tilapia"})
+    agent._mem.add_memory(uid, "had an ammonia spike in June", "event")
+    agent._conv.append_message(uid, "user", "hello")
+    agent._conv.append_message(uid, "assistant", "hi")
+    agent._calibration.record(uid, "tilapia.fcr", 1.6)
+    return uid
+
+
+def test_export_returns_all_personal_data_as_json(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_Chatty())
+    _seed(agent)
+    data = agent.export_user_data("telegram", "1")
+
+    # portable: round-trips through JSON (non-proprietary format, indicator 6)
+    blob = json.dumps(data)
+    assert json.loads(blob)
+
+    assert data["identity"]["channel"] == "telegram"
+    assert data["profile"]["fish_species"] == "tilapia"
+    assert any("ammonia spike" in m["content"] for m in data["memories"])
+    assert any(msg["role"] == "user" for msg in data["messages"])
+    assert any(m["coefficient"] == "tilapia.fcr" for m in data["measurements"])
+
+
+def test_export_for_unknown_user_is_empty_not_error(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_Chatty())
+    data = agent.export_user_data("telegram", "nobody")
+    assert data["profile"] == {}
+    assert data["memories"] == [] and data["messages"] == []
+
+
+def test_delete_me_wipes_everything(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_Chatty())
+    uid = _seed(agent)
+    agent.delete_me("telegram", "1")
+
+    data = agent.export_user_data("telegram", "1")
+    assert data["profile"] == {}
+    assert data["memories"] == []
+    assert data["messages"] == []
+    assert data["measurements"] == []
+    # calibration measurements are gone too (not just conversation/profile)
+    assert agent._calibration._by_coefficient(uid) == {}
+
+
+def test_export_is_scoped_to_the_requesting_user(tmp_path):
+    agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_Chatty())
+    _seed(agent, u="1")
+    _seed(agent, u="2")
+    agent._mem.set_facts("telegram:2", {"location": "secret-place"})
+
+    data = agent.export_user_data("telegram", "1")
+    assert "location" not in data["profile"]          # never leak another user's data

--- a/agronaut_agent/tests/test_telegram_adapter.py
+++ b/agronaut_agent/tests/test_telegram_adapter.py
@@ -20,6 +20,13 @@ def test_command_specs_keep_existing_commands_for_menu():
         assert cmd in names
 
 
+def test_command_specs_include_data_rights_commands():
+    a = _adapter()
+    names = [c for c, _h, _desc in a._command_specs()]
+    assert "export" in names and "delete_me" in names
+    assert hasattr(a, "_on_export") and hasattr(a, "_on_delete_me")
+
+
 def test_every_command_spec_has_a_callable_handler_and_description():
     for cmd, handler, desc in _adapter()._command_specs():
         assert callable(handler), cmd

--- a/docs/dpg/AI_TRANSPARENCY.md
+++ b/docs/dpg/AI_TRANSPARENCY.md
@@ -1,0 +1,58 @@
+# Agronaut — AI Transparency
+
+_Last updated: 2026-07-24_
+
+This note documents how AI is used in Agronaut, for the
+[DPG Standard](https://digitalpublicgoods.net/standard/) AI-transparency expectations.
+
+## The architecture: deterministic core, LLM only at the edges
+
+Agronaut's engineering answers are **not** produced by a language model. They come from
+`aqua_model`, a parametric, unit-tested, cited engineering model built from published
+equations (FAO Fisheries & Aquaculture Technical Paper 589; UVI/Rakocy; peer-reviewed
+literature). Every coefficient carries its value, range, unit, and source.
+
+The language model does three things only:
+1. Collect facts from the conversation.
+2. Route to the right deterministic tool.
+3. Explain the tool's result in plain language.
+
+A validation gate (`validate_design_input`) sits between the LLM and the engineering model:
+the LLM proposes values, the gate rejects anything malformed or out of range, and only
+typed, validated input reaches the calculation. A hallucinated number cannot become a
+design.
+
+## Models used
+
+- **Language model:** pluggable and operator-chosen (`LLM_PROVIDER`). Options include fully
+  open-weights models you self-host (`openai_compat` → vLLM/llama.cpp with e.g. Qwen2.5 or
+  Llama-3.1) — the configuration used for DPG platform-independence — or hosted open models.
+  No proprietary model is required.
+- **Vision (optional):** an operator-chosen VLM turns a photo into a text observation. It
+  only *observes*; it never emits numbers or calls a tool.
+- **Speech (optional):** an operator-chosen ASR model (default: local Whisper-class)
+  transcribes voice notes to text.
+- **Embeddings:** a sentence-transformers model for semantic recall over the user's own
+  notes and the knowledge base.
+
+## Training data
+
+Agronaut trains **no** models. It does not fine-tune on user data, and user conversations
+are never sent anywhere for training. Retrieval-augmented answers draw only from a curated
+set of cited, public sources (`knowledge/` + `urls.txt`), and every retrieved passage is
+surfaced with its `[source: ...]` label.
+
+## Known limitations (what is NOT modeled)
+
+Each design result lists these explicitly. At the model level they include: pH/alkalinity
+dynamics, micronutrients, salinity, solids handling, pests/disease progression, fish cohort
+logic, and per-crop evapotranspiration. The seed coefficients are calibration starting
+points from the literature, not guarantees; they are meant to be calibrated against a real
+running system, and the system says so.
+
+## Advice-safety evaluation
+
+A fixed set of question/answer probes (`docs/dpg/safety_eval/`) exercises design,
+troubleshooting, out-of-scope refusals, and trust-gate behavior. It is scored each release
+as a regression signal on advice quality (a report, not a hard gate), following the
+Gates/GIZ AIEP recommendation to hold LLM advisory tools to a golden-set safety check.

--- a/docs/dpg/DPG_EVIDENCE.md
+++ b/docs/dpg/DPG_EVIDENCE.md
@@ -1,0 +1,31 @@
+# Agronaut — Digital Public Goods Standard: Evidence Map
+
+_Last updated: 2026-07-24_
+
+Mapping Agronaut against the nine
+[DPG Standard](https://github.com/DPGAlliance/DPG-Standard) indicators, for a registry
+submission. Status: **draft — owner to review before submitting.**
+
+| # | Indicator | Status | Evidence |
+|---|---|---|---|
+| 1 | **Relevance to SDGs** | ✅ | SDG 2 (Zero Hunger — food production from less land/water), SDG 6 (Clean Water — water-use-efficiency optimization, water-budget feasibility), SDG 12 (Responsible Consumption — resource-efficient food). See `docs/dpg/SDG_MAPPING.md`. |
+| 2 | **Approved open licence** | ✅ | MIT (`LICENSE`) — on the DPGA-approved list. |
+| 3 | **Clear ownership** | ✅ | Copyright + repository ownership documented in `LICENSE` and the repo. |
+| 4 | **Platform independence** | ✅ | No mandatory proprietary dependency. The tool-calling brain runs on self-hosted open-weights via `LLM_PROVIDER=openai_compat` (vLLM/llama.cpp); the deterministic design/optimizer core needs no LLM at all; channels are abstracted (`ChannelAdapter` — Telegram, WhatsApp, REPL) with no channel imported by the brain (enforced by test). |
+| 5 | **Documentation** | ✅ | `README.md` (install, run, providers, channels), `docs/PLAN.md`, `docs/dpg/*`, in-code docstrings; test suite documents behavior. |
+| 6 | **Data extraction / non-proprietary format** | ✅ | `/export` returns all of a user's data as open JSON; stored in SQLite (open format). Reachable in-chat; tested (`test_data_rights.py`). |
+| 7 | **Privacy & applicable laws** | ✅ | `docs/dpg/PRIVACY.md` — collection, purpose limitation, retention, access control, and in-chat `/export` + `/delete_me` (right to erasure). Data minimization by design; no training on user data. |
+| 8 | **Standards & best practices** | ✅ | Open standards: OpenAI-compatible API, WhatsApp Cloud API, sentence-transformers; TDD with a 300+ test suite; cited engineering model; CI on push/PR. |
+| 9 | **Do no harm by design** | ✅ | Trust gate rejects unvalidated input; every quantitative answer cites sources + lists what is NOT modeled; LLM forbidden from inventing numbers; community sharing is human-gated + PII-stripped; advice-safety golden set scored each release. See `docs/dpg/AI_TRANSPARENCY.md`. |
+
+## Submission checklist (owner actions)
+
+- [ ] Confirm SDG target selection with a domain reviewer.
+- [ ] Publish `PRIVACY.md` at a stable public URL (repo is sufficient).
+- [ ] Submit via the [DPG registry candidate process](https://github.com/DPGAlliance/publicgoods-candidates)
+  (a nomination PR / the guided form).
+- [ ] Optionally engage the FAO–DPGA food-security community of practice, framing Agronaut
+  as an MIT-licensed digital implementation of FAO Technical Paper 589.
+
+> This evidence map is complete and buildable today. Actual submission to the DPGA is an
+> outward-facing action left to the project owner.

--- a/docs/dpg/PRIVACY.md
+++ b/docs/dpg/PRIVACY.md
@@ -1,0 +1,71 @@
+# Agronaut — Privacy & Data Policy
+
+_Last updated: 2026-07-24_
+
+Agronaut is a personal agronomy assistant. This policy describes exactly what it collects,
+why, how long it keeps it, and how you control it. It is written to satisfy the
+[Digital Public Goods Standard](https://digitalpublicgoods.net/standard/) privacy and
+do-no-harm indicators.
+
+## What is collected
+
+Agronaut only stores what you tell it, so it can give advice anchored to *your* system and
+remember it across chats:
+
+| Data | Example | Why |
+|---|---|---|
+| Identity | your channel + native id (e.g. `telegram:12345`), display name | to route your conversation and keep your memory separate from others' |
+| System profile | fish species, crop, grow area, water temperature, water budget, location if you give it | to size/optimize/troubleshoot *your* system |
+| Conversation | the messages you send and the assistant's replies | continuity within and across sessions |
+| Notes & outcomes | "had an ammonia spike in June", "the water change fixed it" | to improve future advice |
+| Measurements | FCR, harvest weight, crop yield you report | to calibrate your future sizings to reality |
+
+Agronaut does **not** collect device identifiers, contacts, location beyond what you type,
+or any special-category data. Photos and voice notes you send are processed to produce a
+text observation/transcript and are **not retained** as media.
+
+## How it is used
+
+- Only to serve *you*, within your own conversation.
+- Numbers you provide are validated at a trust gate before any engineering calculation; a
+  rejected value is never stored.
+- Your data is **never** used to train any model. The language model is used only to route
+  and phrase; the engineering answers come from a deterministic, cited model.
+- Community knowledge sharing is **opt-in and human-gated**: a lesson only becomes visible
+  to other operators if it is generalized, stripped of personal detail, and explicitly
+  approved by the operator in a local review tool. Your identity and original wording never
+  leave that review screen.
+
+## Your controls
+
+Reachable directly from chat at any time:
+
+- **`/whoami`** — see what Agronaut remembers about you.
+- **`/export`** — download everything Agronaut holds about you as open JSON
+  (portable, non-proprietary format).
+- **`/reset`** — clear the current conversation (keeps your long-term profile).
+- **`/forget`** — wipe your profile and notes.
+- **`/delete_me`** — permanently erase *all* your data: conversation, profile, notes, and
+  measurements. Nothing about you remains.
+
+## Storage & retention
+
+- Data is stored in a single local SQLite database on the operator's own machine/server.
+  There is no central Agronaut server and no third-party analytics on your content.
+- Data is retained until you delete it. An operator deployment may set its own retention
+  window; this reference build retains until erasure is requested.
+- Access control: on Telegram/WhatsApp an allowlist restricts who can use a given
+  deployment; each user can only ever read or delete their own data.
+
+## Do no harm
+
+- Every quantitative answer lists its cited source coefficients and an explicit
+  "what is NOT modeled" list, so a confidently-wrong design cannot masquerade as complete.
+- The assistant is instructed never to state a sizing number that did not come from the
+  validated engineering model.
+- Advice quality is tracked against a fixed safety/accuracy question set each release (see
+  `docs/dpg/AI_TRANSPARENCY.md`).
+
+## Contact
+
+Agronaut is open source (MIT). Raise a concern at the project repository's issue tracker.

--- a/docs/dpg/SDG_MAPPING.md
+++ b/docs/dpg/SDG_MAPPING.md
@@ -1,0 +1,37 @@
+# Agronaut — SDG Mapping
+
+_Last updated: 2026-07-24_
+
+Agronaut's relevance to the UN Sustainable Development Goals, for DPG indicator 1.
+
+## Primary
+
+### SDG 2 — Zero Hunger
+**Target 2.3** (double agricultural productivity/incomes of small-scale food producers) and
+**2.4** (resilient, sustainable food production).
+Agronaut lowers the barrier to running a productive aquaponic (and, forthcoming, hydroponic)
+food system: it turns trial-and-error into a sized, cited design — fish count, feed, grow
+area, bill of materials, operating envelope — and its optimizer maximizes food or protein
+output under a smallholder's binding constraint. Calibration tunes advice to the operator's
+real measured outcomes.
+
+### SDG 6 — Clean Water and Sanitation
+**Target 6.4** (water-use efficiency).
+Aquaponics recirculates water; Agronaut's optimizer can maximize **water-use efficiency**
+directly, and its water-balance check tests a design against a fixed daily water budget —
+central for water-scarce and arid-region deployments.
+
+## Secondary
+
+### SDG 12 — Responsible Consumption and Production
+**Target 12.2** (sustainable management and efficient use of natural resources).
+By sizing systems to their inputs and flagging over-sizing via an independent nitrogen
+consistency check, Agronaut steers operators away from wasted feed, water, and materials.
+
+## Context
+
+Aquaponics and hydroponics are deployed in exactly the constrained settings these goals
+prioritize — urban and peri-urban agriculture, arid regions, and humanitarian/refugee
+settings (e.g. FAO's small-scale aquaponics work in Gaza; WFP H2Grow hydroponics in
+refugee camps). The forthcoming hydroponics mode broadens Agronaut toward the
+controlled-environment agriculture those programs most often fund.


### PR DESCRIPTION
Task 2.4 of docs/PLAN.md (Phase 2 — the DPG funding ladder's first rung).

**Code (data rights):**
- `export_user_data` → all of a user's data as portable JSON (indicator 6); `delete_me` → erases everything incl. semantic vectors + calibration measurements (indicator 7/9 right-to-erasure). Strictly user-scoped — tested it never leaks another user's data.
- Telegram `/export` (sends a JSON file) and `/delete_me` commands + `/` menu + help text.
- Plumbing: `MemoryStore.forget` now also drops `memory_embeddings`; `CalibrationStore.export/purge`; `MemoryStore.all_memories`.

**Docs (`docs/dpg/`):** PRIVACY.md, AI_TRANSPARENCY.md, SDG_MAPPING.md (SDG 2/6/12), and DPG_EVIDENCE.md — the 9-indicator evidence map, all indicators marked with concrete evidence.

TDD: 5 tests first (export shape + JSON round-trip, unknown-user empty, delete wipes everything, user-scoping, command wiring). Full suite: 306 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak