### PR TITLE
feat: mixed beds + growing methods in the web Design Calculator

### DIFF
--- a/agent/calculator_ui.py
+++ b/agent/calculator_ui.py
@@ -100,7 +100,10 @@ def render_calculator() -> None:
         col1, col2 = st.columns(2)
         with col1:
             species = st.selectbox("Fish species", facts.available_species())
-            crop = st.selectbox("Crop", facts.available_crops())
+            crops = st.multiselect(
+                "Crops", facts.available_crops(), default=["lettuce"],
+                help="Pick 2+ for a MIXED BED sharing one system — the grow area is split "
+                     "evenly, and the model warns if the crops can't share one water.")
             site = st.text_input("Site / project name (optional)", "")
         with col2:
             grow_area = st.number_input("Grow area (m²)", min_value=0.1, value=6.0, step=0.5)
@@ -116,12 +119,24 @@ def render_calculator() -> None:
         st.info("Set your inputs and press **Size system**.")
         return
 
+    if not crops:
+        st.error("Pick at least one crop.")
+        return
+
     try:
-        design = facts.design_from_form(
-            fish_species=species, crop=crop, grow_area_m2=grow_area,
-            temperature_c=temperature, water_budget_lpd=water_budget,
-            system_type=system_type,
-        )
+        if len(crops) > 1:
+            design = facts.design_from_form(
+                fish_species=species, crop=None, grow_area_m2=None,
+                temperature_c=temperature, water_budget_lpd=water_budget,
+                system_type=system_type,
+                crop_plan=facts.split_area_evenly(crops, grow_area),
+            )
+        else:
+            design = facts.design_from_form(
+                fish_species=species, crop=crops[0], grow_area_m2=grow_area,
+                temperature_c=temperature, water_budget_lpd=water_budget,
+                system_type=system_type,
+            )
     except facts.ValidationError as err:
         st.error("Invalid inputs:\n" + "\n".join(f"- {e}" for e in err.errors))
         return
@@ -132,6 +147,10 @@ def render_calculator() -> None:
         st.success("Feasible design.")
     else:
         st.warning(f"Not feasible — binding constraint: **{out.binding_constraint}**.")
+
+    if out.crop_plan:
+        st.caption("Mixed bed (crops sharing the water): "
+                   + ", ".join(f"{p['crop']} {p['area_m2']:g} m²" for p in out.crop_plan))
 
     for w in out.warnings:
         st.warning(w)
@@ -144,6 +163,10 @@ def render_calculator() -> None:
     m4.metric("System volume", f"{out.system_volume_l:g} L")
     m5.metric("Pump", f"{out.pump_turnover_lph:g} L/h")
     m6.metric("Makeup water", f"{out.makeup_water_lpd:g} L/day")
+    if out.footprint_ratio != 1.0:
+        st.metric("Floor footprint", f"{out.footprint_m2:g} m²",
+                  help=f"{out.grow_area_m2:g} m² of growing area packed onto the floor "
+                       f"(~{out.footprint_ratio:g}× via vertical towers).")
 
     import base64
     from aqua_model.schematic import to_svg
@@ -171,7 +194,9 @@ def render_calculator() -> None:
             {"name": c.name, "value": c.value, "range": f"{c.low}–{c.high}", "unit": c.unit, "source": c.source}
             for c in out.coefficients_used
         ])
-    _render_coefficient_sources(species, crop)
+    # Coefficient-source panels for each crop in the design (one for a single crop).
+    for c in (crops or []):
+        _render_coefficient_sources(species, c)
 
     report_md = to_markdown(design, out, site=site or None)
     st.download_button(

--- a/agent/facts.py
+++ b/agent/facts.py
@@ -38,10 +38,13 @@ def design_from_form(
     water_budget_lpd: float,
     source_water_note: str | None = None,
     system_type: str = "raft",
+    crop_plan: list[dict] | None = None,
 ) -> DesignInput:
     """Validate structured form values into a DesignInput. Raises ValidationError on bad input.
 
     This is the ONLY way the UI puts numbers into the model — the validation gate, reused.
+    Pass crop_plan (a list of {crop, area_m2}) for a mixed bed; then crop/grow_area_m2 are
+    derived from it and may be None.
     """
     return validate_design_input(
         fish_species=fish_species,
@@ -51,7 +54,16 @@ def design_from_form(
         water_budget_lpd=water_budget_lpd,
         source_water_note=source_water_note,
         system_type=system_type,
+        crop_plan=crop_plan,
     )
+
+
+def split_area_evenly(crops: list[str], grow_area_m2: float) -> list[dict]:
+    """Turn a list of crops + a total area into an even-split crop_plan. The calculator form
+    can't collect per-crop areas reactively inside one submit, so it splits equally; the chat
+    agent (size_mixed_bed_aquaponics) takes explicit per-crop areas for finer control."""
+    per = round(grow_area_m2 / len(crops), 3)
+    return [{"crop": c, "area_m2": per} for c in crops]
 
 
 __all__ = [
@@ -59,5 +71,6 @@ __all__ = [
     "available_crops",
     "available_system_types",
     "design_from_form",
+    "split_area_evenly",
     "ValidationError",
 ]

--- a/agent/tests/test_calculator_ui.py
+++ b/agent/tests/test_calculator_ui.py
@@ -16,14 +16,15 @@ def test_calculator_renders_form():
     at = AppTest.from_string(_APP).run(timeout=30)
     assert not at.exception
     assert "Design Calculator" in [s.value for s in at.subheader]
-    assert [sb.label for sb in at.selectbox] == ["Fish species", "Crop", "Growing method"]
+    assert [sb.label for sb in at.selectbox] == ["Fish species", "Growing method"]
+    assert [ms.label for ms in at.multiselect] == ["Crops"]
     assert len(at.number_input) == 3
 
 
 def test_calculator_sizes_a_system_on_submit():
     at = AppTest.from_string(_APP).run(timeout=30)
     at.selectbox[0].set_value("tilapia")
-    at.selectbox[1].set_value("lettuce")
+    at.multiselect[0].set_value(["lettuce"])
     at.number_input[0].set_value(6.0)    # grow area
     at.number_input[1].set_value(26.0)   # temperature
     at.number_input[2].set_value(200.0)  # water budget
@@ -37,10 +38,45 @@ def test_calculator_sizes_a_system_on_submit():
     assert "head" in metrics["Fish"]
 
 
+def test_calculator_sizes_a_mixed_bed():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.selectbox[0].set_value("tilapia")
+    at.multiselect[0].set_value(["lettuce", "basil"])
+    at.number_input[0].set_value(20.0)   # grow area, split evenly → 10 each
+    at.number_input[1].set_value(26.0)
+    at.number_input[2].set_value(8000.0)
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    assert "Feasible design." in [s.value for s in at.success]
+    captions = " ".join(c.value for c in at.caption)
+    assert "Mixed bed" in captions and "lettuce" in captions and "basil" in captions
+    # feed = 10*60 (lettuce) + 10*85 (basil) = 1450 g/day
+    assert {m.label: m.value for m in at.metric}["Feed"] == "1450 g/day"
+
+
+def test_calculator_vertical_tower_shows_floor_footprint():
+    at = AppTest.from_string(_APP).run(timeout=30)
+    at.selectbox[0].set_value("tilapia")
+    at.selectbox[1].set_value("vertical_tower")
+    at.multiselect[0].set_value(["lettuce"])
+    at.number_input[0].set_value(12.0)
+    at.number_input[1].set_value(26.0)
+    at.number_input[2].set_value(3000.0)
+    at.button[0].click()
+    at.run(timeout=30)
+
+    assert not at.exception
+    metrics = {m.label: m.value for m in at.metric}
+    assert "Floor footprint" in metrics
+    assert metrics["Floor footprint"] == "4 m²"    # 12 m² grow / 3.0 ratio
+
+
 def test_calculator_shows_reality_check_vs_real_ponds():
     at = AppTest.from_string(_APP).run(timeout=30)
     at.selectbox[0].set_value("tilapia")
-    at.selectbox[1].set_value("lettuce")
+    at.multiselect[0].set_value(["lettuce"])
     at.number_input[0].set_value(6.0)
     at.number_input[1].set_value(26.0)
     at.number_input[2].set_value(200.0)
@@ -57,7 +93,7 @@ def test_calculator_shows_reality_check_vs_real_ponds():
 def test_calculator_shows_basil_frr_calibration():
     at = AppTest.from_string(_APP).run(timeout=30)
     at.selectbox[0].set_value("tilapia")
-    at.selectbox[1].set_value("basil")
+    at.multiselect[0].set_value(["basil"])
     at.number_input[0].set_value(6.0)
     at.number_input[1].set_value(26.0)
     at.number_input[2].set_value(200.0)
@@ -74,7 +110,7 @@ def test_calculator_shows_basil_frr_calibration():
 def test_calculator_flags_infeasible_water_budget():
     at = AppTest.from_string(_APP).run(timeout=30)
     at.selectbox[0].set_value("tilapia")
-    at.selectbox[1].set_value("lettuce")
+    at.multiselect[0].set_value(["lettuce"])
     at.number_input[0].set_value(50.0)   # large area
     at.number_input[1].set_value(28.0)
     at.number_input[2].set_value(10.0)   # tiny water budget


### PR DESCRIPTION
## What

Brings the two new flexibility features (mixed beds #66, vertical towers #67) into the **Streamlit Design Calculator**, which was single-crop only.

- **"Crop" → "Crops" multiselect.** Pick 2+ for a **mixed bed** sharing one system. The grow area is split evenly, a `crop_plan` is built, and the result surfaces the mix as a caption plus any **pH-incompatibility warning** straight from the model. (The chat agent's `size_mixed_bed_aquaponics` takes explicit per-crop areas for finer control — a single form submit can't collect them reactively, so the calculator splits evenly.)
- **Vertical towers** appear in the "Growing method" selectbox automatically (it reads `SYSTEM_TYPES`), and a **"Floor footprint"** metric shows for towers — 12 m² of growing area → **4 m² of floor**.
- Coefficient-source audit panels now render **per crop** in the design.

## Trust boundary

`facts.design_from_form` gains an optional `crop_plan`; a small `split_area_evenly` helper turns crops + total area into a plan. **Everything still flows through the one validation gate** — no new door into the model.

## Tests

New: mixed-bed sizing (feed **1450 g/day** for lettuce+basil at 10+10 m²) and the tower floor-footprint metric. Existing form tests updated for the multiselect. **380 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak