### PR TITLE
docs(dpg): draft the actual DPG registry submission

### DIFF
--- a/docs/dpg/DPG_EVIDENCE.md
+++ b/docs/dpg/DPG_EVIDENCE.md
@@ -18,6 +18,10 @@ submission. Status: **draft — owner to review before submitting.**
 | 8 | **Standards & best practices** | ✅ | Open standards: OpenAI-compatible API, WhatsApp Cloud API, sentence-transformers; TDD with a 300+ test suite; cited engineering model; CI on push/PR. |
 | 9 | **Do no harm by design** | ✅ | Trust gate rejects unvalidated input; every quantitative answer cites sources + lists what is NOT modeled; LLM forbidden from inventing numbers; community sharing is human-gated + PII-stripped; advice-safety golden set scored each release. See `docs/dpg/AI_TRANSPARENCY.md`. |
 
+> **Ready to submit:** the paste-ready nomination answers and a structured nominee record are
+> in [`submission/`](submission/SUBMISSION.md) — the owner confirms a few `[CONFIRM]` fields
+> (contact, copyright holder) and submits.
+
 ## Submission checklist (owner actions)
 
 - [ ] Confirm SDG target selection with a domain reviewer.

--- a/docs/dpg/submission/SUBMISSION.md
+++ b/docs/dpg/submission/SUBMISSION.md
@@ -1,0 +1,125 @@
+# DPG Registry Submission — Agronaut (paste-ready)
+
+_Prepared 2026-07-25. **Status: ready for the owner to submit.** These are the actual
+answers for the Digital Public Goods Alliance nomination. Submitting is an outward-facing
+action left to the owner — see "How to submit" at the end._
+
+Two ways in (pick one):
+- The **guided eligibility form** at <https://www.digitalpublicgoods.net/submission-guide> —
+  paste the answers below.
+- A **nomination PR** to <https://github.com/DPGAlliance/publicgoods-candidates> — use
+  [`nominee.json`](nominee.json) in this folder as the starting record.
+
+Before submitting, the owner should confirm the fields marked **[CONFIRM]** (contact,
+copyright holder, organization name) — only the owner can speak to those.
+
+---
+
+## Basic information
+
+- **Name:** Agronaut
+- **Short description:** An open-source (MIT) conversational agronomy agent for aquaponics
+  and hydroponics. A deterministic, unit-tested engineering core sizes and optimizes
+  soil-less food systems and produces cited designs; a pluggable open-weights language model
+  collects facts, routes to the right tool, and explains results in plain language. Reachable
+  on Telegram, WhatsApp, and the web, in text, photo, or voice.
+- **Website / repository:** <https://github.com/Rekin226/Agronaut>
+- **Type:** Software
+- **Sectors:** Agriculture; Food & Agriculture; Climate/Environment (water-use efficiency).
+- **Owner / organization:** [CONFIRM — individual maintainer or organization name + contact]
+
+---
+
+## Indicator 1 — Relevance to the SDGs
+
+- **SDG 2 (Zero Hunger), targets 2.3 / 2.4.** Agronaut lowers the barrier to running a
+  productive aquaponic or hydroponic food system: it turns trial-and-error into a sized,
+  cited design (fish count, feed, grow area, bill of materials, operating envelope) and its
+  optimizer maximizes food or protein under a smallholder's binding constraint.
+  Evidence: `README.md`, `aqua_model/`, `docs/dpg/SDG_MAPPING.md`.
+- **SDG 6 (Clean Water), target 6.4.** Recirculating systems reuse water; the optimizer can
+  maximize water-use efficiency directly, and a water-balance check tests every design
+  against a fixed daily water budget — central for water-scarce and arid deployments.
+- **SDG 12 (Responsible Consumption), target 12.2.** An independent nitrogen consistency
+  check flags over-sizing, steering operators away from wasted feed, water, and materials.
+- Evidence URL: <https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/SDG_MAPPING.md>
+
+## Indicator 2 — Use of an approved open licence
+
+- **Licence:** MIT (on the DPGA-approved list).
+- Evidence: <https://github.com/Rekin226/Agronaut/blob/main/LICENSE>
+
+## Indicator 3 — Clear ownership
+
+- Ownership is explicit in the repository and `LICENSE`.
+- **[CONFIRM]** copyright holder name and a copyright/ownership URL.
+
+## Indicator 4 — Platform independence
+
+- No mandatory closed-source dependency. The tool-calling assistant runs on **self-hosted
+  open-weights models** via `LLM_PROVIDER=openai_compat` (vLLM / llama.cpp / LM Studio), and
+  the deterministic design and optimizer modes need **no LLM at all**. Channels are
+  abstracted (`ChannelAdapter`: Telegram, WhatsApp, REPL); a test enforces that the agent
+  core imports no proprietary channel SDK.
+- Evidence: `agent/llm.py` (openai_compat provider), `README.md` "self-hosted, no vendor",
+  `agronaut_agent/channels/`, `agronaut_agent/tests/test_channels.py`.
+
+## Indicator 5 — Documentation
+
+- README (install, providers, channels, deployment), `docs/PLAN.md`, `docs/dpg/*`,
+  in-code docstrings, and a 344-test suite that documents behavior.
+- Evidence URL: <https://github.com/Rekin226/Agronaut/tree/main/docs>
+
+## Indicator 6 — Mechanism for extracting data (non-proprietary format)
+
+- A user can export **all** of their data as open JSON in-chat with `/export`; erase it with
+  `/delete_me`. Storage is SQLite (open format).
+- Evidence: `agronaut_agent/core.py` (`export_user_data`, `delete_me`),
+  `agronaut_agent/tests/test_data_rights.py`.
+
+## Indicator 7 — Adherence to privacy and applicable laws
+
+- Privacy & data policy covers collection, purpose limitation, retention, access control,
+  consent, and the right to erasure. Data minimization by design; **no training on user
+  data**. Usage analytics is content-free (hashed ids, counts only).
+- Evidence: <https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/PRIVACY.md>
+
+## Indicator 8 — Adherence to standards & best practices
+
+- Open standards: OpenAI-compatible API, WhatsApp Cloud API, sentence-transformers,
+  agentskills.io. Engineering: test-driven development, a 344-test suite, cited coefficients
+  (FAO 589, UVI/Rakocy), and a per-release advice-safety golden set.
+- Evidence: `docs/dpg/AI_TRANSPARENCY.md`, `docs/dpg/safety_eval/`, `skills/aquaponics-engineer/`.
+
+## Indicator 9 — Do no harm by design
+
+- A validation gate rejects unvalidated input before any calculation; every quantitative
+  answer cites its source coefficients and lists what it does **not** model; the LLM is
+  forbidden from inventing numbers. Cross-operator knowledge sharing is human-gated and
+  PII-stripped. An advice-safety golden set (191 probes) is scored each release.
+- **AI-specific transparency:** trains no models; retrieval draws only from cited public
+  sources, each surfaced with its `[source:]` label.
+- Evidence: <https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/AI_TRANSPARENCY.md>,
+  `aqua_model/validate.py`, `scripts/safety_eval.py`.
+
+---
+
+## Positioning note (for the reviewer / FAO–DPGA CoP)
+
+Agronaut is, to our knowledge, the first MIT-licensed **digital implementation of FAO
+Fisheries & Aquaculture Technical Paper 589** — it makes that manual's small-scale
+aquaponic sizing computable, cited, and calibratable. Its deterministic, source-cited core
+directly addresses the concern funders raise about LLM farm advice ("wrong advice harms
+farmers"): the advice is verifiable and safety-checked each release.
+
+## How to submit (owner action)
+
+1. Confirm the **[CONFIRM]** fields above (contact, copyright holder, organization).
+2. Ensure `docs/dpg/PRIVACY.md` is reachable at its public repo URL (it is).
+3. Submit via the guided form (<https://www.digitalpublicgoods.net/submission-guide>) **or**
+   open a nomination PR on `DPGAlliance/publicgoods-candidates` using `nominee.json`.
+4. Optionally introduce Agronaut to the FAO–DPGA food-security community of practice using
+   the positioning note above.
+
+> Everything needed is prepared and in-repo. The act of submitting — an outward-facing step
+> that publicly commits the project — is intentionally left to the owner.

--- a/docs/dpg/submission/nominee.json
+++ b/docs/dpg/submission/nominee.json
@@ -1,0 +1,57 @@
+{
+  "name": "Agronaut",
+  "aliases": [],
+  "description": "An open-source conversational agronomy agent for aquaponics and hydroponics. A deterministic, unit-tested engineering core sizes and optimizes soil-less food systems and produces cited designs; a pluggable open-weights language model collects facts, routes to the right tool, and explains results. Reachable on Telegram, WhatsApp, and the web, in text, photo, or voice.",
+  "website": "https://github.com/Rekin226/Agronaut",
+  "license": [
+    { "spdx": "MIT", "licenseURL": "https://github.com/Rekin226/Agronaut/blob/main/LICENSE" }
+  ],
+  "SDGs": [
+    { "SDGNumber": 2, "evidenceText": "Sizes and optimizes productive aquaponic/hydroponic food systems for smallholders (targets 2.3, 2.4).", "evidenceURL": "https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/SDG_MAPPING.md" },
+    { "SDGNumber": 6, "evidenceText": "Optimizes water-use efficiency and checks designs against a fixed daily water budget (target 6.4).", "evidenceURL": "https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/SDG_MAPPING.md" },
+    { "SDGNumber": 12, "evidenceText": "An independent nitrogen consistency check flags over-sizing, reducing wasted feed/water/materials (target 12.2).", "evidenceURL": "https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/SDG_MAPPING.md" }
+  ],
+  "sectors": ["Agriculture"],
+  "type": ["software"],
+  "repositoryURL": "https://github.com/Rekin226/Agronaut",
+  "organizations": [
+    { "name": "[CONFIRM — maintainer or organization name]", "website": "https://github.com/Rekin226/Agronaut", "org_type": "owner", "contact_name": "[CONFIRM]", "contact_email": "[CONFIRM]" }
+  ],
+  "stage": "nominee",
+  "clearOwnership": {
+    "isOwnershipExplicit": "Yes",
+    "copyrightURL": "https://github.com/Rekin226/Agronaut/blob/main/LICENSE"
+  },
+  "platformIndependence": {
+    "mandatoryDepsCreatePlatformDependency": "No",
+    "isSupportingIndependence": "Yes",
+    "evidenceText": "Tool-calling assistant runs on self-hosted open-weights via LLM_PROVIDER=openai_compat; deterministic design/optimizer modes need no LLM; channels are abstracted (Telegram/WhatsApp/REPL), enforced by test.",
+    "evidenceURL": "https://github.com/Rekin226/Agronaut/blob/main/agronaut_agent/tests/test_channels.py"
+  },
+  "documentation": {
+    "isDocumentationAvailable": "Yes",
+    "documentationURL": "https://github.com/Rekin226/Agronaut/tree/main/docs"
+  },
+  "extractingData": {
+    "isDataExtractable": "Yes",
+    "dataExtractableText": "Users export all their data as open JSON in-chat via /export; erase it via /delete_me. Storage is SQLite.",
+    "dataExtractableURL": "https://github.com/Rekin226/Agronaut/blob/main/agronaut_agent/tests/test_data_rights.py"
+  },
+  "adherenceToPrivacyLaws": {
+    "isForNAPrivacyPolicy": "No",
+    "privacyPolicyURL": "https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/PRIVACY.md",
+    "evidenceText": "Documented policy: collection, purpose limitation, retention, access control, consent, right to erasure; data minimization; no training on user data; content-free analytics."
+  },
+  "adherenceToStandards": {
+    "evidenceText": "OpenAI-compatible API, WhatsApp Cloud API, sentence-transformers, agentskills.io; TDD with a 344-test suite; cited coefficients (FAO 589, UVI/Rakocy); a per-release advice-safety golden set.",
+    "evidenceURL": "https://github.com/Rekin226/Agronaut/tree/main/docs/dpg/safety_eval"
+  },
+  "doNoHarm": {
+    "harmMitigationText": "A validation gate rejects unvalidated input; every quantitative answer cites its source coefficients and lists what is NOT modeled; the LLM is forbidden from inventing numbers; cross-operator sharing is human-gated and PII-stripped; a 191-probe advice-safety golden set is scored each release.",
+    "PIICollected": "Yes",
+    "PIICollectedText": "Only user-provided system facts and conversation; stored locally; user-erasable via /delete_me. No training on user data.",
+    "aiEthicsText": "Trains no models. Retrieval draws only from cited public sources, each surfaced with its [source:] label. See docs/dpg/AI_TRANSPARENCY.md.",
+    "evidenceURL": "https://github.com/Rekin226/Agronaut/blob/main/docs/dpg/AI_TRANSPARENCY.md"
+  },
+  "_note": "Field names follow the DPG Standard indicators; reconcile exact keys with the current DPGAlliance/publicgoods-candidates JSON schema at submission time. [CONFIRM] values require the owner."
+}


### PR DESCRIPTION
The #1 move from the gap analysis, drafted and saved so submitting is a few minutes of owner review.

`docs/dpg/submission/`:
- **SUBMISSION.md** — paste-ready answers for all nine DPG Standard indicators, each tied to concrete in-repo evidence (SDG mapping, MIT licence, openai_compat platform independence, /export + /delete_me, PRIVACY.md, the safety golden set, AI_TRANSPARENCY), plus the FAO-589 positioning note and a step-by-step how-to for either the guided eligibility form or a nomination PR to `DPGAlliance/publicgoods-candidates`.
- **nominee.json** — a structured candidate record matching the DPG Standard fields (validated JSON), ready to seed a candidates-repo PR.

Only `[CONFIRM]` fields remain — contact, copyright holder, organization name — which only the owner can supply. **Submission itself is left to the owner** (outward-facing action that publicly commits the project).

Docs only → suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak