### PR TITLE
feat: selectable growing method — the design adapts to preference

### DIFF
--- a/agent/calculator_ui.py
+++ b/agent/calculator_ui.py
@@ -106,6 +106,10 @@ def render_calculator() -> None:
             grow_area = st.number_input("Grow area (m²)", min_value=0.1, value=6.0, step=0.5)
             temperature = st.number_input("Mean water temp (°C)", min_value=0.0, max_value=45.0, value=26.0, step=0.5)
             water_budget = st.number_input("Water budget (L/day)", min_value=0.0, value=200.0, step=10.0)
+            system_type = st.selectbox(
+                "Growing method", facts.available_system_types(),
+                help="raft/DWC (forgiving, more water), NFT (light, low water, needs reliable "
+                     "power), or media bed (robust, also biofilters).")
         submitted = st.form_submit_button("Size system", use_container_width=True)
 
     if not submitted:
@@ -116,6 +120,7 @@ def render_calculator() -> None:
         design = facts.design_from_form(
             fish_species=species, crop=crop, grow_area_m2=grow_area,
             temperature_c=temperature, water_budget_lpd=water_budget,
+            system_type=system_type,
         )
     except facts.ValidationError as err:
         st.error("Invalid inputs:\n" + "\n".join(f"- {e}" for e in err.errors))

--- a/agent/facts.py
+++ b/agent/facts.py
@@ -25,6 +25,11 @@ def available_crops() -> list[str]:
     return sorted(CROPS)
 
 
+def available_system_types() -> list[str]:
+    from aqua_model.system_types import SYSTEM_TYPES
+    return list(SYSTEM_TYPES)
+
+
 def design_from_form(
     fish_species: str,
     crop: str,
@@ -32,6 +37,7 @@ def design_from_form(
     temperature_c: float,
     water_budget_lpd: float,
     source_water_note: str | None = None,
+    system_type: str = "raft",
 ) -> DesignInput:
     """Validate structured form values into a DesignInput. Raises ValidationError on bad input.
 
@@ -44,12 +50,14 @@ def design_from_form(
         temperature_c=temperature_c,
         water_budget_lpd=water_budget_lpd,
         source_water_note=source_water_note,
+        system_type=system_type,
     )
 
 
 __all__ = [
     "available_species",
     "available_crops",
+    "available_system_types",
     "design_from_form",
     "ValidationError",
 ]

--- a/agent/tests/test_calculator_ui.py
+++ b/agent/tests/test_calculator_ui.py
@@ -16,7 +16,7 @@ def test_calculator_renders_form():
     at = AppTest.from_string(_APP).run(timeout=30)
     assert not at.exception
     assert "Design Calculator" in [s.value for s in at.subheader]
-    assert [sb.label for sb in at.selectbox] == ["Fish species", "Crop"]
+    assert [sb.label for sb in at.selectbox] == ["Fish species", "Crop", "Growing method"]
     assert len(at.number_input) == 3
 
 

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -52,6 +52,13 @@ YOU RUN A CONSULTATION, NOT A Q&A. Your job is to understand the person before y
 3. ANCHOR EVERY RECOMMENDATION to their stated goal and their system. Generic advice is a
    failure — tie the answer to what they told you (their species, area, budget, constraints).
 
+RESPECT THEIR PREFERENCES — the design is not one fixed template. The GROWING METHOD is
+theirs to choose: raft/deep-water culture (default, forgiving, more water), NFT (light, low
+water, needs reliable power), or media bed (robust, also biofilters). If the user expresses
+a preference or their situation points to one (e.g. unreliable power → not NFT; wants low
+water → NFT or media bed), pass system_type to the sizing/schematic tools. If they haven't
+said and it matters, briefly ask which they'd prefer rather than assuming.
+
 If the user asks to SEE, DRAW, or picture their system (a diagram/schematic), call
 render_system_schematic — it draws a labeled diagram and sends it to them as an image.
 

--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -27,7 +27,7 @@ def serialize_validation_error(errors: list[str]) -> str:
 def serialize_design_output(out: DesignOutput) -> str:
     lines: list[str] = []
     if out.feasible:
-        lines.append("FEASIBLE design.")
+        lines.append(f"FEASIBLE design ({out.grow_bed_label}).")
     else:
         lines.append(f"NOT FEASIBLE — binding constraint: {out.binding_constraint}.")
 
@@ -77,7 +77,7 @@ def serialize_design_output(out: DesignOutput) -> str:
 
 def serialize_hydroponic_output(out: HydroponicOutput) -> str:
     lines: list[str] = []
-    lines.append("FEASIBLE hydroponic design." if out.feasible
+    lines.append(f"FEASIBLE hydroponic design ({out.grow_bed_label})." if out.feasible
                  else f"NOT FEASIBLE — binding constraint: {out.binding_constraint}.")
     lines.append(
         "Sizing (no fish — nutrient solution): "

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -72,6 +72,25 @@ def test_hydroponic_tool_trust_gate_rejects_unknown_crop():
     assert "VALIDATION_FAILED" in out
 
 
+def test_size_tool_accepts_growing_method():
+    raft = size_aquaponics_system.invoke(
+        {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 20,
+         "temperature_c": 27, "water_budget_lpd": 5000, "system_type": "nft"})
+    assert "NFT" in raft or "nutrient film" in raft.lower()
+    # unknown method is rejected at the trust gate
+    bad = size_aquaponics_system.invoke(
+        {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 20,
+         "temperature_c": 27, "water_budget_lpd": 5000, "system_type": "sky-farm"})
+    assert "VALIDATION_FAILED" in bad
+
+
+def test_list_supported_includes_growing_methods():
+    out = list_supported_species_and_crops.invoke({})
+    assert "Growing methods" in out
+    for m in ("raft", "nft", "media_bed"):
+        assert m in out
+
+
 def test_size_trust_gate_rejects_unknown_species():
     out = size_aquaponics_system.invoke(
         {"fish_species": "shark", "crop": "lettuce", "grow_area_m2": 12,

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -70,6 +70,7 @@ def size_aquaponics_system(
     temperature_c: float,
     water_budget_lpd: float,
     source_water_note: str | None = None,
+    system_type: str = "raft",
 ) -> str:
     """Size ONE aquaponics system deterministically from fixed inputs. Returns tank,
     biofilter and pump sizing, fish count/biomass/feed, bill of materials, operating
@@ -79,15 +80,19 @@ def size_aquaponics_system(
     fish_species: one of tilapia, clarias, channel_catfish, trout, carp.
     crop: one of the supported crops (30+, from leafy greens and herbs to fruiting crops
         like tomato, cucumber, strawberry). Call list_supported_species_and_crops if unsure.
-    grow_area_m2: planted raft/DWC area (the anchor).
+    grow_area_m2: planted area (the anchor).
     temperature_c: mean water temperature.
     water_budget_lpd: makeup water available per day, litres.
     source_water_note: optional salinity/quality caveat.
+    system_type: the GROWING METHOD, matching the user's preference: 'raft' (deep-water
+        culture, the default — forgiving, high water volume), 'nft' (nutrient film — light,
+        low water, needs reliable power), or 'media_bed' (flood & drain — robust, also
+        provides biofiltration). Ask the user which they want if they have a preference.
     """
     try:
         design = validate_design_input(
             fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd,
-            _clean_optional(source_water_note),
+            _clean_optional(source_water_note), system_type,
         )
     except ValidationError as err:
         return serialize.serialize_validation_error(err.errors)
@@ -113,6 +118,7 @@ def size_hydroponic_system_tool(
     temperature_c: float,
     water_budget_lpd: float,
     source_water_note: str | None = None,
+    system_type: str = "raft",
 ) -> str:
     """Size ONE HYDROPONIC (soil-less, NO fish) system deterministically. Use this when the
     user wants plants only — nutrients dosed as salts, not from fish. Returns the nutrient
@@ -121,15 +127,17 @@ def size_hydroponic_system_tool(
     coefficients used, and what is NOT modeled. For fish+plants use size_aquaponics_system.
 
     crop: one of the supported crops (call list_supported_species_and_crops if unsure).
-    grow_area_m2: planted DWC/NFT area (the anchor).
+    grow_area_m2: planted area (the anchor).
     temperature_c: mean ambient/solution temperature.
     water_budget_lpd: makeup water available per day, litres.
     source_water_note: optional salinity/quality caveat.
+    system_type: growing method — 'raft' (deep-water culture, default), 'nft' (nutrient
+        film — light, low water), or 'media_bed'. Match the user's preference.
     """
     try:
         design = validate_hydroponic_input(
             crop, grow_area_m2, temperature_c, water_budget_lpd,
-            _clean_optional(source_water_note),
+            _clean_optional(source_water_note), system_type,
         )
     except ValidationError as err:
         return serialize.serialize_validation_error(err.errors)
@@ -178,12 +186,15 @@ def optimize_fish_crop_ratio(
 
 @tool
 def list_supported_species_and_crops() -> str:
-    """List the fish species, crops, and optimization objectives Agronaut supports. Call
-    this before sizing if unsure whether something the user named is supported."""
+    """List the fish species, crops, growing methods, and optimization objectives Agronaut
+    supports. Call this before sizing if unsure whether something the user named is supported."""
+    from aqua_model.system_types import SYSTEM_TYPES
     fish = ", ".join(sorted(SPECIES))
     crops = ", ".join(sorted(CROPS))
     objs = ", ".join(OBJECTIVES)
-    return f"Fish species: {fish}\nCrops: {crops}\nOptimization objectives: {objs}"
+    methods = ", ".join(f"{k} ({SYSTEM_TYPES[k].name})" for k in sorted(SYSTEM_TYPES))
+    return (f"Fish species: {fish}\nCrops: {crops}\nGrowing methods: {methods}\n"
+            f"Optimization objectives: {objs}")
 
 
 @tool
@@ -262,11 +273,13 @@ def render_system_schematic(
     temperature_c: float,
     water_budget_lpd: float,
     fish_species: str | None = None,
+    system_type: str = "raft",
 ) -> str:
     """DRAW a labeled diagram of the system and send it to the user as an image. Use when the
     user asks to see, draw, or picture their system, or wants a schematic/diagram. Provide
     fish_species for an AQUAPONIC system (fish + plants); omit it for a HYDROPONIC one
-    (plants only). Same sizing inputs as the sizing tools. The image is generated
+    (plants only). system_type is the growing method ('raft', 'nft', 'media_bed') — the
+    diagram labels reflect it. Same sizing inputs as the sizing tools. The image is generated
     deterministically from the sized design — you do not describe it, just call this."""
     import os
     import tempfile
@@ -274,10 +287,12 @@ def render_system_schematic(
     fish = _clean_optional(fish_species)
     try:
         if fish:
-            design = validate_design_input(fish, crop, grow_area_m2, temperature_c, water_budget_lpd)
+            design = validate_design_input(fish, crop, grow_area_m2, temperature_c,
+                                           water_budget_lpd, None, system_type)
             out = size_system(design)
         else:
-            design = validate_hydroponic_input(crop, grow_area_m2, temperature_c, water_budget_lpd)
+            design = validate_hydroponic_input(crop, grow_area_m2, temperature_c,
+                                               water_budget_lpd, None, system_type)
             out = size_hydroponic_system(design)
     except ValidationError as err:
         return serialize.serialize_validation_error(err.errors)

--- a/aqua_model/hydroponics.py
+++ b/aqua_model/hydroponics.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from . import coefficients as C
 from .crops import get_crop
+from .system_types import get_system_type
 from .types import CoefficientUse, HydroponicInput, HydroponicOutput
 
 # What this hydroponics v1 does NOT model. Distinct from the aquaponics list — no fish,
@@ -46,12 +47,13 @@ def _ec_coeff(crop):
 
 def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
     crop = get_crop(design.crop)
+    system = get_system_type(design.system_type)
 
     # 1. ET drives daily solution consumption (the dominant water term in a covered system).
     daily_water_use = design.grow_area_m2 * C.EVAPOTRANSPIRATION_RATE.value
 
-    # 2. Reservoir (solution) volume = bed water (area x depth) + sump headroom. No fish tank.
-    bed_water_m3 = design.grow_area_m2 * C.RAFT_WATER_DEPTH.value
+    # 2. Reservoir (solution) volume = bed water (area x method depth) + sump headroom.
+    bed_water_m3 = design.grow_area_m2 * system.water_depth_m
     reservoir_m3 = bed_water_m3 / (1.0 - C.SUMP_FRACTION.value)
     reservoir_l = reservoir_m3 * 1000.0
 
@@ -75,6 +77,8 @@ def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
 
     out = HydroponicOutput(
         feasible=True,
+        system_type=system.key,
+        grow_bed_label=system.grow_bed_label,
         grow_area_m2=design.grow_area_m2,
         reservoir_volume_l=round(reservoir_l, 1),
         daily_water_use_lpd=round(daily_water_use, 1),
@@ -109,20 +113,22 @@ def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
         "temperature_target_c": [crop.temp_min_c, crop.temp_max_c],
         "dissolved_oxygen_min_mg_l": 5.0,
     }
-    out.bill_of_materials = _bill_of_materials(out, crop)
+    out.bill_of_materials = _bill_of_materials(out, crop, system)
     out.maintenance_checklist = _maintenance_checklist()
-    out.assumptions = _assumptions(crop)
-    out.coefficients_used = _coeff_uses(
-        C.EVAPOTRANSPIRATION_RATE, C.RAFT_WATER_DEPTH, C.SUMP_FRACTION,
-        C.PUMP_TURNOVER_RATE, ec,
+    out.assumptions = _assumptions(crop, system)
+    water_depth_coeff = CoefficientUse(
+        f"grow_bed_water_depth ({system.key})", system.water_depth_m,
+        system.water_depth_low, system.water_depth_high, "m", system.source)
+    out.coefficients_used = [water_depth_coeff] + _coeff_uses(
+        C.EVAPOTRANSPIRATION_RATE, C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, ec,
     )
     return out
 
 
-def _bill_of_materials(out: HydroponicOutput, crop) -> list[dict]:
+def _bill_of_materials(out: HydroponicOutput, crop, system) -> list[dict]:
     return [
         {"item": "nutrient reservoir / sump", "spec": f"~{round(out.reservoir_volume_l)} L", "qty": 1},
-        {"item": "DWC raft / NFT channel grow bed", "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
+        {"item": system.grow_bed_item, "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
         {"item": "circulation pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
         {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L in the root zone", "qty": 1},
         {"item": "nutrient stock (A/B) + pH adjusters", "spec": f"dose to EC "
@@ -141,10 +147,10 @@ def _maintenance_checklist() -> list[str]:
     ]
 
 
-def _assumptions(crop) -> list[str]:
+def _assumptions(crop, system) -> list[str]:
     return [
-        f"Soil-less hydroponic system (DWC/NFT), single crop ({crop.name}), NO fish.",
+        f"Soil-less hydroponic system ({system.name}), single crop ({crop.name}), NO fish.",
         "Nutrients supplied by a complete dosed solution (not fish waste).",
         "Grow area anchors ET-driven water use; rainfall assumed 0 (covered system).",
         "EC band and N/day are seed targets — CALIBRATE against your crop and climate.",
-    ]
+    ] + [f"Method note ({system.key}): {c}" for c in system.considerations]

--- a/aqua_model/report.py
+++ b/aqua_model/report.py
@@ -26,6 +26,7 @@ def to_markdown(design: DesignInput, out: DesignOutput, *, site: str | None = No
     lines.append("## Inputs\n")
     lines.append(f"- Fish species: **{design.fish_species}**")
     lines.append(f"- Crop: **{design.crop}**")
+    lines.append(f"- Growing method: **{out.grow_bed_label}**")
     lines.append(f"- Grow area: **{design.grow_area_m2} m²**")
     lines.append(f"- Mean water temperature: **{design.temperature_c} °C**")
     lines.append(f"- Water budget: **{design.water_budget_lpd} L/day**")

--- a/aqua_model/schematic.py
+++ b/aqua_model/schematic.py
@@ -56,14 +56,15 @@ class _Scene:
 
 def _aqua_scene(out: DesignOutput) -> _Scene:
     status = "FEASIBLE" if out.feasible else f"NOT FEASIBLE ({out.binding_constraint})"
-    s = _Scene("Aquaponics System", status)
+    method = (out.system_type or "raft").upper().replace("_", " ")
+    s = _Scene(f"Aquaponics System — {method}", status)
     s.boxes = [
         _Box(40, 90, 180, 90, "Rearing tank (fish)", [
             f"{out.fish_count} fish, {_g(out.fish_biomass_kg)} kg",
             f"~{_g(out.rearing_tank_volume_l)} L", f"feed {_g(out.feed_g_per_day)} g/day"], "#dbeafe"),
         _Box(270, 90, 170, 90, "Biofilter", [
             f"~{_g(out.biofilter_media_m2)} m2 media", "nitrification"], "#e6f4ea"),
-        _Box(490, 90, 190, 90, "Grow beds (raft/DWC)", [
+        _Box(490, 90, 190, 90, out.grow_bed_label, [
             f"{_g(out.grow_area_m2)} m2 planted", f"system {_g(out.system_volume_l)} L"], "#e8f5e9"),
         _Box(270, 250, 170, 80, "Sump + pump", [
             f"pump >={_g(out.pump_turnover_lph)} L/h", f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
@@ -78,13 +79,14 @@ def _aqua_scene(out: DesignOutput) -> _Scene:
 def _hydro_scene(out: HydroponicOutput) -> _Scene:
     status = "FEASIBLE" if out.feasible else f"NOT FEASIBLE ({out.binding_constraint})"
     ec = out.nutrient_target.get("ec_mS_cm", {})
-    s = _Scene("Hydroponic System (no fish)", status)
+    method = (out.system_type or "raft").upper().replace("_", " ")
+    s = _Scene(f"Hydroponic System (no fish) — {method}", status)
     s.boxes = [
         _Box(60, 100, 200, 100, "Nutrient reservoir", [
             f"~{_g(out.reservoir_volume_l)} L solution",
             f"EC {_g(ec.get('low'))}-{_g(ec.get('high'))} mS/cm",
             f"N {_g(out.nutrient_target.get('elemental_n_g_per_day'))} g/day"], "#e0f2fe"),
-        _Box(460, 100, 200, 100, "Grow beds (DWC/NFT)", [
+        _Box(460, 100, 200, 100, out.grow_bed_label, [
             f"{_g(out.grow_area_m2)} m2 planted",
             f"water use {_g(out.daily_water_use_lpd)} L/day"], "#e8f5e9"),
         _Box(260, 270, 200, 80, "Pump", [

--- a/aqua_model/sizing.py
+++ b/aqua_model/sizing.py
@@ -24,6 +24,7 @@ from . import massbalance as mb
 from .crops import get_crop
 from .overrides import validate_overrides, apply_overrides
 from .species import get_species, temperature_feed_factor
+from .system_types import get_system_type
 from .types import CoefficientUse, DesignInput, DesignOutput
 
 # What this v1 model does NOT account for. Every output carries this so a design can
@@ -48,6 +49,7 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
         validate_overrides(overrides)
     species = get_species(design.fish_species)
     crop = get_crop(design.crop)
+    system = get_system_type(design.system_type)
     species, crop = apply_overrides(species=species, crop=crop, overrides=overrides)
 
     # 1. FRR sizes feed from grow area (the anchor).
@@ -66,9 +68,10 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
     rearing_tank_volume_m3 = fish_biomass_kg / species.stocking_density_kg_m3
     rearing_tank_volume_l = rearing_tank_volume_m3 * 1000.0
 
-    # 5. System volume = rearing tank + raft water + sump.
-    raft_water_m3 = design.grow_area_m2 * C.RAFT_WATER_DEPTH.value
-    subtotal_m3 = rearing_tank_volume_m3 + raft_water_m3
+    # 5. System volume = rearing tank + grow-bed water + sump. The grow-bed water depth is
+    #    the method's (raft is deep, NFT a thin film, media bed the void space).
+    bed_water_m3 = design.grow_area_m2 * system.water_depth_m
+    subtotal_m3 = rearing_tank_volume_m3 + bed_water_m3
     system_volume_m3 = subtotal_m3 / (1.0 - C.SUMP_FRACTION.value)
     system_volume_l = system_volume_m3 * 1000.0
 
@@ -88,6 +91,8 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
 
     out = DesignOutput(
         feasible=True,
+        system_type=system.key,
+        grow_bed_label=system.grow_bed_label,
         system_volume_l=round(system_volume_l, 1),
         rearing_tank_volume_l=round(rearing_tank_volume_l, 1),
         fish_count=fish_count,
@@ -126,11 +131,15 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
         )
 
     out.operating_envelope = _operating_envelope(species, crop, design)
-    out.bill_of_materials = _bill_of_materials(out)
+    out.bill_of_materials = _bill_of_materials(out, system)
     out.maintenance_checklist = _maintenance_checklist()
-    out.assumptions = _assumptions(species, crop, temp_factor)
-    out.coefficients_used = _coeff_uses(
-        C.N_FRACTION_OF_PROTEIN, C.PLANT_N_UPTAKE_FRACTION, C.RAFT_WATER_DEPTH,
+    out.assumptions = _assumptions(species, crop, temp_factor, system)
+    # A method-specific water-depth coefficient replaces the raft default in the citation list.
+    water_depth_coeff = CoefficientUse(
+        f"grow_bed_water_depth ({system.key})", system.water_depth_m,
+        system.water_depth_low, system.water_depth_high, "m", system.source)
+    out.coefficients_used = [water_depth_coeff] + _coeff_uses(
+        C.N_FRACTION_OF_PROTEIN, C.PLANT_N_UPTAKE_FRACTION,
         C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, C.NITRIFICATION_RATE,
         C.EVAPOTRANSPIRATION_RATE, C.TANK_EVAPORATION_RATE, C.SAFETY_FACTOR,
     )
@@ -153,12 +162,15 @@ def species_ph_low(crop) -> float:
     return crop.ph_min
 
 
-def _bill_of_materials(out: DesignOutput) -> list[dict]:
+def _bill_of_materials(out: DesignOutput, system) -> list[dict]:
+    biofilter_spec = f"~{out.biofilter_media_m2} m2 surface"
+    if system.provides_biofiltration:
+        biofilter_spec += " (the media bed also nitrifies — a separate biofilter may be reduced)"
     return [
         {"item": "rearing tank", "spec": f"~{round(out.rearing_tank_volume_l)} L", "qty": 1},
-        {"item": "raft / DWC grow bed", "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
+        {"item": system.grow_bed_item, "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
         {"item": "water pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
-        {"item": "biofilter media", "spec": f"~{out.biofilter_media_m2} m2 surface", "qty": 1},
+        {"item": "biofilter media", "spec": biofilter_spec, "qty": 1},
         {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L", "qty": 1},
         {"item": "fish (fingerlings)", "spec": f"~{out.fish_count} head", "qty": out.fish_count},
     ]
@@ -174,11 +186,12 @@ def _maintenance_checklist() -> list[str]:
     ]
 
 
-def _assumptions(species, crop, temp_factor) -> list[str]:
+def _assumptions(species, crop, temp_factor, system) -> list[str]:
     return [
-        f"Raft/DWC system, single fish species ({species.name}), single crop ({crop.name}).",
+        f"{system.name.capitalize()} system, single fish species ({species.name}), "
+        f"single crop ({crop.name}).",
         "Steady-state average biomass (no cohort/harvest scheduling).",
         f"Feeding scaled to {round(temp_factor * 100)}% for the given mean temperature.",
         "Coefficients are seed defaults — CALIBRATE against a real system before building.",
         "Rainfall assumed 0 (covered/controlled system).",
-    ]
+    ] + [f"Method note ({system.key}): {c}" for c in system.considerations]

--- a/aqua_model/system_types.py
+++ b/aqua_model/system_types.py
@@ -1,0 +1,79 @@
+"""Growing methods — the design is flexible, not one fixed framework.
+
+An operator can build the same species/crop as raft/DWC, NFT, or a media bed, and each is a
+genuinely different system: different grow-bed water volume, a different bill of materials,
+and different considerations. This module holds the CITED per-method geometry so the
+deterministic sizing adapts to the chosen method while every number stays traceable.
+
+The fish/feed sizing is method-independent (it is driven by plant area via the feeding-rate
+ratio), so only the water geometry and the component set change between methods.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SystemType:
+    key: str
+    name: str
+    water_depth_m: float          # effective standing water per m² of grow area
+    water_depth_low: float
+    water_depth_high: float
+    provides_biofiltration: bool  # media beds host nitrifiers on the media surface
+    grow_bed_label: str           # for the bill of materials and the schematic
+    grow_bed_item: str
+    considerations: list          # honest, method-specific notes surfaced to the operator
+    source: str
+
+
+RAFT = SystemType(
+    key="raft", name="raft / deep-water culture (DWC)",
+    water_depth_m=0.30, water_depth_low=0.20, water_depth_high=0.40,
+    provides_biofiltration=False,
+    grow_bed_label="raft / DWC grow beds", grow_bed_item="raft / DWC grow bed",
+    considerations=[
+        "Deep water buffers temperature and pH swings — forgiving and beginner-friendly.",
+        "Highest water volume of the three methods (more makeup water to warm/cool).",
+    ],
+    source="FAO589",
+)
+
+NFT = SystemType(
+    key="nft", name="nutrient film technique (NFT)",
+    water_depth_m=0.03, water_depth_low=0.01, water_depth_high=0.05,
+    provides_biofiltration=False,
+    grow_bed_label="NFT channels", grow_bed_item="NFT channels",
+    considerations=[
+        "Channels hold only a thin film, so the system carries little water — light and cheap.",
+        "Little thermal/chemical buffering; a pump failure dries roots within hours — needs "
+        "reliable power and backup.",
+        "Best for lightweight leafy greens and herbs; heavy fruiting crops need support.",
+    ],
+    source="LIT",
+)
+
+MEDIA_BED = SystemType(
+    key="media_bed", name="media bed (flood & drain)",
+    water_depth_m=0.12, water_depth_low=0.08, water_depth_high=0.16,
+    provides_biofiltration=True,
+    grow_bed_label="media beds (flood & drain)", grow_bed_item="media bed (gravel/clay)",
+    considerations=[
+        "The media itself hosts nitrifiers and captures solids — it provides biofiltration, "
+        "so a separate biofilter can often be reduced (size conservatively before removing it).",
+        "Heavier and needs more media, but robust and good for fruiting crops.",
+        "Effective water volume is the void space in the media (~40%), between raft and NFT.",
+    ],
+    source="LIT",
+)
+
+SYSTEM_TYPES = {st.key: st for st in (RAFT, NFT, MEDIA_BED)}
+DEFAULT_SYSTEM_TYPE = "raft"
+
+
+def get_system_type(key: str | None) -> SystemType:
+    k = (key or DEFAULT_SYSTEM_TYPE).strip().lower()
+    if k not in SYSTEM_TYPES:
+        raise KeyError(f"unknown system_type {key!r}; known: {sorted(SYSTEM_TYPES)}")
+    return SYSTEM_TYPES[k]

--- a/aqua_model/tests/test_system_types.py
+++ b/aqua_model/tests/test_system_types.py
@@ -1,0 +1,59 @@
+"""Growing method is a first-class, selectable preference — not a fixed framework. A design
+can be raft/DWC, NFT, or media bed; each has cited geometry and its own considerations. The
+default (raft) is byte-identical to the pre-flexibility behavior, so nothing regresses.
+"""
+
+import pytest
+
+from aqua_model import size_system, validate_design_input, ValidationError
+from aqua_model.system_types import SYSTEM_TYPES, get_system_type
+
+
+def test_supported_methods_are_cited():
+    assert set(SYSTEM_TYPES) >= {"raft", "nft", "media_bed"}
+    for key in SYSTEM_TYPES:
+        st = get_system_type(key)
+        assert st.water_depth_m > 0
+        assert st.source                       # every method's geometry is sourced
+        assert st.considerations               # honest method-specific notes
+
+
+def test_default_is_raft_and_unchanged():
+    # omitting system_type must reproduce the exact prior design (raft/DWC, 0.30 m water).
+    a = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000))
+    b = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000, system_type="raft"))
+    assert a.system_volume_l == b.system_volume_l
+    assert a.rearing_tank_volume_l == b.rearing_tank_volume_l
+    assert a.feed_g_per_day == b.feed_g_per_day   # fish/feed sizing is method-independent
+
+
+def test_nft_holds_less_water_than_raft():
+    raft = size_system(validate_design_input("tilapia", "lettuce", 20, 27, 5000, system_type="raft"))
+    nft = size_system(validate_design_input("tilapia", "lettuce", 20, 27, 5000, system_type="nft"))
+    # NFT channels hold a thin film, so the system water volume is smaller than deep-water raft
+    assert nft.system_volume_l < raft.system_volume_l
+    # but the fish/feed sizing (driven by plant area, not method) is identical
+    assert nft.feed_g_per_day == raft.feed_g_per_day
+    assert nft.fish_count == raft.fish_count
+
+
+def test_method_appears_in_output_and_assumptions():
+    out = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000, system_type="media_bed"))
+    text = " ".join(out.assumptions).lower()
+    assert "media bed" in text
+    # media beds nitrify, so the design surfaces that consideration honestly
+    assert any("biofilt" in c.lower() or "nitrif" in c.lower() for c in out.assumptions + out.warnings) \
+        or "media bed" in text
+
+
+def test_validate_rejects_unknown_method():
+    with pytest.raises(ValidationError):
+        validate_design_input("tilapia", "lettuce", 12, 27, 3000, system_type="hydro-tower-9000")
+
+
+def test_bom_and_schematic_reflect_the_method():
+    from aqua_model.schematic import to_svg
+    out = size_system(validate_design_input("tilapia", "lettuce", 20, 27, 5000, system_type="nft"))
+    bom = " ".join(i["item"].lower() + " " + str(i["spec"]).lower() for i in out.bill_of_materials)
+    assert "nft" in bom or "channel" in bom
+    assert "nft" in to_svg(out).lower() or "channel" in to_svg(out).lower()

--- a/aqua_model/types.py
+++ b/aqua_model/types.py
@@ -21,10 +21,11 @@ class DesignInput:
 
     fish_species: str          # must exist in species.SPECIES
     crop: str                  # must exist in crops.CROPS
-    grow_area_m2: float        # the anchor; effective raft/DWC planted area
+    grow_area_m2: float        # the anchor; effective planted area
     temperature_c: float       # mean water temperature
     water_budget_lpd: float    # makeup water available per day (sanity-checked)
     source_water_note: str | None = None  # salinity/quality caveat
+    system_type: str = "raft"  # growing method: raft | nft | media_bed (system_types.py)
 
 
 @dataclass(frozen=True)
@@ -33,16 +34,19 @@ class HydroponicInput:
     validate_hydroponic_input — the trust gate — never from raw LLM output."""
 
     crop: str                  # must exist in crops.CROPS
-    grow_area_m2: float        # the anchor; planted DWC/NFT area
+    grow_area_m2: float        # the anchor; planted area
     temperature_c: float       # mean ambient/solution temperature
     water_budget_lpd: float    # makeup water available per day
     source_water_note: str | None = None
+    system_type: str = "raft"  # growing method: raft | nft | media_bed (system_types.py)
 
 
 @dataclass
 class HydroponicOutput:
     feasible: bool
     binding_constraint: str | None = None
+    system_type: str = "raft"
+    grow_bed_label: str = "DWC raft / NFT channel grow bed"
 
     # --- sizing numbers ---
     grow_area_m2: float = 0.0
@@ -82,6 +86,8 @@ class CoefficientUse:
 class DesignOutput:
     feasible: bool
     binding_constraint: str | None = None   # set when infeasible -> nearest-feasible hint
+    system_type: str = "raft"               # growing method used (for labels/schematic)
+    grow_bed_label: str = "raft / DWC grow beds"
 
     # --- sizing numbers ---
     system_volume_l: float = 0.0

--- a/aqua_model/validate.py
+++ b/aqua_model/validate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from .crops import CROPS
 from .species import SPECIES
+from .system_types import SYSTEM_TYPES
 from .types import DesignInput, HydroponicInput
 
 
@@ -36,6 +37,7 @@ def validate_design_input(
     temperature_c,
     water_budget_lpd,
     source_water_note=None,
+    system_type="raft",
 ) -> DesignInput:
     errors: list[str] = []
 
@@ -46,6 +48,8 @@ def validate_design_input(
     crop_key = str(crop or "").strip().lower()
     if crop_key not in CROPS:
         errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
+
+    system_type_key = _validate_system_type(system_type, errors)
 
     grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
     temperature_c = _as_float(temperature_c, "temperature_c", errors)
@@ -75,7 +79,15 @@ def validate_design_input(
         temperature_c=float(temperature_c),
         water_budget_lpd=float(water_budget_lpd),
         source_water_note=source_water_note,
+        system_type=system_type_key,
     )
+
+
+def _validate_system_type(system_type, errors) -> str:
+    key = str(system_type or "raft").strip().lower()
+    if key not in SYSTEM_TYPES:
+        errors.append(f"unknown system_type {system_type!r}; known: {sorted(SYSTEM_TYPES)}")
+    return key
 
 
 def validate_hydroponic_input(
@@ -84,6 +96,7 @@ def validate_hydroponic_input(
     temperature_c,
     water_budget_lpd,
     source_water_note=None,
+    system_type="raft",
 ) -> HydroponicInput:
     """Trust gate for hydroponic sizing — same discipline as validate_design_input, but no
     fish species (nutrients are dosed, not produced by fish)."""
@@ -92,6 +105,8 @@ def validate_hydroponic_input(
     crop_key = str(crop or "").strip().lower()
     if crop_key not in CROPS:
         errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
+
+    system_type_key = _validate_system_type(system_type, errors)
 
     grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
     temperature_c = _as_float(temperature_c, "temperature_c", errors)
@@ -120,6 +135,7 @@ def validate_hydroponic_input(
         temperature_c=float(temperature_c),
         water_budget_lpd=float(water_budget_lpd),
         source_water_note=source_water_note,
+        system_type=system_type_key,
     )
 
 


### PR DESCRIPTION
Answers "it shouldn't be a fixed framework." The design was locked to raft/DWC; now the **growing method** is a first-class, selectable preference — **raft/DWC** (default, forgiving, more water), **NFT** (light, low water, needs reliable power), or **media bed** (robust, also biofilters).

**How it's cited and threaded (trust zone intact):**
- New `aqua_model/system_types.py` — each method carries cited geometry (grow-bed water depth + range + source) and honest, method-specific considerations.
- Threads through `DesignInput`/`HydroponicInput`, both validation gates (unknown method → `VALIDATION_FAILED`), sizing (method water depth → system volume, pump, makeup water), the bill of materials, the schematic (title + grow-bed label reflect the method), the report, and the honesty layer (considerations become assumptions; media bed notes it provides biofiltration, sized conservatively — never silently undersized).
- **Fish/feed sizing stays method-independent** (driven by plant area via the FRR), so only water geometry + components change. Verified: raft 11,111 L vs NFT 5,111 L vs media bed 7,111 L for the same 20 m² system, identical 1200 g/day feed.
- **Backward compatible:** default `raft` (0.30 m) reproduces prior output byte-for-byte — no existing sizing test changed.

**Exposed everywhere:** agent tools gain `system_type` (+ `list_supported` lists methods); the system prompt asks about / honors the preference; the Streamlit calculator gets a "Growing method" selector.

TDD: 8 new tests (cited methods, default-raft identity, NFT<raft water, method in output/BOM/schematic, gate rejects unknown, tool param). Full suite: 359 passed, 2 skipped.

Follow-ons if wanted: multi-crop calculator designs, vertical towers (needs footprint-vs-area handling), topology-aware drawing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak