### PR TITLE
feat(aqua_model): hydroponics sizing mode (PLAN 3.1)

### DIFF
--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -28,7 +28,11 @@ Keep replies short and scannable for a phone: lead with the point, use short bul
 YOU RUN A CONSULTATION, NOT A Q&A. Your job is to understand the person before you advise them.
 
 1. FIND THE GOAL. Every conversation has one of three goals — figure out which:
-   - design: size a new system from scratch.
+   - design: size a new system from scratch. Agronaut sizes two kinds: AQUAPONIC (fish +
+     plants — use size_aquaponics_system) and HYDROPONIC (plants only, nutrients dosed as
+     salts, NO fish — use size_hydroponic_system_tool). If the user mentions fish, pick
+     aquaponics; if they say plants-only / hydroponic / no fish, pick hydroponics; if
+     unclear, ask which they want.
    - optimize: find the best fish/crop ratio for an existing or planned system.
    - troubleshoot: diagnose a problem (sick fish, bad water, failing plants).
    If the goal is unclear, ask — briefly — what they're trying to do. Do not guess.

--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -8,7 +8,7 @@ a reviewer can trace every number back to a cited coefficient.
 
 from __future__ import annotations
 
-from aqua_model.types import DesignOutput
+from aqua_model.types import DesignOutput, HydroponicOutput
 from aqua_model.optimizer import OptimizeResult, Candidate
 
 
@@ -72,6 +72,43 @@ def serialize_design_output(out: DesignOutput) -> str:
         lines.append("NOT modeled (surface these caveats to the user):")
         lines += [f"  - {n}" for n in out.not_modeled]
 
+    return "\n".join(lines)
+
+
+def serialize_hydroponic_output(out: HydroponicOutput) -> str:
+    lines: list[str] = []
+    lines.append("FEASIBLE hydroponic design." if out.feasible
+                 else f"NOT FEASIBLE — binding constraint: {out.binding_constraint}.")
+    lines.append(
+        "Sizing (no fish — nutrient solution): "
+        f"grow_area={_g(out.grow_area_m2)} m2, reservoir={_g(out.reservoir_volume_l)} L, "
+        f"daily_water_use={_g(out.daily_water_use_lpd)} L/day, "
+        f"makeup_water={_g(out.makeup_water_lpd)} L/day, pump={_g(out.pump_turnover_lph)} L/h"
+    )
+    nt = out.nutrient_target
+    if nt:
+        ec = nt.get("ec_mS_cm", {})
+        lines.append(
+            f"Nutrient target: EC {_g(ec.get('low', 0))}-{_g(ec.get('high', 0))} mS/cm "
+            f"(aim {_g(ec.get('target', 0))}), elemental N {_g(nt.get('elemental_n_g_per_day', 0))} "
+            f"g/day, pH {nt.get('ph_target')}. {nt.get('note', '')}"
+        )
+    if out.bill_of_materials:
+        lines.append("Bill of materials:")
+        for item in out.bill_of_materials:
+            lines.append("  - " + ", ".join(f"{k}={v}" for k, v in item.items()))
+    if out.operating_envelope:
+        lines.append(f"Operating envelope: {out.operating_envelope}")
+    if out.coefficients_used:
+        lines.append("Coefficients used (cite these — every number traces here):")
+        for c in out.coefficients_used:
+            lines.append(f"  - {c.name} = {_g(c.value)} {c.unit} "
+                         f"(range {_g(c.low)}-{_g(c.high)}; source: {c.source})")
+    if out.warnings:
+        lines.append("Warnings: " + " | ".join(out.warnings))
+    if out.not_modeled:
+        lines.append("NOT modeled (surface these caveats to the user):")
+        lines += [f"  - {n}" for n in out.not_modeled]
     return "\n".join(lines)
 
 

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -14,7 +14,7 @@ def test_tool_registry():
     assert "optimize_fish_crop_ratio" in names
     assert "search_knowledge_base" in names
     assert "remember_about_user" in names
-    assert len(AGRONAUT_TOOLS) == 12
+    assert len(AGRONAUT_TOOLS) == 13
 
 
 def test_size_valid_carries_numbers_and_sources():
@@ -27,6 +27,26 @@ def test_size_valid_carries_numbers_and_sources():
     # honesty layer: coefficients with sources and not-modeled caveats are present
     assert "Coefficients used" in out and "source:" in out
     assert "NOT modeled" in out
+
+
+def test_hydroponic_tool_registered_and_sizes_without_fish():
+    from agronaut_agent.tools import size_hydroponic_system_tool, AGRONAUT_TOOLS
+    assert "size_hydroponic_system_tool" in {t.name for t in AGRONAUT_TOOLS}
+    out = size_hydroponic_system_tool.invoke(
+        {"crop": "lettuce", "grow_area_m2": 10, "temperature_c": 22, "water_budget_lpd": 500})
+    assert "FEASIBLE hydroponic design" in out
+    assert "EC" in out and "reservoir" in out.lower()
+    assert "NOT modeled" in out
+    # no fish CONCEPT (feed/biofilter/fingerlings) — the only "fish" is the "(no fish)" label
+    assert "feed=" not in out and "biofilter" not in out.lower()
+    assert "fingerling" not in out.lower()
+
+
+def test_hydroponic_tool_trust_gate_rejects_unknown_crop():
+    from agronaut_agent.tools import size_hydroponic_system_tool
+    out = size_hydroponic_system_tool.invoke(
+        {"crop": "moonfruit", "grow_area_m2": 10, "temperature_c": 22, "water_budget_lpd": 500})
+    assert "VALIDATION_FAILED" in out
 
 
 def test_size_trust_gate_rejects_unknown_species():
@@ -71,7 +91,7 @@ def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "update_profile" in names
-    assert len(AGRONAUT_TOOLS) == 12
+    assert len(AGRONAUT_TOOLS) == 13
 
 
 def test_update_profile_writes_canonical_drops_unknown():
@@ -102,7 +122,7 @@ def test_registry_includes_schedule_followup():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "schedule_followup" in names
-    assert len(AGRONAUT_TOOLS) == 12
+    assert len(AGRONAUT_TOOLS) == 13
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
@@ -146,7 +166,7 @@ def test_registry_includes_community_tools():
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "nominate_shared_insight" in names
     assert "search_community_knowledge" in names
-    assert len(AGRONAUT_TOOLS) == 12
+    assert len(AGRONAUT_TOOLS) == 13
 
 
 def test_nominate_writes_pending_and_rejects_blank():
@@ -197,7 +217,7 @@ def test_registry_includes_record_measurement():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "record_measurement" in names
-    assert len(AGRONAUT_TOOLS) == 12
+    assert len(AGRONAUT_TOOLS) == 13
 
 
 def test_record_measurement_maps_metric_to_qualified_key():

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -15,9 +15,11 @@ from langchain_core.tools import tool
 
 from aqua_model import (
     size_system,
+    size_hydroponic_system,
     optimize,
     OptimizeInput,
     validate_design_input,
+    validate_hydroponic_input,
     ValidationError,
     OBJECTIVES,
 )
@@ -102,6 +104,36 @@ def size_aquaponics_system(
     except ValidationError as err:
         return serialize.serialize_validation_error(err.errors)
     return sized + note
+
+
+@tool
+def size_hydroponic_system_tool(
+    crop: str,
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    source_water_note: str | None = None,
+) -> str:
+    """Size ONE HYDROPONIC (soil-less, NO fish) system deterministically. Use this when the
+    user wants plants only — nutrients dosed as salts, not from fish. Returns the nutrient
+    reservoir volume, ET-driven daily water use, pump sizing, the nutrient-solution target
+    (EC band + elemental N/day + pH), bill of materials, operating envelope, the CITED
+    coefficients used, and what is NOT modeled. For fish+plants use size_aquaponics_system.
+
+    crop: one of the supported crops (call list_supported_species_and_crops if unsure).
+    grow_area_m2: planted DWC/NFT area (the anchor).
+    temperature_c: mean ambient/solution temperature.
+    water_budget_lpd: makeup water available per day, litres.
+    source_water_note: optional salinity/quality caveat.
+    """
+    try:
+        design = validate_hydroponic_input(
+            crop, grow_area_m2, temperature_c, water_budget_lpd,
+            _clean_optional(source_water_note),
+        )
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    return serialize.serialize_hydroponic_output(size_hydroponic_system(design))
 
 
 @tool
@@ -360,6 +392,7 @@ def record_measurement(metric: str, value: float) -> str:
 
 AGRONAUT_TOOLS = [
     size_aquaponics_system,
+    size_hydroponic_system_tool,
     optimize_fish_crop_ratio,
     list_supported_species_and_crops,
     design_envelope_reality_check,

--- a/aqua_model/__init__.py
+++ b/aqua_model/__init__.py
@@ -17,22 +17,29 @@ Design rules (from the approved design doc + eng/CEO reviews):
 """
 
 from .sizing import size_system
+from .hydroponics import size_hydroponic_system
 from .optimizer import optimize, OptimizeInput, OptimizeResult, Candidate, OBJECTIVES
-from .validate import validate_design_input, ValidationError
-from .types import DesignInput, DesignOutput, CoefficientUse
+from .validate import validate_design_input, validate_hydroponic_input, ValidationError
+from .types import (
+    DesignInput, DesignOutput, CoefficientUse, HydroponicInput, HydroponicOutput,
+)
 
 __all__ = [
     "size_system",
+    "size_hydroponic_system",
     "optimize",
     "OptimizeInput",
     "OptimizeResult",
     "Candidate",
     "OBJECTIVES",
     "validate_design_input",
+    "validate_hydroponic_input",
     "ValidationError",
     "DesignInput",
     "DesignOutput",
     "CoefficientUse",
+    "HydroponicInput",
+    "HydroponicOutput",
 ]
 
 __version__ = "0.1.0"

--- a/aqua_model/coefficients.py
+++ b/aqua_model/coefficients.py
@@ -104,6 +104,20 @@ NITRIFICATION_RATE = Coefficient(
     note="Conservative. Tank/raft surfaces also nitrify but are NOT counted here (eng decision).",
 )
 
+# --- Hydroponics: nutrient-solution targets (no fish; salts dosed directly). ------------
+# Target electrical conductivity (EC) of the nutrient solution, a standard proxy for total
+# dissolved nutrient strength. Leafy crops run leaner than fruiting crops.
+EC_TARGET_LEAFY = Coefficient(
+    name="ec_target_leafy",
+    value=1.5, low=1.2, high=1.8, unit="mS/cm", source="LIT",
+    note="DWC/NFT leafy-green nutrient strength; climate- and stage-dependent.",
+)
+EC_TARGET_FRUITING = Coefficient(
+    name="ec_target_fruiting",
+    value=2.6, low=2.0, high=3.5, unit="mS/cm", source="LIT",
+    note="Fruiting-crop nutrient strength (tomato/pepper/cucumber); raise as fruit sets.",
+)
+
 
 def registry() -> dict[str, Coefficient]:
     """All global coefficients by name (species/crop coefficients live in their own modules)."""
@@ -119,5 +133,7 @@ def registry() -> dict[str, Coefficient]:
             SUMP_FRACTION,
             PUMP_TURNOVER_RATE,
             NITRIFICATION_RATE,
+            EC_TARGET_LEAFY,
+            EC_TARGET_FRUITING,
         )
     }

--- a/aqua_model/hydroponics.py
+++ b/aqua_model/hydroponics.py
@@ -1,0 +1,150 @@
+"""size_hydroponic_system() — the calculator for soil-less systems WITHOUT fish.
+
+Hydroponics differs from aquaponics at the root of the solve chain: there is no fish, no
+feed, no biofilter, and no fish-nitrogen balance. Nutrients are dosed directly as salts, so
+grow area drives water (evapotranspiration) and the nutrient solution is specified by a
+target EC band plus the crop's elemental-nitrogen demand.
+
+Solve order (grow area anchors everything):
+
+    grow_area ──ET──▶ daily water use ─▶ makeup water ─▶ (feasibility vs budget)
+        │
+        ├─ raft depth + sump ─▶ reservoir (solution) volume ─▶ pump turnover
+        └─ crop EC band + N uptake ─▶ nutrient-solution target
+
+Reuses the cited crop database and water/geometry coefficients; keeps the same honesty
+layer (cited coefficients + an explicit 'not modeled' list). Never raises on a valid
+HydroponicInput.
+"""
+
+from __future__ import annotations
+
+from . import coefficients as C
+from .crops import get_crop
+from .types import CoefficientUse, HydroponicInput, HydroponicOutput
+
+# What this hydroponics v1 does NOT model. Distinct from the aquaponics list — no fish,
+# but new soil-less concerns (EC drift, micronutrient chemistry, root-zone disease).
+NOT_MODELED = [
+    "pH / alkalinity dynamics and buffering",
+    "micronutrient chemistry (iron chelation, Ca/Mg antagonism)",
+    "EC drift and salt accumulation as water evaporates and solution is topped up",
+    "specific fertilizer formulation and A/B stock-tank recipes",
+    "root-zone temperature and dissolved oxygen beyond the stated target",
+    "root-zone disease (e.g. pythium) and biosecurity",
+    "climate-driven evapotranspiration variability (mean rate only; calibrate per site)",
+]
+
+
+def _coeff_uses(*coeffs) -> list[CoefficientUse]:
+    return [CoefficientUse(c.name, c.value, c.low, c.high, c.unit, c.source) for c in coeffs]
+
+
+def _ec_coeff(crop):
+    return C.EC_TARGET_FRUITING if crop.category == "fruiting" else C.EC_TARGET_LEAFY
+
+
+def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
+    crop = get_crop(design.crop)
+
+    # 1. ET drives daily solution consumption (the dominant water term in a covered system).
+    daily_water_use = design.grow_area_m2 * C.EVAPOTRANSPIRATION_RATE.value
+
+    # 2. Reservoir (solution) volume = bed water (area x depth) + sump headroom. No fish tank.
+    bed_water_m3 = design.grow_area_m2 * C.RAFT_WATER_DEPTH.value
+    reservoir_m3 = bed_water_m3 / (1.0 - C.SUMP_FRACTION.value)
+    reservoir_l = reservoir_m3 * 1000.0
+
+    # 3. Pump turnover: circulate the reservoir volume at the standard turnover rate.
+    pump_lph = reservoir_l * C.PUMP_TURNOVER_RATE.value
+
+    # 4. Makeup water = ET consumption (rainfall 0 for a covered system). Evaporative loss
+    #    from open canals is folded into the ET range, which is wide and calibrated per site.
+    makeup_lpd = round(daily_water_use, 1)
+
+    # 5. Nutrient target: EC band for the crop category + the crop's elemental-N demand.
+    ec = _ec_coeff(crop)
+    elemental_n = round(design.grow_area_m2 * crop.n_uptake_g_per_m2_day, 1)
+    nutrient_target = {
+        "ec_mS_cm": {"target": ec.value, "low": ec.low, "high": ec.high},
+        "elemental_n_g_per_day": elemental_n,
+        "ph_target": [max(crop.ph_min, 5.5), min(crop.ph_max, 6.5)],
+        "note": "Dose to the EC band; N/day is the crop's uptake — supply via a complete "
+                "hydroponic nutrient mix, not a single salt.",
+    }
+
+    out = HydroponicOutput(
+        feasible=True,
+        grow_area_m2=design.grow_area_m2,
+        reservoir_volume_l=round(reservoir_l, 1),
+        daily_water_use_lpd=round(daily_water_use, 1),
+        makeup_water_lpd=makeup_lpd,
+        pump_turnover_lph=round(pump_lph, 1),
+        nutrient_target=nutrient_target,
+        not_modeled=list(NOT_MODELED),
+    )
+
+    # 6. Feasibility: water budget is the binding constraint.
+    if makeup_lpd > design.water_budget_lpd:
+        out.feasible = False
+        out.binding_constraint = "water_budget"
+        if makeup_lpd > 0:
+            feasible_area = design.grow_area_m2 * (design.water_budget_lpd / makeup_lpd)
+            out.warnings.append(
+                f"Makeup water {makeup_lpd} L/day exceeds budget {design.water_budget_lpd} "
+                f"L/day. Nearest feasible: reduce grow area to ~{round(feasible_area, 1)} m2 "
+                f"(a {round((1 - feasible_area / design.grow_area_m2) * 100)}% cut)."
+            )
+
+    # Temperature caution against the crop's own band (no fish band to check).
+    if not (crop.temp_min_c <= design.temperature_c <= crop.temp_max_c):
+        out.warnings.append(
+            f"{design.temperature_c} C is outside {crop.name}'s range "
+            f"({crop.temp_min_c}-{crop.temp_max_c} C); growth and water use will differ."
+        )
+
+    out.operating_envelope = {
+        "ph_target": nutrient_target["ph_target"],
+        "ec_target_mS_cm": [ec.low, ec.high],
+        "temperature_target_c": [crop.temp_min_c, crop.temp_max_c],
+        "dissolved_oxygen_min_mg_l": 5.0,
+    }
+    out.bill_of_materials = _bill_of_materials(out, crop)
+    out.maintenance_checklist = _maintenance_checklist()
+    out.assumptions = _assumptions(crop)
+    out.coefficients_used = _coeff_uses(
+        C.EVAPOTRANSPIRATION_RATE, C.RAFT_WATER_DEPTH, C.SUMP_FRACTION,
+        C.PUMP_TURNOVER_RATE, ec,
+    )
+    return out
+
+
+def _bill_of_materials(out: HydroponicOutput, crop) -> list[dict]:
+    return [
+        {"item": "nutrient reservoir / sump", "spec": f"~{round(out.reservoir_volume_l)} L", "qty": 1},
+        {"item": "DWC raft / NFT channel grow bed", "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
+        {"item": "circulation pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
+        {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L in the root zone", "qty": 1},
+        {"item": "nutrient stock (A/B) + pH adjusters", "spec": f"dose to EC "
+         f"{out.nutrient_target['ec_mS_cm']['low']}–{out.nutrient_target['ec_mS_cm']['high']} mS/cm", "qty": 1},
+        {"item": "EC + pH meters", "spec": "for daily monitoring", "qty": 1},
+    ]
+
+
+def _maintenance_checklist() -> list[str]:
+    return [
+        "Daily: check EC and pH; top up makeup water and record the amount.",
+        "Daily: check pump/aeration operation and root-zone appearance.",
+        "Weekly: adjust or refresh the nutrient solution; inspect roots for browning/slime.",
+        "Weekly: clean pump intake and channels; check flow.",
+        "Monthly: fully drain, clean, and remix the reservoir to reset salt build-up.",
+    ]
+
+
+def _assumptions(crop) -> list[str]:
+    return [
+        f"Soil-less hydroponic system (DWC/NFT), single crop ({crop.name}), NO fish.",
+        "Nutrients supplied by a complete dosed solution (not fish waste).",
+        "Grow area anchors ET-driven water use; rainfall assumed 0 (covered system).",
+        "EC band and N/day are seed targets — CALIBRATE against your crop and climate.",
+    ]

--- a/aqua_model/tests/test_hydroponics.py
+++ b/aqua_model/tests/test_hydroponics.py
@@ -1,0 +1,77 @@
+"""Hydroponics sizing: ET-driven nutrient-solution systems (NO fish). Reuses the crop
+database, water/geometry coefficients, and the honesty layer, with its own trust gate,
+its own 'not modeled' list, and nutrient (EC / elemental-N) targets fish systems lack.
+"""
+
+import pytest
+
+from aqua_model import (
+    size_hydroponic_system,
+    validate_hydroponic_input,
+    HydroponicInput,
+    HydroponicOutput,
+    ValidationError,
+)
+
+
+def _valid(**kw):
+    args = dict(crop="lettuce", grow_area_m2=10.0, temperature_c=22.0, water_budget_lpd=500.0)
+    args.update(kw)
+    return validate_hydroponic_input(**args)
+
+
+def test_validate_builds_input_and_rejects_unknown_crop():
+    inp = _valid()
+    assert isinstance(inp, HydroponicInput)
+    assert inp.crop == "lettuce"
+    with pytest.raises(ValidationError):
+        _valid(crop="unobtainium")
+
+
+def test_validate_rejects_out_of_range():
+    with pytest.raises(ValidationError):
+        _valid(grow_area_m2=-5)
+    with pytest.raises(ValidationError):
+        _valid(temperature_c=99)
+
+
+def test_size_feasible_carries_numbers_sources_and_not_modeled():
+    out = size_hydroponic_system(_valid())
+    assert isinstance(out, HydroponicOutput)
+    assert out.feasible is True
+    assert out.reservoir_volume_l > 0
+    assert out.daily_water_use_lpd > 0
+    assert out.pump_turnover_lph > 0
+    assert out.coefficients_used and all(c.source for c in out.coefficients_used)
+    assert out.not_modeled
+    # hydroponics-specific: NO fish concepts anywhere
+    text = " ".join(out.not_modeled + out.assumptions).lower()
+    assert "fish" not in text or "no fish" in text
+    assert not hasattr(out, "feed_g_per_day")
+
+
+def test_size_includes_nutrient_targets():
+    out = size_hydroponic_system(_valid())
+    # a hydroponic design must state the nutrient solution target the aquaponic one doesn't
+    assert out.nutrient_target["ec_mS_cm"]["low"] > 0
+    assert out.nutrient_target["elemental_n_g_per_day"] > 0
+
+
+def test_fruiting_crop_targets_higher_ec_than_leafy():
+    leafy = size_hydroponic_system(_valid(crop="lettuce")).nutrient_target["ec_mS_cm"]["target"]
+    fruiting = size_hydroponic_system(_valid(crop="tomato")).nutrient_target["ec_mS_cm"]["target"]
+    assert fruiting > leafy
+
+
+def test_water_budget_infeasible_gives_nearest_feasible():
+    out = size_hydroponic_system(_valid(grow_area_m2=200.0, water_budget_lpd=50.0))
+    assert out.feasible is False
+    assert out.binding_constraint == "water_budget"
+    assert any("reduce grow area" in w.lower() for w in out.warnings)
+
+
+def test_hydroponic_output_has_no_fish_fields():
+    out = size_hydroponic_system(_valid())
+    bom_text = " ".join(item["item"].lower() for item in out.bill_of_materials)
+    assert "fish" not in bom_text and "biofilter" not in bom_text
+    assert "reservoir" in bom_text or "tank" in bom_text

--- a/aqua_model/types.py
+++ b/aqua_model/types.py
@@ -28,6 +28,45 @@ class DesignInput:
 
 
 @dataclass(frozen=True)
+class HydroponicInput:
+    """Fixed inputs for ONE hydroponic system (nutrient solution, no fish). Built only by
+    validate_hydroponic_input — the trust gate — never from raw LLM output."""
+
+    crop: str                  # must exist in crops.CROPS
+    grow_area_m2: float        # the anchor; planted DWC/NFT area
+    temperature_c: float       # mean ambient/solution temperature
+    water_budget_lpd: float    # makeup water available per day
+    source_water_note: str | None = None
+
+
+@dataclass
+class HydroponicOutput:
+    feasible: bool
+    binding_constraint: str | None = None
+
+    # --- sizing numbers ---
+    grow_area_m2: float = 0.0
+    reservoir_volume_l: float = 0.0     # nutrient-solution reservoir (no fish tank)
+    daily_water_use_lpd: float = 0.0    # ET-driven solution consumption
+    makeup_water_lpd: float = 0.0
+    pump_turnover_lph: float = 0.0
+
+    # --- nutrient solution (the hydroponics-specific part) ---
+    nutrient_target: dict = field(default_factory=dict)  # EC band + elemental-N/day
+
+    # --- build artifacts ---
+    bill_of_materials: list[dict] = field(default_factory=list)
+    operating_envelope: dict = field(default_factory=dict)
+    maintenance_checklist: list[str] = field(default_factory=list)
+
+    # --- honesty layer ---
+    coefficients_used: list["CoefficientUse"] = field(default_factory=list)
+    not_modeled: list[str] = field(default_factory=list)
+    assumptions: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class CoefficientUse:
     """Provenance record: one coefficient as it was used in a specific design run."""
 

--- a/aqua_model/validate.py
+++ b/aqua_model/validate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from .crops import CROPS
 from .species import SPECIES
-from .types import DesignInput
+from .types import DesignInput, HydroponicInput
 
 
 class ValidationError(ValueError):
@@ -70,6 +70,51 @@ def validate_design_input(
 
     return DesignInput(
         fish_species=species_key,
+        crop=crop_key,
+        grow_area_m2=float(grow_area_m2),
+        temperature_c=float(temperature_c),
+        water_budget_lpd=float(water_budget_lpd),
+        source_water_note=source_water_note,
+    )
+
+
+def validate_hydroponic_input(
+    crop,
+    grow_area_m2,
+    temperature_c,
+    water_budget_lpd,
+    source_water_note=None,
+) -> HydroponicInput:
+    """Trust gate for hydroponic sizing — same discipline as validate_design_input, but no
+    fish species (nutrients are dosed, not produced by fish)."""
+    errors: list[str] = []
+
+    crop_key = str(crop or "").strip().lower()
+    if crop_key not in CROPS:
+        errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
+
+    grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
+    temperature_c = _as_float(temperature_c, "temperature_c", errors)
+    water_budget_lpd = _as_float(water_budget_lpd, "water_budget_lpd", errors)
+
+    for field, val in (
+        ("grow_area_m2", grow_area_m2),
+        ("temperature_c", temperature_c),
+        ("water_budget_lpd", water_budget_lpd),
+    ):
+        if val is None:
+            continue
+        lo, hi = _BOUNDS[field]
+        if not (lo <= val <= hi):
+            errors.append(f"{field}={val} out of range [{lo}, {hi}]")
+
+    if source_water_note is not None and not isinstance(source_water_note, str):
+        errors.append("source_water_note must be a string or None")
+
+    if errors:
+        raise ValidationError(errors)
+
+    return HydroponicInput(
         crop=crop_key,
         grow_area_m2=float(grow_area_m2),
         temperature_c=float(temperature_c),


### PR DESCRIPTION
Task 3.1 of docs/PLAN.md (Phase 3) — doubles the audience and opens the humanitarian/WFP funding door (refugee-camp soil-less ag is hydroponics, not aquaponics).

A second deterministic engine under the same trust discipline. Hydroponics has no fish, so the solve chain changes at the root: grow area anchors **ET-driven** water use; the reservoir + pump reuse the cited raft-depth/sump/turnover coefficients; and a **nutrient-solution target** (EC band by crop category + the crop's elemental-N demand + pH band) replaces the fish→feed→biofilter→nitrogen chain.

- New `aqua_model/hydroponics.py`, `HydroponicInput/Output`, `validate_hydroponic_input` (own trust gate, no fish species), `EC_TARGET_LEAFY/FRUITING` cited coefficients, and a distinct 'not modeled' list (EC drift, micronutrient chemistry, root-zone disease).
- Agent tool `size_hydroponic_system_tool` (registry 12→13) + `serialize_hydroponic_output`; system prompt routes fish→aquaponics, plants-only→hydroponics.
- Reuses the crop DB and honesty layer; seeds never mutated; trust gate rejects unknown crops loudly.

TDD: 9 tests first (validate + gate, feasible numbers/sources/not-modeled, nutrient targets, fruiting>leafy EC, water-budget infeasibility, no-fish-fields, tool registration + gate). Full suite: 315 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak