### PR TITLE
feat(safety): advice-safety golden set (PLAN 4.1)

### DIFF
--- a/agronaut_agent/tests/test_safety_eval.py
+++ b/agronaut_agent/tests/test_safety_eval.py
@@ -1,0 +1,34 @@
+"""The advice-safety golden set runs hermetically (no LLM/network) and scores the
+deterministic advice surface Agronaut relays: trust-gate refusals, sizing sanity, and the
+honesty layer (cited sources + 'not modeled' on every design). A regression signal per
+release, per the Gates/GIZ AIEP golden-set recommendation.
+"""
+
+from scripts import safety_eval
+
+
+def test_golden_set_has_at_least_100_probes():
+    report = safety_eval.run()
+    assert report["total"] >= 100
+
+
+def test_all_critical_probes_pass_on_current_code():
+    report = safety_eval.run()
+    critical_failures = [f for f in report["failures"] if f["severity"] == "critical"]
+    assert critical_failures == [], critical_failures
+
+
+def test_report_is_scored_and_structured():
+    report = safety_eval.run()
+    assert set(report) >= {"total", "passed", "failed", "score", "failures", "by_category"}
+    assert 0.0 <= report["score"] <= 1.0
+    # trust-gate and honesty categories must be represented
+    assert "trust_gate" in report["by_category"]
+    assert "honesty" in report["by_category"]
+
+
+def test_trust_gate_probes_actually_reject():
+    # sanity: the eval would catch a broken trust gate (an unknown species must be refused)
+    report = safety_eval.run()
+    tg = report["by_category"]["trust_gate"]
+    assert tg["total"] > 0 and tg["passed"] == tg["total"]

--- a/docs/dpg/safety_eval/golden_set.json
+++ b/docs/dpg/safety_eval/golden_set.json
@@ -1,0 +1,41 @@
+{
+  "description": "Advice-safety golden set. Each probe exercises the deterministic advice surface (aqua_model tools) with expectations on the output. Hermetic: no LLM, no network. Severity 'critical' probes gate; 'warn' probes are informational.",
+  "probes": [
+    {"id": "tg-unknown-fish", "category": "trust_gate", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "shark", "crop": "lettuce", "area": 12, "temp": 27, "water": 3000},
+     "must_include": ["VALIDATION_FAILED"]},
+    {"id": "tg-unknown-crop", "category": "trust_gate", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "tilapia", "crop": "moonfruit", "area": 12, "temp": 27, "water": 3000},
+     "must_include": ["VALIDATION_FAILED"]},
+    {"id": "tg-negative-area", "category": "trust_gate", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "tilapia", "crop": "lettuce", "area": -5, "temp": 27, "water": 3000},
+     "must_include": ["VALIDATION_FAILED"]},
+    {"id": "tg-absurd-temp", "category": "trust_gate", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "tilapia", "crop": "lettuce", "area": 12, "temp": 99, "water": 3000},
+     "must_include": ["VALIDATION_FAILED"]},
+    {"id": "tg-hydro-unknown-crop", "category": "trust_gate", "severity": "critical",
+     "tool": "size_hydroponics", "args": {"crop": "unobtainium", "area": 10, "temp": 22, "water": 500},
+     "must_include": ["VALIDATION_FAILED"]},
+    {"id": "tg-optimize-bad-objective", "category": "trust_gate", "severity": "critical",
+     "tool": "optimize", "args": {"area": 10, "temp": 28, "water": 5000, "objective": "money"},
+     "must_include": ["Unknown objective"]},
+
+    {"id": "size-tilapia-lettuce", "category": "sizing", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "tilapia", "crop": "lettuce", "area": 12, "temp": 27, "water": 3000},
+     "must_include": ["FEASIBLE", "fish=", "feed="]},
+    {"id": "size-water-infeasible", "category": "sizing", "severity": "critical",
+     "tool": "size_aquaponics", "args": {"fish": "tilapia", "crop": "lettuce", "area": 500, "temp": 27, "water": 10},
+     "must_include": ["NOT FEASIBLE", "water_budget"]},
+
+    {"id": "hydro-lettuce", "category": "sizing", "severity": "critical",
+     "tool": "size_hydroponics", "args": {"crop": "lettuce", "area": 10, "temp": 22, "water": 500},
+     "must_include": ["FEASIBLE hydroponic", "EC", "reservoir"]},
+    {"id": "hydro-no-fish", "category": "honesty", "severity": "critical",
+     "tool": "size_hydroponics", "args": {"crop": "tomato", "area": 8, "temp": 24, "water": 500},
+     "must_exclude": ["feed=", "biofilter"]},
+
+    {"id": "optimize-food", "category": "sizing", "severity": "warn",
+     "tool": "optimize", "args": {"area": 10, "temp": 28, "water": 5000, "objective": "food"},
+     "must_include": ["Best ratio"]}
+  ]
+}

--- a/scripts/safety_eval.py
+++ b/scripts/safety_eval.py
@@ -1,0 +1,120 @@
+"""Advice-safety golden-set scorer — hermetic (no LLM, no network).
+
+Scores the deterministic advice surface Agronaut relays: trust-gate refusals, sizing sanity,
+and the honesty layer (every design cites its coefficients and lists what it does NOT model).
+Combines curated probes (docs/dpg/safety_eval/golden_set.json) with a generated matrix over
+every supported species x crop, so a regression in the engine or serializer shows up as a
+failed probe. This is the Gates/GIZ AIEP-recommended golden-set check, adapted to a
+deterministic core we can score in CI without a model server.
+
+Run standalone for a scorecard:
+    python -m scripts.safety_eval          # exits non-zero if any CRITICAL probe fails
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agronaut_agent.tools import (  # noqa: E402
+    size_aquaponics_system, size_hydroponic_system_tool, optimize_fish_crop_ratio,
+)
+from aqua_model.species import SPECIES  # noqa: E402
+from aqua_model.crops import CROPS  # noqa: E402
+
+_GOLDEN = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "safety_eval" / "golden_set.json"
+
+
+def _invoke(tool: str, args: dict) -> str:
+    if tool == "size_aquaponics":
+        return size_aquaponics_system.invoke({
+            "fish_species": args["fish"], "crop": args["crop"],
+            "grow_area_m2": args["area"], "temperature_c": args["temp"],
+            "water_budget_lpd": args["water"]})
+    if tool == "size_hydroponics":
+        return size_hydroponic_system_tool.invoke({
+            "crop": args["crop"], "grow_area_m2": args["area"],
+            "temperature_c": args["temp"], "water_budget_lpd": args["water"]})
+    if tool == "optimize":
+        return optimize_fish_crop_ratio.invoke({
+            "grow_area_m2": args["area"], "temperature_c": args["temp"],
+            "water_budget_lpd": args["water"], "objective": args.get("objective", "food")})
+    raise ValueError(f"unknown probe tool {tool!r}")
+
+
+def _check(probe: dict) -> tuple[bool, str]:
+    out = _invoke(probe["tool"], probe["args"])
+    for s in probe.get("must_include", []):
+        if s not in out:
+            return False, f"missing {s!r}"
+    for s in probe.get("must_exclude", []):
+        if s in out:
+            return False, f"unexpected {s!r}"
+    return True, ""
+
+
+def _curated_probes() -> list[dict]:
+    return json.loads(_GOLDEN.read_text())["probes"]
+
+
+def _generated_probes() -> list[dict]:
+    """One honesty+sizing probe per (species, crop): with a generous water budget every design
+    must be FEASIBLE, cite its coefficients, and list what it does NOT model. Plus one
+    hydroponic honesty probe per crop."""
+    probes = []
+    crops = sorted(CROPS)
+    for fish in sorted(SPECIES):
+        for crop in crops:
+            probes.append({
+                "id": f"gen-aqua-{fish}-{crop}", "category": "honesty", "severity": "critical",
+                "tool": "size_aquaponics",
+                "args": {"fish": fish, "crop": crop, "area": 10, "temp": 26, "water": 1_000_000},
+                "must_include": ["FEASIBLE", "source:", "NOT modeled"]})
+    for crop in crops:
+        probes.append({
+            "id": f"gen-hydro-{crop}", "category": "honesty", "severity": "critical",
+            "tool": "size_hydroponics",
+            "args": {"crop": crop, "area": 10, "temp": 22, "water": 1_000_000},
+            "must_include": ["FEASIBLE hydroponic", "source:", "NOT modeled"]})
+    return probes
+
+
+def run() -> dict:
+    probes = _curated_probes() + _generated_probes()
+    failures, by_cat = [], {}
+    passed = 0
+    for p in probes:
+        cat = by_cat.setdefault(p["category"], {"total": 0, "passed": 0})
+        cat["total"] += 1
+        ok, reason = _check(p)
+        if ok:
+            passed += 1
+            cat["passed"] += 1
+        else:
+            failures.append({"id": p["id"], "category": p["category"],
+                             "severity": p["severity"], "reason": reason})
+    total = len(probes)
+    return {
+        "total": total, "passed": passed, "failed": total - passed,
+        "score": round(passed / total, 4) if total else 1.0,
+        "failures": failures, "by_category": by_cat,
+    }
+
+
+def main() -> int:
+    r = run()
+    print(f"Advice-safety golden set: {r['passed']}/{r['total']} passed "
+          f"(score {r['score']:.3f})")
+    for cat, s in sorted(r["by_category"].items()):
+        print(f"  {cat:12s} {s['passed']}/{s['total']}")
+    critical = [f for f in r["failures"] if f["severity"] == "critical"]
+    for f in r["failures"]:
+        print(f"  FAIL [{f['severity']}] {f['id']} ({f['category']}): {f['reason']}")
+    return 1 if critical else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Task 4.1 of docs/PLAN.md (Phase 4) — the evidence artifact funders ask for first.

191 probes scoring Agronaut's deterministic advice surface, hermetically (no LLM, no network — runs in CI):
- **trust_gate** (6): unknown species/crop, out-of-range, bad objective → must be refused.
- **sizing** (4): feasible + infeasible cases produce the right verdict.
- **honesty** (181): every design across *all* species × crops must be FEASIBLE with a generous budget, **cite its coefficients**, and **list what it does NOT model** — a regression in the engine or serializer trips a probe.

Curated probes live in `docs/dpg/safety_eval/golden_set.json`; `scripts/safety_eval.py` adds the generated matrix, prints a scorecard, and exits non-zero on any CRITICAL failure. The test suite runs it (`test_all_critical_probes_pass`), so critical regressions gate; non-critical stays a report. This is the Gates/GIZ AIEP golden-set recommendation adapted to a core we can score without a model server.

Current: **191/191 passed (score 1.000)**. TDD: 4 tests first. Full suite: 333 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak