### PR TITLE
feat(analytics): privacy-preserving usage analytics (PLAN 4.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ data/raw/
 .idea/
 .vscode/
 *.swp
+data/*.jsonl

--- a/agronaut_agent/analytics.py
+++ b/agronaut_agent/analytics.py
@@ -1,0 +1,93 @@
+"""Privacy-preserving usage analytics.
+
+Records COUNTS and FUNNELS, never message content. By construction the only fields that can
+be written are an event name, a truncated hash of the user id (so distinct users can be
+counted without knowing who they are), a coarse date, and a small allowlist of non-PII
+metadata (e.g. which tool was called). Free-text kwargs are silently dropped — content
+cannot leak even if a caller passes it.
+
+Local-only: appends to a JSONL file on the operator's machine; nothing is sent anywhere.
+Disable entirely with AGRONAUT_ANALYTICS=off. Consistent with docs/dpg/PRIVACY.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Only these metadata keys are ever persisted alongside an event — anything else (notably
+# anything that could carry message content) is dropped.
+_ALLOWED_FIELDS = {"tool", "goal", "channel", "ok"}
+
+_SIZING_TOOLS = {"size_aquaponics_system", "size_hydroponic_system_tool"}
+
+_DEFAULT_PATH = Path(__file__).resolve().parent.parent / "data" / "analytics.jsonl"
+
+
+def _hash_uid(user_id: str) -> str:
+    return hashlib.sha256(str(user_id).encode()).hexdigest()[:12]
+
+
+class Analytics:
+    def __init__(self, path=None):
+        self.path = Path(path) if path else Path(os.getenv("AGRONAUT_ANALYTICS_PATH", _DEFAULT_PATH))
+
+    @property
+    def enabled(self) -> bool:
+        return os.getenv("AGRONAUT_ANALYTICS", "").lower() not in {"off", "0", "false"}
+
+    def record(self, event: str, user_id: str | None = None, **fields) -> None:
+        if not self.enabled:
+            return
+        row = {
+            "event": str(event),
+            "uid": _hash_uid(user_id) if user_id is not None else None,
+            "date": datetime.now(timezone.utc).date().isoformat(),  # date only — no fine tracking
+        }
+        for k, v in fields.items():
+            if k in _ALLOWED_FIELDS:
+                row[k] = v
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(row) + "\n")
+        except Exception:  # analytics must never break a live turn
+            pass
+
+    def summarize(self) -> dict:
+        events: dict[str, int] = {}
+        users: set[str] = set()
+        sized_users: set[str] = set()
+        if self.path.exists():
+            for line in self.path.read_text().splitlines():
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                events[r["event"]] = events.get(r["event"], 0) + 1
+                if r.get("uid"):
+                    users.add(r["uid"])
+                    if r["event"] == "tool_call" and r.get("tool") in _SIZING_TOOLS:
+                        sized_users.add(r["uid"])
+        return {
+            "events": events,
+            "distinct_users": len(users),
+            "users_who_sized": len(sized_users),
+        }
+
+
+def main() -> int:  # pragma: no cover - CLI convenience
+    s = Analytics().summarize()
+    print(f"Distinct users: {s['distinct_users']}")
+    print(f"Users who sized a system: {s['users_who_sized']}")
+    print("Events:")
+    for ev, n in sorted(s["events"].items(), key=lambda kv: -kv[1]):
+        print(f"  {ev:16s} {n}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -132,6 +132,10 @@ class AgronautAgent:
             from agent import transcribe
             transcribe_fn = transcribe.default_transcriber()
         self._transcribe = transcribe_fn
+        # Privacy-preserving usage analytics (counts/funnels, no content). Local-only;
+        # AGRONAUT_ANALYTICS=off disables. Injectable path for tests via env.
+        from .analytics import Analytics
+        self._analytics = Analytics()
 
     # --- context assembly -------------------------------------------------
     def _build_context(self, user_id: str, query: str | None = None) -> list:
@@ -211,6 +215,8 @@ class AgronautAgent:
                         result = tool.invoke(call["args"])
                     except Exception as exc:  # fed back so the model can correct; never hidden
                         result = f"TOOL_ERROR: {exc}"
+                self._analytics.record("tool_call", user_id=user_id, tool=call["name"],
+                                       ok=not str(result).startswith("TOOL_ERROR"))
                 self._conv.append_message(user_id, "tool", result, tool_name=call["name"])
                 captured = profile.profile_updates_from_tool(call["name"], call["args"], result)
                 if captured:
@@ -232,6 +238,7 @@ class AgronautAgent:
     # --- the single public seam ------------------------------------------
     def handle_message(self, channel: str, channel_user: str, text: str, display_name: str | None = None) -> str:
         user_id = self._conv.get_or_create_user(channel, channel_user, display_name)
+        self._analytics.record("message", user_id=user_id, channel=channel)
         self._mem.set_facts(user_id, memory_extract.extract_facts(text), source="parsed")
         self._conv.append_message(user_id, "user", text)
 
@@ -267,6 +274,8 @@ class AgronautAgent:
         """A photo arrives: the VLM produces a plain-language visual observation, which is
         then run through the NORMAL text turn — so memory, the trust-gated tools, and cited
         knowledge all still apply. The vision model never calls tools or emits numbers."""
+        self._analytics.record("image", user_id=self._conv.get_or_create_user(channel, channel_user),
+                               channel=channel)
         if self._describe is None:
             return ("I can't look at images yet — but describe what you see (leaf colour, "
                     "fish behaviour, water look) and I'll help from there.")
@@ -289,6 +298,8 @@ class AgronautAgent:
         """A voice note arrives: transcribe it, then run the transcript through the NORMAL
         text turn. The transcript IS the user's message, so everything (memory, tools, cited
         knowledge, reply-in-user-language) applies unchanged."""
+        self._analytics.record("voice", user_id=self._conv.get_or_create_user(channel, channel_user),
+                               channel=channel)
         if self._transcribe is None:
             return ("I can't listen to voice notes yet — type your message and I'll help "
                     "right away.")
@@ -364,6 +375,7 @@ class AgronautAgent:
             raise ValueError(f"unknown goal {goal!r}")
         user_id = self._conv.get_or_create_user(channel, channel_user)
         self._mem.set_fact(user_id, "goal", g, source="user_stated")
+        self._analytics.record("goal_set", user_id=user_id, goal=g)
         facts = self._mem.get_facts(user_id)
         return f"{profile.GOAL_HEADERS[g]}. {profile.essentials_hint(g, facts)}"
 

--- a/agronaut_agent/tests/test_analytics.py
+++ b/agronaut_agent/tests/test_analytics.py
@@ -1,0 +1,65 @@
+"""Privacy-preserving usage analytics: counts and funnels, never message content. User ids
+are stored only as a truncated hash (distinct-user counts without knowing who), and the API
+structurally cannot record free text. Disabled with AGRONAUT_ANALYTICS=off.
+"""
+
+import json
+
+from agronaut_agent.analytics import Analytics
+
+
+def test_records_events_without_raw_user_id_or_content(tmp_path):
+    a = Analytics(path=tmp_path / "a.jsonl")
+    a.record("message", user_id="telegram:12345")
+    a.record("tool_call", user_id="telegram:12345", tool="size_aquaponics_system")
+
+    rows = [json.loads(ln) for ln in (tmp_path / "a.jsonl").read_text().splitlines()]
+    assert len(rows) == 2
+    for r in rows:
+        # the raw id never appears; only a short hash
+        assert "12345" not in json.dumps(r)
+        assert "telegram:12345" not in json.dumps(r)
+        assert len(r["uid"]) <= 16 and r["uid"] != "telegram:12345"
+    assert rows[1]["tool"] == "size_aquaponics_system"   # event metadata is fine, content isn't
+
+
+def test_same_user_hashes_stably_for_distinct_counts(tmp_path):
+    a = Analytics(path=tmp_path / "a.jsonl")
+    a.record("message", user_id="u1")
+    a.record("message", user_id="u1")
+    a.record("message", user_id="u2")
+    rows = [json.loads(ln) for ln in (tmp_path / "a.jsonl").read_text().splitlines()]
+    uids = {r["uid"] for r in rows}
+    assert len(uids) == 2                                 # u1 collapses, u2 distinct
+
+
+def test_summarize_reports_counts_and_distinct_users(tmp_path):
+    a = Analytics(path=tmp_path / "a.jsonl")
+    a.record("message", user_id="u1")
+    a.record("tool_call", user_id="u1", tool="size_aquaponics_system")
+    a.record("message", user_id="u2")
+    a.record("image", user_id="u2")
+
+    s = a.summarize()
+    assert s["events"]["message"] == 2
+    assert s["events"]["tool_call"] == 1
+    assert s["events"]["image"] == 1
+    assert s["distinct_users"] == 2
+    # funnel: users who reached a sizing tool
+    assert s["users_who_sized"] == 1
+
+
+def test_disabled_by_env_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGRONAUT_ANALYTICS", "off")
+    a = Analytics(path=tmp_path / "a.jsonl")
+    a.record("message", user_id="u1")
+    assert not (tmp_path / "a.jsonl").exists()
+    assert a.summarize()["distinct_users"] == 0
+
+
+def test_record_ignores_unknown_freetext_kwargs_defensively(tmp_path):
+    # content must never leak in even if a caller passes it — only allowlisted fields persist
+    a = Analytics(path=tmp_path / "a.jsonl")
+    a.record("message", user_id="u1", text="my secret farm location", note="pii here")
+    blob = (tmp_path / "a.jsonl").read_text()
+    assert "secret farm" not in blob and "pii here" not in blob

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+"""Test-session setup shared across the suite."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_analytics(monkeypatch):
+    """Keep usage-analytics writes out of the repo's data/ dir during tests. Agents built
+    without an explicit analytics path would otherwise append to data/analytics.jsonl; point
+    that at a throwaway temp file. Analytics unit tests pass an explicit path and are
+    unaffected."""
+    tmp = Path(tempfile.gettempdir()) / "agronaut_test_analytics.jsonl"
+    monkeypatch.setenv("AGRONAUT_ANALYTICS_PATH", str(tmp))

--- a/docs/dpg/PRIVACY.md
+++ b/docs/dpg/PRIVACY.md
@@ -52,6 +52,10 @@ Reachable directly from chat at any time:
 
 - Data is stored in a single local SQLite database on the operator's own machine/server.
   There is no central Agronaut server and no third-party analytics on your content.
+- The operator may keep **local usage analytics** — event counts and funnels only (e.g. how
+  many messages, how many designs). These are content-free by construction: no message text
+  is recorded, and user ids are stored only as a truncated one-way hash, so distinct users
+  can be counted without identifying anyone. Disable with `AGRONAUT_ANALYTICS=off`.
 - Data is retained until you delete it. An operator deployment may set its own retention
   window; this reference build retains until erasure is requested.
 - Access control: on Telegram/WhatsApp an allowlist restricts who can use a given


### PR DESCRIPTION
Task 4.2 of docs/PLAN.md (Phase 4) — the last buildable task.

Content-free usage analytics: counts and funnels, never message content.
- **Privacy by construction:** the API only persists an event name, a truncated SHA-256 hash of the user id (distinct-user counts without knowing who), a date (no fine-grained time), and an allowlist of non-PII fields (`tool`, `goal`, `channel`, `ok`). Free-text kwargs are dropped even if a caller passes them — tested.
- Wired into `handle_message`, the tool loop, `handle_image`, `handle_voice`, and `set_goal`. `summarize()` reports event counts, distinct users, and a 'users who sized a system' funnel.
- Local JSONL only; nothing sent anywhere. `AGRONAUT_ANALYTICS=off` kills it. Consistent with docs/dpg/PRIVACY.md (updated). A session `conftest.py` keeps analytics writes out of the repo during tests.

TDD: 5 tests first (no raw id/content in records, stable hashing for distinct counts, summarize funnel, env-disable, defensive free-text drop). Full suite: 338 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak