### PR TITLE
feat: mixed beds — grow several crops in one system, honestly

### DIFF
--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -32,7 +32,10 @@ YOU RUN A CONSULTATION, NOT A Q&A. Your job is to understand the person before y
      plants — use size_aquaponics_system) and HYDROPONIC (plants only, nutrients dosed as
      salts, NO fish — use size_hydroponic_system_tool). If the user mentions fish, pick
      aquaponics; if they say plants-only / hydroponic / no fish, pick hydroponics; if
-     unclear, ask which they want.
+     unclear, ask which they want. If the user wants SEVERAL crops in one system (a mixed
+     bed — e.g. "lettuce and basil and some tomato"), use size_mixed_bed_aquaponics with a
+     crop_plan of {crop, area_m2} entries instead of forcing a single crop; it sizes the
+     shared system and warns if the crops can't share one water chemistry.
    - optimize: find the best fish/crop ratio for an existing or planned system.
    - troubleshoot: diagnose a problem (sick fish, bad water, failing plants).
    If the goal is unclear, ask — briefly — what they're trying to do. Do not guess.

--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -31,6 +31,10 @@ def serialize_design_output(out: DesignOutput) -> str:
     else:
         lines.append(f"NOT FEASIBLE — binding constraint: {out.binding_constraint}.")
 
+    if out.crop_plan:
+        mix = ", ".join(f"{p['crop']} {_g(p['area_m2'])} m2" for p in out.crop_plan)
+        lines.append(f"Mixed beds (crops sharing the water): {mix}")
+
     lines.append(
         "Sizing: "
         f"feed={_g(out.feed_g_per_day)} g/day, fish={out.fish_count} head, "

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -14,7 +14,7 @@ def test_tool_registry():
     assert "optimize_fish_crop_ratio" in names
     assert "search_knowledge_base" in names
     assert "remember_about_user" in names
-    assert len(AGRONAUT_TOOLS) == 15
+    assert len(AGRONAUT_TOOLS) == 16
 
 
 def test_size_valid_carries_numbers_and_sources():
@@ -27,6 +27,39 @@ def test_size_valid_carries_numbers_and_sources():
     # honesty layer: coefficients with sources and not-modeled caveats are present
     assert "Coefficients used" in out and "source:" in out
     assert "NOT modeled" in out
+
+
+def test_mixed_bed_tool_sizes_several_crops_and_carries_the_plan():
+    from agronaut_agent.tools import size_mixed_bed_aquaponics, AGRONAUT_TOOLS
+    assert "size_mixed_bed_aquaponics" in {t.name for t in AGRONAUT_TOOLS}
+    out = size_mixed_bed_aquaponics.invoke({
+        "fish_species": "tilapia",
+        "crop_plan": [{"crop": "lettuce", "area_m2": 10}, {"crop": "basil", "area_m2": 10}],
+        "temperature_c": 27, "water_budget_lpd": 8000,
+    })
+    assert "FEASIBLE" in out
+    assert "Mixed beds" in out and "lettuce" in out and "basil" in out
+    assert "Coefficients used" in out and "source:" in out
+
+
+def test_mixed_bed_tool_warns_on_incompatible_ph():
+    from agronaut_agent.tools import size_mixed_bed_aquaponics
+    out = size_mixed_bed_aquaponics.invoke({
+        "fish_species": "tilapia",
+        "crop_plan": [{"crop": "watercress", "area_m2": 10}, {"crop": "strawberry", "area_m2": 10}],
+        "temperature_c": 26, "water_budget_lpd": 8000,
+    })
+    assert "pH" in out and "Warnings" in out
+
+
+def test_mixed_bed_tool_rejects_unknown_crop_through_the_trust_gate():
+    from agronaut_agent.tools import size_mixed_bed_aquaponics
+    out = size_mixed_bed_aquaponics.invoke({
+        "fish_species": "tilapia",
+        "crop_plan": [{"crop": "dragonfruit", "area_m2": 10}],
+        "temperature_c": 26, "water_budget_lpd": 8000,
+    })
+    assert "unknown crop" in out.lower() or "VALIDATION" in out.upper()
 
 
 def test_pilot_proposal_tool_renders_funder_document():
@@ -133,7 +166,7 @@ def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "update_profile" in names
-    assert len(AGRONAUT_TOOLS) == 15
+    assert len(AGRONAUT_TOOLS) == 16
 
 
 def test_update_profile_writes_canonical_drops_unknown():
@@ -164,7 +197,7 @@ def test_registry_includes_schedule_followup():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "schedule_followup" in names
-    assert len(AGRONAUT_TOOLS) == 15
+    assert len(AGRONAUT_TOOLS) == 16
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
@@ -208,7 +241,7 @@ def test_registry_includes_community_tools():
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "nominate_shared_insight" in names
     assert "search_community_knowledge" in names
-    assert len(AGRONAUT_TOOLS) == 15
+    assert len(AGRONAUT_TOOLS) == 16
 
 
 def test_nominate_writes_pending_and_rejects_blank():
@@ -259,7 +292,7 @@ def test_registry_includes_record_measurement():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "record_measurement" in names
-    assert len(AGRONAUT_TOOLS) == 15
+    assert len(AGRONAUT_TOOLS) == 16
 
 
 def test_record_measurement_maps_metric_to_qualified_key():

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -145,6 +145,55 @@ def size_hydroponic_system_tool(
 
 
 @tool
+def size_mixed_bed_aquaponics(
+    fish_species: str,
+    crop_plan: list[dict],
+    temperature_c: float,
+    water_budget_lpd: float,
+    source_water_note: str | None = None,
+    system_type: str = "raft",
+) -> str:
+    """Size ONE aquaponics system whose beds grow SEVERAL crops sharing the same water (a mixed
+    bed). Use this instead of size_aquaponics_system whenever the user wants more than one crop
+    in one system — e.g. "lettuce and basil and a bit of tomato". Feed is summed from each
+    crop's own feeding-rate ratio over its own area, and the system is sized for the total.
+    Returns the same artifacts as size_aquaponics_system, plus a check that WARNS if the crops
+    cannot share one water chemistry (e.g. their pH bands don't overlap) — never averages it
+    away silently. Never state sizing numbers yourself; call this tool.
+
+    fish_species: one of tilapia, clarias, channel_catfish, trout, carp.
+    crop_plan: the mix, as a list of {"crop": <name>, "area_m2": <planted m2>} entries — one per
+        crop. Each crop must be supported (call list_supported_species_and_crops if unsure); each
+        area must be > 0. The total grow area is their sum.
+    temperature_c: mean water temperature.
+    water_budget_lpd: makeup water available per day, litres.
+    source_water_note: optional salinity/quality caveat.
+    system_type: the GROWING METHOD — 'raft' (default), 'nft', or 'media_bed' — matching the
+        user's preference, exactly as in size_aquaponics_system.
+    """
+    try:
+        design = validate_design_input(
+            fish_species, None, None, temperature_c, water_budget_lpd,
+            _clean_optional(source_water_note), system_type, crop_plan=crop_plan,
+        )
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    cur = runtime.get_current()
+    overrides, note = None, ""
+    if cur is not None:
+        _mem, user_id = cur
+        cal = runtime.get_calibration()
+        if cal is not None:
+            overrides = cal.overrides_for(user_id) or None
+            note = _calibration_note(user_id, fish_species)
+    try:
+        sized = serialize.serialize_design_output(size_system(design, overrides=overrides))
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    return sized + note
+
+
+@tool
 def optimize_fish_crop_ratio(
     grow_area_m2: float,
     temperature_c: float,
@@ -477,6 +526,7 @@ def record_measurement(metric: str, value: float) -> str:
 
 AGRONAUT_TOOLS = [
     size_aquaponics_system,
+    size_mixed_bed_aquaponics,
     size_hydroponic_system_tool,
     optimize_fish_crop_ratio,
     list_supported_species_and_crops,

--- a/aqua_model/schematic.py
+++ b/aqua_model/schematic.py
@@ -54,6 +54,18 @@ class _Scene:
     arrows: list = field(default_factory=list)
 
 
+def _grow_bed_lines(out: DesignOutput) -> list:
+    """The grow-bed box body: a mixed bed lists each crop and its area; a single bed just
+    shows the planted area. System volume is always shown."""
+    if out.crop_plan:
+        lines = [f"{p['crop']} {_g(p['area_m2'])} m2" for p in out.crop_plan[:3]]
+        if len(out.crop_plan) > 3:
+            lines.append(f"+{len(out.crop_plan) - 3} more")
+        lines.append(f"system {_g(out.system_volume_l)} L")
+        return lines
+    return [f"{_g(out.grow_area_m2)} m2 planted", f"system {_g(out.system_volume_l)} L"]
+
+
 def _aqua_scene(out: DesignOutput) -> _Scene:
     status = "FEASIBLE" if out.feasible else f"NOT FEASIBLE ({out.binding_constraint})"
     method = (out.system_type or "raft").upper().replace("_", " ")
@@ -64,8 +76,8 @@ def _aqua_scene(out: DesignOutput) -> _Scene:
             f"~{_g(out.rearing_tank_volume_l)} L", f"feed {_g(out.feed_g_per_day)} g/day"], "#dbeafe"),
         _Box(270, 90, 170, 90, "Biofilter", [
             f"~{_g(out.biofilter_media_m2)} m2 media", "nitrification"], "#e6f4ea"),
-        _Box(490, 90, 190, 90, out.grow_bed_label, [
-            f"{_g(out.grow_area_m2)} m2 planted", f"system {_g(out.system_volume_l)} L"], "#e8f5e9"),
+        _Box(490, 90, 190, 90, out.grow_bed_label,
+             _grow_bed_lines(out), "#e8f5e9"),
         _Box(270, 250, 170, 80, "Sump + pump", [
             f"pump >={_g(out.pump_turnover_lph)} L/h", f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
     ]

--- a/aqua_model/sizing.py
+++ b/aqua_model/sizing.py
@@ -17,6 +17,7 @@ Never raises on a valid DesignInput; never returns a silently-wrong number.
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 from . import coefficients as C
@@ -44,16 +45,25 @@ def _coeff_uses(*coeffs) -> list[CoefficientUse]:
     return [CoefficientUse(c.name, c.value, c.low, c.high, c.unit, c.source) for c in coeffs]
 
 
+def _area(a: float) -> str:
+    return f"{float(a):g}"
+
+
 def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOutput:
     if overrides:
         validate_overrides(overrides)
     species = get_species(design.fish_species)
-    crop = get_crop(design.crop)
     system = get_system_type(design.system_type)
-    species, crop = apply_overrides(species=species, crop=crop, overrides=overrides)
+    species, _ = apply_overrides(species=species, crop=None, overrides=overrides)
 
-    # 1. FRR sizes feed from grow area (the anchor).
-    feed_g_per_day = design.grow_area_m2 * crop.frr_g_per_m2_day
+    # Resolve the crop allocation: a mixed-bed plan (>1 crop sharing the water) or a single
+    # crop over the whole area. Each crop keeps its OWN feeding-rate ratio; overrides apply
+    # per crop. A single-entry plan is identical to the single-crop design (no drift).
+    plantings = _resolve_plantings(design, overrides)
+    dominant = max(plantings, key=lambda p: p[1])[0]
+
+    # 1. FRR sizes feed from grow area (the anchor) — summed over each crop's own area.
+    feed_g_per_day = sum(area * c.frr_g_per_m2_day for c, area in plantings)
 
     # 2. Feed -> fish biomass, adjusted for how well fish eat at this temperature.
     temp_factor = temperature_feed_factor(species, design.temperature_c)
@@ -86,8 +96,16 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
     # 8. Biofilter media.
     media_m2 = mb.biofilter_media_m2(feed_g_per_day, species)
 
-    # 9. Nitrogen consistency check (does NOT resize anything).
-    n_check = mb.nitrogen_check(feed_g_per_day, species, crop, design.grow_area_m2)
+    # 9. Nitrogen consistency check (does NOT resize anything). For a mixed bed we check against
+    #    an area-weighted blended crop, so the FRR-vs-nitrogen agreement test still holds over
+    #    the whole planting (identical to the single crop when there is only one).
+    total_area = design.grow_area_m2
+    blended_crop = dataclasses.replace(
+        dominant,
+        frr_g_per_m2_day=feed_g_per_day / total_area,
+        n_uptake_g_per_m2_day=sum(a * c.n_uptake_g_per_m2_day for c, a in plantings) / total_area,
+    )
+    n_check = mb.nitrogen_check(feed_g_per_day, species, blended_crop, total_area)
 
     out = DesignOutput(
         feasible=True,
@@ -130,10 +148,16 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
             f"{round(temp_factor * 100)}% — yields and sizing reflect reduced intake."
         )
 
-    out.operating_envelope = _operating_envelope(species, crop, design)
+    # Mixed-bed honesty: record the plan, and flag crops that cannot share one water. Only
+    # emitted for a real mix (>1 crop) so the single-crop design is byte-for-byte unchanged.
+    if len(plantings) > 1:
+        out.crop_plan = [{"crop": c.name, "area_m2": a} for c, a in plantings]
+        _add_mixed_bed_warnings(out, plantings, design)
+
+    out.operating_envelope = _operating_envelope(species, plantings, design)
     out.bill_of_materials = _bill_of_materials(out, system)
     out.maintenance_checklist = _maintenance_checklist()
-    out.assumptions = _assumptions(species, crop, temp_factor, system)
+    out.assumptions = _assumptions(species, plantings, temp_factor, system)
     # A method-specific water-depth coefficient replaces the raft default in the citation list.
     water_depth_coeff = CoefficientUse(
         f"grow_bed_water_depth ({system.key})", system.water_depth_m,
@@ -146,20 +170,45 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
     return out
 
 
-def _operating_envelope(species, crop, design) -> dict:
+def _resolve_plantings(design: DesignInput, overrides: dict | None) -> list[tuple]:
+    """The crop allocation as [(Crop, area_m2), ...]: the mixed-bed plan if set, else the single
+    crop over the whole area. Overrides apply per crop. Single crop => one entry (no drift)."""
+    if design.crop_plan:
+        raw = [(get_crop(k), float(a)) for k, a in design.crop_plan]
+    else:
+        raw = [(get_crop(design.crop), design.grow_area_m2)]
+    return [(apply_overrides(species=None, crop=c, overrides=overrides)[1], a) for c, a in raw]
+
+
+def _shared_ph_band(plantings) -> tuple[float, float]:
+    """The pH window every crop in the mix can tolerate — the INTERSECTION of their bands,
+    never a widening. If lo >= hi the crops have no usable shared band."""
+    return max(c.ph_min for c, _ in plantings), min(c.ph_max for c, _ in plantings)
+
+
+def _add_mixed_bed_warnings(out: DesignOutput, plantings, design) -> None:
+    ph_lo, ph_hi = _shared_ph_band(plantings)
+    if ph_lo >= ph_hi:
+        ranges = ", ".join(f"{c.name} {c.ph_min}-{c.ph_max}" for c, _ in plantings)
+        out.warnings.append(
+            f"These crops cannot share one pH — their pH ranges do not overlap ({ranges}). "
+            "Grow them in separate systems, or drop one, rather than compromising on a pH "
+            "that suits none of them."
+        )
+
+
+def _operating_envelope(species, plantings, design) -> dict:
+    ph_lo, ph_hi = _shared_ph_band(plantings)
     return {
-        "ph_target": [max(species_ph_low(crop), 6.0), min(crop.ph_max, 7.0)],
-        "ph_do_not_exceed": [crop.ph_min, crop.ph_max],
+        # Aquaponics compromise pH sits between fish, plants, and nitrifiers (~6.0-7.0); for a
+        # mixed bed the plants' half of that compromise is the intersection of all their bands.
+        "ph_target": [max(ph_lo, 6.0), min(ph_hi, 7.0)],
+        "ph_do_not_exceed": [ph_lo, ph_hi],
         "temperature_target_c": [species.temp_opt_low_c, species.temp_opt_high_c],
         "temperature_do_not_exceed_c": [species.temp_min_c, species.temp_max_c],
         "dissolved_oxygen_min_mg_l": 5.0,
         "ammonia_nitrite_target": "as low as possible (≈0)",
     }
-
-
-def species_ph_low(crop) -> float:
-    # Aquaponics compromise pH sits between fish, plants, and nitrifiers (~6.0-7.0).
-    return crop.ph_min
 
 
 def _bill_of_materials(out: DesignOutput, system) -> list[dict]:
@@ -186,10 +235,16 @@ def _maintenance_checklist() -> list[str]:
     ]
 
 
-def _assumptions(species, crop, temp_factor, system) -> list[str]:
+def _assumptions(species, plantings, temp_factor, system) -> list[str]:
+    if len(plantings) > 1:
+        mix = ", ".join(f"{c.name} ({_area(a)} m2)" for c, a in plantings)
+        crop_line = (f"{system.name.capitalize()} system, single fish species "
+                     f"({species.name}), mixed beds: {mix}.")
+    else:
+        crop_line = (f"{system.name.capitalize()} system, single fish species "
+                     f"({species.name}), single crop ({plantings[0][0].name}).")
     return [
-        f"{system.name.capitalize()} system, single fish species ({species.name}), "
-        f"single crop ({crop.name}).",
+        crop_line,
         "Steady-state average biomass (no cohort/harvest scheduling).",
         f"Feeding scaled to {round(temp_factor * 100)}% for the given mean temperature.",
         "Coefficients are seed defaults — CALIBRATE against a real system before building.",

--- a/aqua_model/tests/test_mixed_bed.py
+++ b/aqua_model/tests/test_mixed_bed.py
@@ -1,0 +1,101 @@
+"""Mixed beds — the design is not locked to one crop. An operator can grow several crops in
+the same water (lettuce + basil + tomato), and the deterministic model sizes the shared
+system by SUMMING each crop's feed demand over its own area (FRR is per-crop, per-m²).
+
+Two invariants make this trustworthy rather than just flexible:
+  1. A single-crop plan reproduces the single-crop design EXACTLY (no silent drift).
+  2. Crops that cannot share one water chemistry are FLAGGED, never quietly averaged.
+"""
+
+import pytest
+
+from aqua_model import size_system, validate_design_input, ValidationError
+
+
+def test_single_entry_plan_matches_single_crop_exactly():
+    # A one-crop plan is just the old single-crop design — byte-identical, no regression.
+    plan = size_system(validate_design_input(
+        "tilapia", None, None, 27, 5000, crop_plan=[{"crop": "lettuce", "area_m2": 20}]))
+    single = size_system(validate_design_input("tilapia", "lettuce", 20, 27, 5000))
+    assert plan.feed_g_per_day == single.feed_g_per_day
+    assert plan.fish_count == single.fish_count
+    assert plan.system_volume_l == single.system_volume_l
+    assert plan.grow_area_m2 == single.grow_area_m2
+
+
+def test_feed_is_the_sum_of_per_crop_demand():
+    # Feed must equal each crop's own FRR × its own area, summed — not one crop over the total.
+    mix = size_system(validate_design_input(
+        "tilapia", None, None, 27, 8000,
+        crop_plan=[{"crop": "lettuce", "area_m2": 10}, {"crop": "basil", "area_m2": 10}]))
+    lettuce = size_system(validate_design_input("tilapia", "lettuce", 10, 27, 8000))
+    basil = size_system(validate_design_input("tilapia", "basil", 10, 27, 8000))
+    assert mix.feed_g_per_day == pytest.approx(lettuce.feed_g_per_day + basil.feed_g_per_day)
+    assert mix.grow_area_m2 == 20
+
+
+def test_mixing_leafy_and_fruiting_lands_between_the_monocultures():
+    # Basil (leafy, lower FRR) + tomato (fruiting, higher FRR) → feed between the two extremes.
+    mix = size_system(validate_design_input(
+        "tilapia", None, None, 27, 12000,
+        crop_plan=[{"crop": "basil", "area_m2": 10}, {"crop": "tomato", "area_m2": 10}]))
+    all_basil = size_system(validate_design_input("tilapia", "basil", 20, 27, 12000))
+    all_tomato = size_system(validate_design_input("tilapia", "tomato", 20, 27, 12000))
+    assert all_basil.feed_g_per_day < mix.feed_g_per_day < all_tomato.feed_g_per_day
+
+
+def test_crop_plan_appears_in_output_and_assumptions():
+    out = size_system(validate_design_input(
+        "tilapia", None, None, 27, 8000,
+        crop_plan=[{"crop": "lettuce", "area_m2": 6}, {"crop": "basil", "area_m2": 4}]))
+    assert len(out.crop_plan) == 2
+    names = {p["crop"] for p in out.crop_plan}
+    assert names == {"lettuce", "basil"}
+    text = " ".join(out.assumptions).lower()
+    assert "lettuce" in text and "basil" in text
+
+
+def test_incompatible_ph_bands_are_flagged_not_averaged():
+    # watercress wants an alkaline band (6.5–7.5); strawberry an acidic one (5.5–6.5).
+    # Their shared pH window is razor-thin/nonexistent — the model must WARN, not silently pick one.
+    out = size_system(validate_design_input(
+        "tilapia", None, None, 26, 8000,
+        crop_plan=[{"crop": "watercress", "area_m2": 10}, {"crop": "strawberry", "area_m2": 10}]))
+    warned = " ".join(out.warnings).lower()
+    assert "ph" in warned and ("share" in warned or "compat" in warned or "overlap" in warned)
+
+
+def test_compatible_crops_do_not_falsely_warn_about_ph():
+    out = size_system(validate_design_input(
+        "tilapia", None, None, 26, 8000,
+        crop_plan=[{"crop": "lettuce", "area_m2": 10}, {"crop": "basil", "area_m2": 10}]))
+    assert not any("ph" in w.lower() and "share" in w.lower() for w in out.warnings)
+
+
+def test_operating_envelope_ph_is_the_intersection():
+    # The shared pH band must be the INTERSECTION of both crops, never a widening.
+    out = size_system(validate_design_input(
+        "tilapia", None, None, 26, 8000,
+        crop_plan=[{"crop": "lettuce", "area_m2": 10}, {"crop": "tomato", "area_m2": 10}]))
+    lo, hi = out.operating_envelope["ph_do_not_exceed"]
+    # lettuce 5.5–7.0, tomato 5.5–6.5 → intersection 5.5–6.5
+    assert lo == 5.5 and hi == 6.5
+
+
+def test_empty_plan_is_rejected():
+    with pytest.raises(ValidationError):
+        validate_design_input("tilapia", None, None, 27, 5000, crop_plan=[])
+
+
+def test_unknown_crop_in_plan_is_rejected():
+    with pytest.raises(ValidationError):
+        validate_design_input(
+            "tilapia", None, None, 27, 5000,
+            crop_plan=[{"crop": "lettuce", "area_m2": 5}, {"crop": "dragonfruit", "area_m2": 5}])
+
+
+def test_nonpositive_area_in_plan_is_rejected():
+    with pytest.raises(ValidationError):
+        validate_design_input(
+            "tilapia", None, None, 27, 5000,
+            crop_plan=[{"crop": "lettuce", "area_m2": 0}])

--- a/aqua_model/types.py
+++ b/aqua_model/types.py
@@ -26,6 +26,10 @@ class DesignInput:
     water_budget_lpd: float    # makeup water available per day (sanity-checked)
     source_water_note: str | None = None  # salinity/quality caveat
     system_type: str = "raft"  # growing method: raft | nft | media_bed (system_types.py)
+    # Mixed beds: an optional ((crop_key, area_m2), ...) allocation. When set, it drives feed
+    # and total area (crop/grow_area_m2 above hold the dominant crop and the summed area). Empty
+    # => single-crop design, byte-identical to before. Built only by the validation gate.
+    crop_plan: tuple = ()
 
 
 @dataclass(frozen=True)
@@ -88,6 +92,9 @@ class DesignOutput:
     binding_constraint: str | None = None   # set when infeasible -> nearest-feasible hint
     system_type: str = "raft"               # growing method used (for labels/schematic)
     grow_bed_label: str = "raft / DWC grow beds"
+    # Populated only for mixed beds (>1 crop): [{"crop": name, "area_m2": a}, ...]. Empty for a
+    # single-crop design, so single-crop output/serialization is unchanged.
+    crop_plan: list = field(default_factory=list)
 
     # --- sizing numbers ---
     system_volume_l: float = 0.0

--- a/aqua_model/validate.py
+++ b/aqua_model/validate.py
@@ -38,6 +38,7 @@ def validate_design_input(
     water_budget_lpd,
     source_water_note=None,
     system_type="raft",
+    crop_plan=None,
 ) -> DesignInput:
     errors: list[str] = []
 
@@ -45,13 +46,19 @@ def validate_design_input(
     if species_key not in SPECIES:
         errors.append(f"unknown fish_species {fish_species!r}; known: {sorted(SPECIES)}")
 
-    crop_key = str(crop or "").strip().lower()
-    if crop_key not in CROPS:
-        errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
-
     system_type_key = _validate_system_type(system_type, errors)
 
-    grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
+    # Mixed beds: a validated crop plan supersedes the single crop/area — the dominant crop and
+    # the summed area are DERIVED from it, so the single-crop fields stay meaningful downstream.
+    plan = _validate_crop_plan(crop_plan, errors)
+    if plan is not None:
+        crop_key = max(plan, key=lambda p: p[1])[0] if plan else ""
+        grow_area_m2 = sum(a for _, a in plan)
+    else:
+        crop_key = str(crop or "").strip().lower()
+        if crop_key not in CROPS:
+            errors.append(f"unknown crop {crop!r}; known: {sorted(CROPS)}")
+        grow_area_m2 = _as_float(grow_area_m2, "grow_area_m2", errors)
     temperature_c = _as_float(temperature_c, "temperature_c", errors)
     water_budget_lpd = _as_float(water_budget_lpd, "water_budget_lpd", errors)
 
@@ -80,6 +87,7 @@ def validate_design_input(
         water_budget_lpd=float(water_budget_lpd),
         source_water_note=source_water_note,
         system_type=system_type_key,
+        crop_plan=tuple(plan) if plan is not None else (),
     )
 
 
@@ -88,6 +96,36 @@ def _validate_system_type(system_type, errors) -> str:
     if key not in SYSTEM_TYPES:
         errors.append(f"unknown system_type {system_type!r}; known: {sorted(SYSTEM_TYPES)}")
     return key
+
+
+def _validate_crop_plan(crop_plan, errors) -> list | None:
+    """Normalize a mixed-bed plan to [(crop_key, area_m2), ...] or return None for single-crop.
+
+    Accepts a list of {"crop", "area_m2"} dicts or (crop, area) pairs. Every crop must be known
+    and every area strictly positive — a bad plan is rejected loudly, never partially applied.
+    """
+    if crop_plan is None:
+        return None
+    if not isinstance(crop_plan, (list, tuple)) or len(crop_plan) == 0:
+        errors.append("crop_plan must be a non-empty list of {crop, area_m2} entries")
+        return []
+    normalized: list = []
+    for entry in crop_plan:
+        if isinstance(entry, dict):
+            ck = str(entry.get("crop") or "").strip().lower()
+            area = entry.get("area_m2")
+        elif isinstance(entry, (list, tuple)) and len(entry) == 2:
+            ck, area = str(entry[0] or "").strip().lower(), entry[1]
+        else:
+            errors.append(f"crop_plan entry not understood: {entry!r}")
+            continue
+        if ck not in CROPS:
+            errors.append(f"unknown crop {ck!r} in crop_plan; known: {sorted(CROPS)}")
+        a = _as_float(area, f"crop_plan area for {ck!r}", errors)
+        if a is not None and a <= 0:
+            errors.append(f"crop_plan area for {ck!r} must be > 0, got {a}")
+        normalized.append((ck, float(a) if a is not None else 0.0))
+    return normalized
 
 
 def validate_hydroponic_input(


### PR DESCRIPTION
## What & why

The design was still a *fixed framework* in one way its own docstring admitted — **one crop per system**. Real smallholders grow **mixed beds** (lettuce + basil + a little tomato in the same water). This lets a design carry a `crop_plan` of `{crop, area_m2}` allocations sharing one system.

Feed is **summed from each crop's own feeding-rate ratio over its own area** — not one crop stretched over the total. For 20 m² of lettuce(10)+basil(6)+tomato(4): feed = 10×60 + 6×85 + 4×110 = **1550 g/day**, landing between all-lettuce (1200) and all-tomato (2200), exactly as it should.

## Trust preserved *and* extended

- A **single-crop plan reproduces the single-crop design byte-for-byte** — no silent drift.
- The **nitrogen consistency check** runs against an area-weighted blended crop, so the FRR-vs-nitrogen agreement test still holds over the whole planting.
- The operating-envelope **pH band is the INTERSECTION** of the crops' bands (never a widening), and a **new honesty check WARNS when crops cannot share one water chemistry** (their pH bands don't overlap) — e.g. watercress (6.5–7.5) + strawberry (5.5–6.5) — instead of quietly averaging to a pH that suits none of them.

## Surface

Threaded through `DesignInput`/`DesignOutput`, the validation gate (loud rejection of empty plans, unknown crops, non-positive areas), sizing, the schematic (mixed-bed grow box), serialization, and a dedicated **`size_mixed_bed_aquaponics`** agent tool (tools 15→16) with the system prompt routing multi-crop requests to it.

## Tests

10 model-layer tests (feed-sum, monoculture bracketing, single-entry identity, pH intersection, incompatibility warning, gate rejections) + 3 agent-tool tests. **372 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak