### PR TITLE
fix(deploy): CPU-only torch keeps the Docker image lean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python deps first for layer caching.
+# Install CPU-only torch FIRST, from PyTorch's CPU wheel index. sentence-transformers pulls
+# torch transitively, and the default Linux wheel drags in a multi-GB CUDA stack (cuBLAS,
+# cuDNN, NCCL…) this app never uses. Pinning the CPU build keeps the image lean and the
+# build fast — right for a small VPS. The later `pip install -r` then sees torch satisfied.
+RUN pip install --index-url https://download.pytorch.org/whl/cpu torch
+
+# Install the rest of the Python deps (layer cached on requirement.txt).
 COPY requirement.txt ./
 RUN pip install -r requirement.txt
 


### PR DESCRIPTION
Follow-up to #50 (Docker).

A pip `--dry-run` resolve of `requirement.txt` (the daemon-free way to de-risk the build's riskiest layer) confirmed it resolves cleanly on Python 3.12 — but showed `sentence-transformers` → `torch` pulls the full **CUDA** wheel stack (cuBLAS, cuDNN, NCCL, …), which would make the image multiple GB and slow to build. This app does no GPU inference, so the Dockerfile now installs **CPU-only torch** from PyTorch's CPU index before `requirement.txt`; the later install sees torch satisfied and skips the CUDA wheels. Right for the '$5 VPS, one-command deploy' goal.

Dockerfile-only change → test suite unaffected (338 passing).

**Note:** a live `docker build` still couldn't run in my environment — no Docker daemon, no host socket, and rootless Docker is blocked by missing setuid `newuidmap`/`newgidmap` (installable only by root). Build verification needs a machine with Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak