### PR TITLE
feat(knowledge): Tier-3 KB docs (PLAN 3.4)

### DIFF
--- a/agronaut_agent/tests/test_knowledge_coverage.py
+++ b/agronaut_agent/tests/test_knowledge_coverage.py
@@ -1,0 +1,29 @@
+"""Knowledge-base coverage: the Tier-3 economics / feasibility / food-safety / regulations
+docs exist, are substantive, and carry a sources line — so the RAG layer can cite them.
+"""
+
+import pathlib
+
+KB = pathlib.Path(__file__).resolve().parents[2] / "knowledge"
+
+TIER3 = [
+    "economics_and_costs.md",
+    "feasibility_and_business_case.md",
+    "food_safety_and_hygiene.md",
+    "regulations_and_permits.md",
+]
+
+
+def test_tier3_docs_exist_and_are_substantive():
+    for name in TIER3:
+        doc = KB / name
+        assert doc.exists(), f"missing Tier-3 KB doc: {name}"
+        text = doc.read_text()
+        assert len(text) > 800, f"{name} is too thin to be useful"
+        assert text.lstrip().startswith("# "), f"{name} needs a title heading"
+
+
+def test_tier3_docs_cite_sources():
+    for name in TIER3:
+        text = (KB / name).read_text().lower()
+        assert "source" in text or "fao" in text, f"{name} has no citation"

--- a/knowledge/economics_and_costs.md
+++ b/knowledge/economics_and_costs.md
@@ -1,0 +1,56 @@
+# Economics and Costs
+
+Aquaponics and hydroponics can produce a lot of food per square metre, but **profitability is
+not automatic** — the peer-reviewed and practitioner consensus is that many operations are
+not economically viable, and food-security claims are regularly overstated (FAO Yumina work;
+Wiley review of aquaponics economics, 2025). Treat every design as a business case, not just
+an engineering one.
+
+## The main cost buckets
+
+**Capital (one-time):**
+- Tanks/reservoir, grow beds (raft/DWC or NFT), plumbing, and a sump.
+- Pumps and aeration (air pump + stones) — and the power to run them 24/7.
+- A greenhouse or shade/cover structure in most climates.
+- Instrumentation: pH and EC meters at minimum.
+- Fingerlings/seedlings and initial nutrient or feed stock.
+
+**Operating (recurring):**
+- **Energy** is usually the largest and most underestimated ongoing cost — pumps and
+  aeration run continuously, plus heating/cooling to hold the operating temperature band.
+- Feed (aquaponics) or nutrient salts (hydroponics).
+- Water and makeup water (small in a recirculating system, but not zero).
+- Labour — daily monitoring, feeding, harvesting, cleaning. Often the true largest cost once
+  you price your own time.
+- Replacements: fish losses, pump/impeller wear, seals, media.
+
+## Why systems lose money
+
+- **Energy and labour dwarf the value of the crop** at small scale. A few square metres of
+  lettuce rarely pays for a pump running 8,760 hours a year plus daily attention.
+- **Underpricing your labour.** Hobby math that ignores time looks profitable; commercial
+  math that pays for it usually does not, until scale.
+- **Single low-value crop.** Leafy greens have thin margins; high-value herbs (basil, mint)
+  and the fish protein are where aquaponics economics improve.
+- **Undersized or oversold.** A design sized past its water/energy budget bleeds cost; see
+  Agronaut's water-budget feasibility check.
+
+## What improves the economics
+
+- **Scale** — fixed costs (your time, a controller, a greenhouse) amortise over more area.
+- **High-value crops** and selling the fish, not just greens.
+- **Cheap, reliable energy** — solar for pumps/aeration in off-grid and field settings
+  changes the equation more than any other single lever.
+- **Local, direct sales** (restaurants, markets) that capture the freshness premium.
+- **Calibration** — matching stocking, feed, and grow area to what the system actually
+  sustains avoids wasted feed, water, and materials.
+
+## How to think about feasibility
+
+Before building, estimate: annual energy cost (pump + aeration + climate control), annual
+feed/nutrient cost, realistic yield × a price you can actually get, and the value of your own
+labour. If the crop value does not clear energy + labour, the design is a hobby, not a
+business — which is fine if that is the goal, but say so honestly.
+
+_Sources: FAO Fisheries & Aquaculture Technical Paper 589; FAO Yumina/aquaponics economics
+notes; Wiley aquaponics economics review (2025); practitioner cost surveys._

--- a/knowledge/feasibility_and_business_case.md
+++ b/knowledge/feasibility_and_business_case.md
@@ -1,0 +1,46 @@
+# Feasibility and Business Case
+
+A design that is *engineering-feasible* (the water balance closes, the biofilter is sized) can
+still be *economically* or *operationally* infeasible. Run all three checks before building.
+
+## 1. Resource feasibility
+
+- **Water budget.** Recirculating systems use little water, but evapotranspiration + evaporation
+  set a daily makeup requirement. If it exceeds the available budget the design is not feasible —
+  shrink the grow area to the nearest-feasible size (Agronaut computes this).
+- **Energy.** Continuous pumping and aeration, plus heating/cooling to hold the temperature band,
+  are the binding constraint in most real deployments. Confirm a reliable power source (grid,
+  generator, or solar) before anything else.
+- **Source water quality.** High salinity, hardness, or chlorine/chloramine can make an otherwise
+  fine site unworkable without treatment (see `water_source_and_treatment`).
+- **Climate.** The mean temperature must suit both the fish and the crop; wide diel swings or
+  seasonal extremes may require a greenhouse or cooling that changes the cost basis.
+
+## 2. Operational feasibility
+
+- **Labour and skill.** Daily monitoring (fish behaviour, pH, EC, water level) and weekly testing
+  are non-negotiable. A system with no one to watch it fails, regardless of design.
+- **Supply chains.** Reliable access to fingerlings, feed or nutrient salts, and replacement parts.
+  A design that depends on an import that arrives twice a year is fragile.
+- **Failure tolerance.** Power cuts crash dissolved oxygen within hours (see
+  `dissolved_oxygen_and_aeration`). Backup aeration is often the difference between a setback and a
+  total loss.
+
+## 3. Market and business feasibility
+
+- **Who buys the output, at what price?** Feasibility is crop value vs energy + labour + inputs.
+  Leafy greens alone rarely clear it; high-value herbs plus fish protein, sold locally for a
+  freshness premium, are where the case closes.
+- **Scale.** Small systems carry the same fixed costs (your time, a controller, a structure) as
+  larger ones but spread them over less output. Many pilots are feasible only as demonstrations,
+  not businesses — that is a legitimate goal, but name it.
+
+## For grants and pilots (funder-facing)
+
+Programs (FAO, WFP, GIZ, CGIAR) fund pilots that show: a named local partner, a realistic
+outcome estimate (food/water/income), a cost that includes energy and labour, and a plan for who
+operates and maintains it after the grant. A cited, honest design that lists what it does *not*
+model is more fundable than an optimistic one — funders scrutinise over-claims closely.
+
+_Sources: FAO Technical Paper 589; Gates/GIZ AIEP advisory-tool lessons (2025); WFP H2Grow
+hydroponics deployment reports; practitioner feasibility guidance._

--- a/knowledge/food_safety_and_hygiene.md
+++ b/knowledge/food_safety_and_hygiene.md
@@ -1,0 +1,49 @@
+# Food Safety and Hygiene
+
+Aquaponic and hydroponic produce is food. Because fish, water, and edible plants share one
+system, a few hazards need active management — most are avoidable with basic hygiene.
+
+## The main hazards
+
+- **Faecal pathogens (E. coli, Salmonella).** The fish and their waste are the source. Risk is
+  highest where **edible parts contact system water** — leafy greens in raft/DWC, and any
+  splashing onto the crop.
+- **Listeria** can persist in cool, wet surfaces (channels, sumps, packing areas).
+- **Physical/chemical:** anything you add to the water reaches the food. Only use inputs approved
+  for food production.
+
+## Practices that keep produce safe
+
+- **Keep the edible part out of the water.** Harvest leaves and fruit above the waterline; don't
+  let crops sit in or splash with tank water near harvest.
+- **Never handle fish and then harvest produce** without washing hands and changing gloves. Keep
+  separate tools for fish work and plant harvest.
+- **Wash produce in clean (potable) water at harvest**, not system water.
+- **Cool the harvest promptly** — the cold chain limits pathogen growth after picking.
+- **No raw manure, ever.** Do not add manure or untreated organic matter to a system growing food;
+  the fish waste is the nutrient source and it is processed by the biofilter.
+- **Handle mortalities fast.** Remove dead fish immediately — decomposition spikes ammonia (a fish
+  hazard) and raises the pathogen load.
+
+## System hygiene
+
+- Clean and sanitise harvest surfaces, tools, and containers between uses.
+- Control pests and birds that can introduce contamination (see `plant_pests_and_ipm`).
+- Keep the site clean and drained; standing organic sludge is both a water-quality and a
+  food-safety problem (see `solids_and_mineralization`).
+
+## What Agronaut does NOT model
+
+Agronaut sizes and troubleshoots the *engineering* of a system. It does **not** certify food
+safety, run a HACCP plan, or replace local food-safety law. Treat this page as general good
+practice and follow your jurisdiction's rules (see `regulations_and_permits`).
+
+## For commercial sale
+
+If you sell produce, expect to follow a food-safety scheme (e.g. GAP-style Good Agricultural
+Practices, or your national equivalent): documented water testing, worker hygiene, traceability,
+and harvest/handling records. Build the record-keeping in from day one — it is far easier than
+retrofitting it.
+
+_Sources: FAO/WHO produce-safety guidance; FAO Technical Paper 589 (food-safety section);
+national Good Agricultural Practices (GAP) frameworks._

--- a/knowledge/regulations_and_permits.md
+++ b/knowledge/regulations_and_permits.md
@@ -1,0 +1,44 @@
+# Regulations and Permits
+
+Rules vary widely by country and locality, so this is a **checklist of what to ask about**, not
+legal advice. Confirm every item with your local authority before building or selling.
+
+## What is commonly regulated
+
+- **Aquaculture / fish-keeping.** Many jurisdictions require a permit to raise fish, restrict
+  which **species** you may keep (invasive-species law is strict — e.g. some tilapia and catfish
+  species are banned or permit-only in certain regions), and regulate sourcing of fingerlings.
+- **Water use and discharge.** Abstraction (how much water you may draw) and, importantly,
+  **effluent discharge** — releasing nutrient-rich water to drains, ground, or waterways is often
+  controlled. A well-run recirculating system discharges little, which helps.
+- **Food business / produce sales.** Selling food usually triggers registration as a food business,
+  a food-safety scheme (GAP-style), labelling rules, and sometimes inspection.
+- **Structures.** Greenhouses and tanks may need building permits, and zoning/land-use rules
+  determine whether food production is allowed at your site (urban and residential zones often
+  restrict it).
+- **Organic claims.** "Organic" is a legally protected term in many markets, and several
+  **do not allow hydroponic/soil-less produce to be certified organic** — check before marketing.
+
+## Species: the sharpest trap
+
+Choosing a fish species is not only a biology decision. An otherwise ideal species may be
+**illegal to keep or move** where you are, or require containment measures to prevent escape into
+local ecosystems. Verify legality *before* sizing a system around a species.
+
+## Practical checklist
+
+- [ ] Is raising fish permitted at my site, and is my chosen **species** legal here?
+- [ ] Do I need an aquaculture permit or registration?
+- [ ] Are there rules on **water abstraction and effluent discharge**?
+- [ ] If I sell produce/fish: food-business registration, food-safety scheme, labelling?
+- [ ] Do the structures need a **building permit**, and does **zoning** allow food production?
+- [ ] If marketing as "organic": is soil-less produce eligible here?
+
+## What Agronaut does NOT do
+
+Agronaut does not track or enforce regulations, and its species/crop list reflects what the
+engineering model supports — **not** what is legal in your location. Always confirm with the
+relevant authority. See also `food_safety_and_hygiene`.
+
+_Sources: national aquaculture and invasive-species regulations; FAO legal-frameworks guidance
+(FAOLEX); local food-business and zoning rules; organic-certification standards._


### PR DESCRIPTION
Task 3.4 of docs/PLAN.md (Phase 3). Closes the open gap from the 2026-07 KB audit.

Four cited knowledge docs, the topics funder conversations and real operators need beyond water chemistry — and each is explicit about what Agronaut does *not* do:
- `economics_and_costs.md` — cost buckets, why systems lose money (energy + labour), what improves margins.
- `feasibility_and_business_case.md` — resource / operational / market feasibility; funder-facing pilot framing.
- `food_safety_and_hygiene.md` — pathogen hazards, keep-edible-parts-out-of-water, GAP for sale; not a HACCP substitute.
- `regulations_and_permits.md` — species legality (the sharpest trap), water/discharge, food-business, zoning, organic; a checklist, not legal advice.

TDD: 2 coverage tests first (docs exist + substantive + titled; carry citations). Full suite: 329 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak