### PR TITLE
fix(deploy): keep safety-eval data in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,7 @@ data/
 .superpowers/
 .pytest_cache/
 docs/
+# keep the advice-safety golden-set data — scripts/safety_eval.py loads it at runtime
+!docs/dpg/safety_eval/
 *.md
 !README.md


### PR DESCRIPTION
Caught by an actual `docker compose build` + in-container smoke test (the verification that couldn't run before Docker was installed).

`scripts/safety_eval.py` ships in the runtime image (`scripts/` isn't excluded), but its data file `docs/dpg/safety_eval/golden_set.json` was dropped by the `docs/` rule in `.dockerignore` — so `python -m scripts.safety_eval` inside the container crashed with `FileNotFoundError`. Whitelisted that one small data dir.

**Live build verification (all passing):**
- `docker compose build web` → `agronaut:latest`, **3.3 GB** (the CPU-torch fix from #58 kept the CUDA stack out — would've been ~6 GB otherwise).
- Web container: Streamlit serves **HTTP 200** on `/_stcore/health` and `/`.
- Deterministic engine in-container: `size-aquaponics` returns a correct cited design.
- Advice-safety golden set in-container: **191/191** after this fix.
- All entrypoints (`app`, `bot`, `AgronautAgent`, `WhatsAppAdapter`) import cleanly.

Config-only change → test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak