### PR TITLE
feat(deploy): Docker one-liner + compose (PLAN 2.5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+__pycache__/
+*.pyc
+.git/
+.gitignore
+.env
+*.sqlite3
+*.sqlite
+web_cache.sqlite
+data/
+.superpowers/
+.pytest_cache/
+docs/
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Agronaut — one image, two entrypoints (Streamlit web app or the Telegram bot).
+# Pick with the container command: `streamlit run app.py` (default) or `python bot.py`.
+FROM python:3.12-slim
+
+# Faster, quieter Python; no .pyc clutter.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# System deps: ffmpeg is only needed if you enable voice notes (ASR); kept minimal.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python deps first for layer caching.
+COPY requirement.txt ./
+RUN pip install -r requirement.txt
+
+# App code.
+COPY . .
+
+# Persist the SQLite memory DB outside the image.
+ENV AGRONAUT_DB=/data/agronaut.sqlite3
+VOLUME ["/data"]
+
+EXPOSE 8501
+
+# Default: the Streamlit web app. Override in compose / `docker run` for the bot.
+CMD ["streamlit", "run", "app.py", "--server.address=0.0.0.0", "--server.port=8501"]

--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ the one you use. The design/optimizer modes run with **no LLM dependency at all.
 
 ## Quick start
 
+### Docker (one command)
+
+```bash
+docker compose up web            # Streamlit at http://localhost:8501
+docker compose --profile bot up  # web + the Telegram bot (needs .env)
+```
+
+The web app's Design Calculator and Optimizer work immediately. Chat and the bot need an
+LLM provider configured in a local `.env` (see below). The SQLite memory DB persists in a
+named volume, shared between web and bot.
+
+### From source
+
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirement.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# Agronaut — `docker compose up` brings up the web app; add the bot with a profile.
+#
+#   docker compose up web            # Streamlit at http://localhost:8501
+#   docker compose --profile bot up  # web + the Telegram bot (needs .env)
+#
+# Configuration comes from a local .env file (see README). The SQLite memory DB is shared
+# between web and bot via the named volume, so they see the same users and memory.
+
+services:
+  web:
+    build: .
+    image: agronaut:latest
+    ports:
+      - "8501:8501"
+    env_file:
+      - .env
+    volumes:
+      - agronaut-data:/data
+    restart: unless-stopped
+
+  bot:
+    build: .
+    image: agronaut:latest
+    profiles: ["bot"]
+    command: ["python", "bot.py"]
+    env_file:
+      - .env
+    volumes:
+      - agronaut-data:/data
+    restart: unless-stopped
+
+volumes:
+  agronaut-data:


### PR DESCRIPTION
Task 2.5 of docs/PLAN.md (Phase 2).

One slim `python:3.12-slim` image, two entrypoints:
- `docker compose up web` → Streamlit at :8501 (default CMD)
- `docker compose --profile bot up` → web + the Telegram bot (`python bot.py`)

SQLite memory DB persisted in a named volume (`AGRONAUT_DB=/data/...`), shared between web and bot so they see the same users/memory. ffmpeg bundled for optional voice-note ASR. `.dockerignore` keeps the image lean (no .venv/.git/data). README quick-start now leads with the one-command Docker path.

**Caveat:** no Docker daemon in my environment, so I could not run a live build. The compose YAML parses, service wiring is asserted, and all referenced files (`app.py`, `bot.py`, `requirement.txt`) exist. A real `docker compose build` should be run once before relying on it.

No code changes → full suite unaffected (306 passed at 2.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak