### PR TITLE
feat: quantify pump head and power (not just flow)

### DIFF
--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -45,8 +45,9 @@ def serialize_design_output(out: DesignOutput) -> str:
         "Sizing: "
         f"feed={_g(out.feed_g_per_day)} g/day, fish={out.fish_count} head, "
         f"biomass={_g(out.fish_biomass_kg)} kg, system_volume={_g(out.system_volume_l)} L, "
-        f"rearing_tank={_g(out.rearing_tank_volume_l)} L, pump={_g(out.pump_turnover_lph)} L/h, "
-        f"makeup_water={_g(out.makeup_water_lpd)} L/day"
+        f"rearing_tank={_g(out.rearing_tank_volume_l)} L, "
+        f"pump={_g(out.pump_turnover_lph)} L/h against {_g(out.pump_head_m)} m head "
+        f"(~{_g(out.pump_power_w)} W), makeup_water={_g(out.makeup_water_lpd)} L/day"
     )
     if out.biofilter_media_m2 is not None:
         lines.append(f"Biofilter media: ~{_g(out.biofilter_media_m2)} m2 surface")
@@ -98,7 +99,9 @@ def serialize_hydroponic_output(out: HydroponicOutput) -> str:
         "Sizing (no fish — nutrient solution): "
         f"grow_area={_g(out.grow_area_m2)} m2, reservoir={_g(out.reservoir_volume_l)} L, "
         f"daily_water_use={_g(out.daily_water_use_lpd)} L/day, "
-        f"makeup_water={_g(out.makeup_water_lpd)} L/day, pump={_g(out.pump_turnover_lph)} L/h"
+        f"makeup_water={_g(out.makeup_water_lpd)} L/day, "
+        f"pump={_g(out.pump_turnover_lph)} L/h against {_g(out.pump_head_m)} m head "
+        f"(~{_g(out.pump_power_w)} W)"
     )
     nt = out.nutrient_target
     if nt:

--- a/aqua_model/coefficients.py
+++ b/aqua_model/coefficients.py
@@ -96,6 +96,23 @@ PUMP_TURNOVER_RATE = Coefficient(
     value=1.0, low=0.5, high=2.0, unit="system volumes / hour", source="FAO589",
 )
 
+# Pump HEAD: the static lift (per method, see system_types) is raised by this fraction to
+# cover pipe/fitting friction (dynamic head). A rough but standard allowance for the short,
+# low-velocity plumbing of a small recirculating system.
+FRICTION_HEAD_FRACTION = Coefficient(
+    name="friction_head_fraction",
+    value=0.30, low=0.20, high=0.50, unit="fraction of static lift", source="LIT",
+    note="Dynamic (friction) head as a fraction of static lift; size real pipework per layout.",
+)
+
+# Wire-to-water efficiency of a small submersible/pond pump — electrical power in vs hydraulic
+# power out. Low, as these pumps are inefficient; used only to estimate running power/energy.
+PUMP_EFFICIENCY = Coefficient(
+    name="pump_efficiency",
+    value=0.35, low=0.20, high=0.50, unit="dimensionless (wire-to-water)", source="LIT",
+    note="Small submersible pumps are inefficient; a power estimate, not a spec — verify the curve.",
+)
+
 # Biofilter: nitrification rate per m2 of media surface. HIGHLY media- and
 # temperature-dependent; deliberately conservative (low) so we don't undersize.
 NITRIFICATION_RATE = Coefficient(
@@ -132,6 +149,8 @@ def registry() -> dict[str, Coefficient]:
             RAFT_WATER_DEPTH,
             SUMP_FRACTION,
             PUMP_TURNOVER_RATE,
+            FRICTION_HEAD_FRACTION,
+            PUMP_EFFICIENCY,
             NITRIFICATION_RATE,
             EC_TARGET_LEAFY,
             EC_TARGET_FRUITING,

--- a/aqua_model/hydroponics.py
+++ b/aqua_model/hydroponics.py
@@ -20,6 +20,7 @@ HydroponicInput.
 from __future__ import annotations
 
 from . import coefficients as C
+from . import massbalance as mb
 from .crops import get_crop
 from .system_types import get_system_type
 from .types import CoefficientUse, HydroponicInput, HydroponicOutput
@@ -57,8 +58,9 @@ def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
     reservoir_m3 = bed_water_m3 / (1.0 - C.SUMP_FRACTION.value)
     reservoir_l = reservoir_m3 * 1000.0
 
-    # 3. Pump turnover: circulate the reservoir volume at the standard turnover rate.
+    # 3. Pump turnover (flow) + the head/power it must deliver it against (method lift).
     pump_lph = reservoir_l * C.PUMP_TURNOVER_RATE.value
+    pump_head_m, pump_power_w = mb.pump_hydraulics(pump_lph, system)
 
     # 4. Makeup water = ET consumption (rainfall 0 for a covered system). Evaporative loss
     #    from open canals is folded into the ET range, which is wide and calibrated per site.
@@ -86,6 +88,8 @@ def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
         daily_water_use_lpd=round(daily_water_use, 1),
         makeup_water_lpd=makeup_lpd,
         pump_turnover_lph=round(pump_lph, 1),
+        pump_head_m=pump_head_m,
+        pump_power_w=pump_power_w,
         nutrient_target=nutrient_target,
         not_modeled=list(NOT_MODELED),
     )
@@ -121,8 +125,12 @@ def size_hydroponic_system(design: HydroponicInput) -> HydroponicOutput:
     water_depth_coeff = CoefficientUse(
         f"grow_bed_water_depth ({system.key})", system.water_depth_m,
         system.water_depth_low, system.water_depth_high, "m", system.source)
-    out.coefficients_used = [water_depth_coeff] + _coeff_uses(
-        C.EVAPOTRANSPIRATION_RATE, C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, ec,
+    lift_coeff = CoefficientUse(
+        f"pump_lift_height ({system.key})", system.lift_height_m,
+        system.lift_low, system.lift_high, "m", system.source)
+    out.coefficients_used = [water_depth_coeff, lift_coeff] + _coeff_uses(
+        C.EVAPOTRANSPIRATION_RATE, C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE,
+        C.FRICTION_HEAD_FRACTION, C.PUMP_EFFICIENCY, ec,
     )
     return out
 
@@ -131,7 +139,8 @@ def _bill_of_materials(out: HydroponicOutput, crop, system) -> list[dict]:
     return [
         {"item": "nutrient reservoir / sump", "spec": f"~{round(out.reservoir_volume_l)} L", "qty": 1},
         {"item": system.grow_bed_item, "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
-        {"item": "circulation pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
+        {"item": "circulation pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h against "
+         f"~{out.pump_head_m} m head (~{round(out.pump_power_w)} W electrical)", "qty": 1},
         {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L in the root zone", "qty": 1},
         {"item": "nutrient stock (A/B) + pH adjusters", "spec": f"dose to EC "
          f"{out.nutrient_target['ec_mS_cm']['low']}–{out.nutrient_target['ec_mS_cm']['high']} mS/cm", "qty": 1},

--- a/aqua_model/massbalance.py
+++ b/aqua_model/massbalance.py
@@ -116,6 +116,21 @@ def water_balance(grow_area_m2: float, tank_surface_m2: float, rainfall_lpd: flo
     }
 
 
+def pump_hydraulics(pump_turnover_lph: float, system) -> tuple[float, float]:
+    """Total dynamic head (m) and estimated electrical power (W) for the recirculation pump.
+
+    Head = static lift (the method's, sump surface to highest discharge) raised by a friction
+    allowance for pipework. Power = ρ g Q H / efficiency — a running-power estimate, not a
+    pump-curve spec. This is why a tower (high lift) costs more to run than a raft at the same
+    flow: power scales with head.
+    """
+    head_m = system.lift_height_m * (1.0 + C.FRICTION_HEAD_FRACTION.value)
+    q_m3_s = pump_turnover_lph / 1000.0 / 3600.0
+    hydraulic_w = 1000.0 * 9.81 * q_m3_s * head_m   # ρ(kg/m³) · g(m/s²) · Q(m³/s) · H(m)
+    power_w = hydraulic_w / C.PUMP_EFFICIENCY.value
+    return round(head_m, 2), round(power_w, 1)
+
+
 def biofilter_media_m2(feed_g_per_day: float, species: FishSpecies) -> float:
     """Required nitrifying media area, sized to TAN production with a safety factor.
 

--- a/aqua_model/report.py
+++ b/aqua_model/report.py
@@ -42,6 +42,7 @@ def to_markdown(design: DesignInput, out: DesignOutput, *, site: str | None = No
     lines.append(f"| Rearing tank | {out.rearing_tank_volume_l} L |")
     lines.append(f"| System volume | {out.system_volume_l} L |")
     lines.append(f"| Pump turnover | {out.pump_turnover_lph} L/h |")
+    lines.append(f"| Pump head / power | ~{out.pump_head_m} m (~{round(out.pump_power_w)} W electrical) |")
     lines.append(f"| Biofilter media | {out.biofilter_media_m2} m² |")
     lines.append(f"| Makeup water | {out.makeup_water_lpd} L/day |")
     lines.append("")

--- a/aqua_model/schematic.py
+++ b/aqua_model/schematic.py
@@ -81,8 +81,10 @@ def _aqua_scene(out: DesignOutput) -> _Scene:
             f"~{_g(out.biofilter_media_m2)} m2 media", "nitrification"], "#e6f4ea"),
         _Box(490, 90, 190, 90, out.grow_bed_label,
              _grow_bed_lines(out), "#e8f5e9"),
-        _Box(270, 250, 170, 80, "Sump + pump", [
-            f"pump >={_g(out.pump_turnover_lph)} L/h", f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
+        _Box(270, 250, 170, 90, "Sump + pump", [
+            f"pump >={_g(out.pump_turnover_lph)} L/h",
+            f"{_g(out.pump_head_m)} m head, ~{_g(out.pump_power_w)} W",
+            f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
     ]
     s.arrows = [
         _Arrow(220, 135, 270, 135, "water"), _Arrow(440, 135, 490, 135, "nitrate"),
@@ -105,8 +107,10 @@ def _hydro_scene(out: HydroponicOutput) -> _Scene:
             f"{_g(out.grow_area_m2)} m2 planted"]
             + ([f"floor {_g(out.footprint_m2)} m2"] if out.footprint_ratio != 1.0 else [])
             + [f"water use {_g(out.daily_water_use_lpd)} L/day"], "#e8f5e9"),
-        _Box(260, 270, 200, 80, "Pump", [
-            f">={_g(out.pump_turnover_lph)} L/h", f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
+        _Box(260, 270, 200, 90, "Pump", [
+            f">={_g(out.pump_turnover_lph)} L/h",
+            f"{_g(out.pump_head_m)} m head, ~{_g(out.pump_power_w)} W",
+            f"makeup {_g(out.makeup_water_lpd)} L/day"], "#fff7ed"),
     ]
     s.arrows = [
         _Arrow(260, 150, 460, 150, "dosed solution"),

--- a/aqua_model/sizing.py
+++ b/aqua_model/sizing.py
@@ -85,8 +85,9 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
     system_volume_m3 = subtotal_m3 / (1.0 - C.SUMP_FRACTION.value)
     system_volume_l = system_volume_m3 * 1000.0
 
-    # 6. Pump turnover.
+    # 6. Pump turnover (flow) and the head/power it must deliver it against (method lift).
     pump_turnover_lph = system_volume_l * C.PUMP_TURNOVER_RATE.value
+    pump_head_m, pump_power_w = mb.pump_hydraulics(pump_turnover_lph, system)
 
     # 7. Water balance (tank surface approximated from rearing tank at ~1 m depth).
     tank_surface_m2 = rearing_tank_volume_m3 / 1.0
@@ -120,6 +121,8 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
         feed_g_per_day=round(feed_g_per_day, 1),
         grow_area_m2=design.grow_area_m2,
         pump_turnover_lph=round(pump_turnover_lph, 1),
+        pump_head_m=pump_head_m,
+        pump_power_w=pump_power_w,
         biofilter_media_m2=media_m2,
         makeup_water_lpd=makeup_lpd,
         nitrogen_check=n_check,
@@ -164,9 +167,13 @@ def size_system(design: DesignInput, overrides: dict | None = None) -> DesignOut
     water_depth_coeff = CoefficientUse(
         f"grow_bed_water_depth ({system.key})", system.water_depth_m,
         system.water_depth_low, system.water_depth_high, "m", system.source)
-    out.coefficients_used = [water_depth_coeff] + _coeff_uses(
+    lift_coeff = CoefficientUse(
+        f"pump_lift_height ({system.key})", system.lift_height_m,
+        system.lift_low, system.lift_high, "m", system.source)
+    out.coefficients_used = [water_depth_coeff, lift_coeff] + _coeff_uses(
         C.N_FRACTION_OF_PROTEIN, C.PLANT_N_UPTAKE_FRACTION,
-        C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, C.NITRIFICATION_RATE,
+        C.SUMP_FRACTION, C.PUMP_TURNOVER_RATE, C.FRICTION_HEAD_FRACTION,
+        C.PUMP_EFFICIENCY, C.NITRIFICATION_RATE,
         C.EVAPOTRANSPIRATION_RATE, C.TANK_EVAPORATION_RATE, C.SAFETY_FACTOR,
     )
     return out
@@ -220,7 +227,8 @@ def _bill_of_materials(out: DesignOutput, system) -> list[dict]:
     return [
         {"item": "rearing tank", "spec": f"~{round(out.rearing_tank_volume_l)} L", "qty": 1},
         {"item": system.grow_bed_item, "spec": f"{out.grow_area_m2} m2 planted area", "qty": 1},
-        {"item": "water pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h at head", "qty": 1},
+        {"item": "water pump", "spec": f"≥{round(out.pump_turnover_lph)} L/h against "
+         f"~{out.pump_head_m} m head (~{round(out.pump_power_w)} W electrical)", "qty": 1},
         {"item": "biofilter media", "spec": biofilter_spec, "qty": 1},
         {"item": "aeration", "spec": "air pump + stones; maintain DO ≥5 mg/L", "qty": 1},
         {"item": "fish (fingerlings)", "spec": f"~{out.fish_count} head", "qty": out.fish_count},

--- a/aqua_model/system_types.py
+++ b/aqua_model/system_types.py
@@ -29,6 +29,11 @@ class SystemType:
     # m² of GROWING area packed onto 1 m² of FLOOR. 1.0 for flat beds (footprint == grow area);
     # >1 for stacked/tower systems that trade vertical structure for floor space.
     footprint_ratio: float = 1.0
+    # Static lift (m) the pump must raise water — sump surface to the highest discharge point.
+    # Flat beds lift water a little above the sump; towers lift it to the top of every tower.
+    lift_height_m: float = 0.5
+    lift_low: float = 0.3
+    lift_high: float = 0.8
 
 
 RAFT = SystemType(
@@ -41,6 +46,7 @@ RAFT = SystemType(
         "Highest water volume of the three methods (more makeup water to warm/cool).",
     ],
     source="FAO589",
+    lift_height_m=0.4, lift_low=0.3, lift_high=0.6,
 )
 
 NFT = SystemType(
@@ -55,6 +61,7 @@ NFT = SystemType(
         "Best for lightweight leafy greens and herbs; heavy fruiting crops need support.",
     ],
     source="LIT",
+    lift_height_m=0.8, lift_low=0.5, lift_high=1.2,
 )
 
 MEDIA_BED = SystemType(
@@ -69,6 +76,7 @@ MEDIA_BED = SystemType(
         "Effective water volume is the void space in the media (~40%), between raft and NFT.",
     ],
     source="LIT",
+    lift_height_m=0.6, lift_low=0.4, lift_high=0.9,
 )
 
 VERTICAL_TOWER = SystemType(
@@ -80,12 +88,13 @@ VERTICAL_TOWER = SystemType(
         "Packs roughly 3 m2 of growing face onto 1 m2 of floor — the most space-efficient "
         "method, for growers where land or floor area is the binding constraint.",
         "Needs a vertical frame and even top-down water distribution; the pump must LIFT water "
-        "to the top of every tower, so size it for the extra head, not just turnover.",
+        "to the top of every tower — the design sizes the pump for that head and its power.",
         "Thin film with little buffering, and towers self-shade — best for light leafy greens, "
         "herbs, and strawberries; heavy fruiting crops are a poor fit.",
     ],
     source="LIT",
     footprint_ratio=3.0,  # ~2-4 m2 grow face per m2 floor; 3.0 is a conservative mid value
+    lift_height_m=2.0, lift_low=1.5, lift_high=2.5,  # top of a ~2 m tower
 )
 
 SYSTEM_TYPES = {st.key: st for st in (RAFT, NFT, MEDIA_BED, VERTICAL_TOWER)}

--- a/aqua_model/tests/test_pump_head.py
+++ b/aqua_model/tests/test_pump_head.py
@@ -1,0 +1,74 @@
+"""Pump HEAD, not just flow. A pump is specified by two numbers — the flow it moves (L/h)
+and the head it moves it against (m). The turnover flow was already sized; this quantifies
+the head (static lift + friction) and the resulting electrical power, so the vertical-tower
+"needs more lift" note becomes a real number a buyer can shop with.
+
+Physics anchor: electrical power = ρ g Q H / efficiency. Same flow at 5× the head costs ~5×
+the pump power — which is exactly why towers are not a free lunch, now shown numerically.
+"""
+
+import math
+
+import pytest
+
+from aqua_model import size_system, size_hydroponic_system, validate_design_input, \
+    validate_hydroponic_input
+from aqua_model import coefficients as C
+
+
+def test_every_design_reports_head_and_power():
+    out = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000))
+    assert out.pump_head_m > 0
+    assert out.pump_power_w > 0
+
+
+def test_head_is_static_lift_plus_friction():
+    from aqua_model.system_types import get_system_type
+    out = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000, system_type="raft"))
+    lift = get_system_type("raft").lift_height_m
+    expected = round(lift * (1 + C.FRICTION_HEAD_FRACTION.value), 2)
+    assert out.pump_head_m == pytest.approx(expected)
+
+
+def test_tower_costs_more_power_despite_moving_less_water():
+    tower = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000,
+                                              system_type="vertical_tower"))
+    raft = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000, system_type="raft"))
+    # A tower holds less water, so it actually recirculates a SMALLER flow than a raft...
+    assert tower.pump_turnover_lph < raft.pump_turnover_lph
+    # ...yet it lifts that water much higher, so both head and running power are larger.
+    # (This is the honest "towers are not a free lunch" signal, now quantified.)
+    assert tower.pump_head_m > raft.pump_head_m
+    assert tower.pump_power_w > raft.pump_power_w
+
+
+def test_power_matches_the_hydraulic_formula():
+    out = size_system(validate_design_input("tilapia", "lettuce", 20, 27, 6000,
+                                            system_type="vertical_tower"))
+    q_m3s = out.pump_turnover_lph / 1000.0 / 3600.0
+    hydraulic_w = 1000.0 * 9.81 * q_m3s * out.pump_head_m
+    expected = round(hydraulic_w / C.PUMP_EFFICIENCY.value, 1)
+    assert out.pump_power_w == pytest.approx(expected, rel=1e-3)
+
+
+def test_hydroponic_pump_also_reports_head_and_power():
+    out = size_hydroponic_system(validate_hydroponic_input("lettuce", 15, 22, 4000,
+                                                           system_type="vertical_tower"))
+    assert out.pump_head_m > 0 and out.pump_power_w > 0
+
+
+def test_head_and_power_are_cited_and_surfaced():
+    out = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000,
+                                            system_type="vertical_tower"))
+    names = " ".join(c.name for c in out.coefficients_used).lower()
+    assert "lift" in names and "friction" in names and "efficien" in names
+    bom = " ".join(str(i["spec"]).lower() for i in out.bill_of_materials)
+    assert "head" in bom and ("w" in bom)  # pump spec now carries head + power
+
+
+def test_serialization_shows_head_and_power():
+    from agronaut_agent.serialize import serialize_design_output
+    out = size_system(validate_design_input("tilapia", "lettuce", 12, 27, 3000,
+                                            system_type="vertical_tower"))
+    text = serialize_design_output(out).lower()
+    assert "head" in text and "w" in text

--- a/aqua_model/types.py
+++ b/aqua_model/types.py
@@ -63,6 +63,8 @@ class HydroponicOutput:
     daily_water_use_lpd: float = 0.0    # ET-driven solution consumption
     makeup_water_lpd: float = 0.0
     pump_turnover_lph: float = 0.0
+    pump_head_m: float = 0.0            # total dynamic head the pump works against
+    pump_power_w: float = 0.0           # estimated electrical power at that flow + head
 
     # --- nutrient solution (the hydroponics-specific part) ---
     nutrient_target: dict = field(default_factory=dict)  # EC band + elemental-N/day
@@ -111,6 +113,8 @@ class DesignOutput:
     feed_g_per_day: float = 0.0
     grow_area_m2: float = 0.0
     pump_turnover_lph: float = 0.0
+    pump_head_m: float = 0.0                 # total dynamic head the pump works against
+    pump_power_w: float = 0.0                # estimated electrical power at that flow + head
     biofilter_media_m2: float | None = None
     makeup_water_lpd: float = 0.0
 


### PR DESCRIPTION
## What & why

Vertical towers (#67) carried only an advisory *"needs more lift"* note. This makes it a real number. A pump is specified by **two** numbers — the flow it moves **and the head it moves it against** — and the head was missing. Now every design reports:

- **`pump_head_m`** — the method's static lift (sump surface → highest discharge) raised by a cited friction allowance for pipework (total dynamic head).
- **`pump_power_w`** — `ρ·g·Q·H / efficiency`, a running-power estimate a buyer can shop and budget with.

## The honest payoff, quantified

| Method | Flow | Head | Power |
|---|---|---|---|
| raft/DWC | 6667 L/h | 0.52 m | ~27 W |
| NFT | 3067 L/h | 1.04 m | ~25 W |
| media bed | 4267 L/h | 0.78 m | ~26 W |
| **vertical tower** | 3200 L/h | **2.60 m** | **~65 W** |

A tower draws **~2.5× the running power** of a flat bed at the same scale — even though it recirculates *less* water — because it lifts that water ~5× higher. Towers are not a free lunch, and now the model says so with a number instead of a caveat.

## Cited, not invented

Per-method static lift is cited/ranged on `SystemType` (raft 0.4, NFT 0.8, media 0.6, tower 2.0 m). Two new cited coefficients — `FRICTION_HEAD_FRACTION` (0.30) and `PUMP_EFFICIENCY` (0.35, wire-to-water) — both flow into `coefficients_used`, so head and power are as auditable as every other number. A shared `mb.pump_hydraulics()` feeds both aquaponic and hydroponic sizing.

## Surface

Threaded into the BOM (pump spec now `≥X L/h against ~Y m head (~Z W electrical)`), serialization, the schematic pump box, and the design report.

## Tests

7 new (head/power present, static-lift+friction formula, tower > flat power despite less flow, hydraulic-power formula, hydroponic pump, cited + surfaced, serialization). **387 passed, 2 skipped.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJrKmzSKhGu4MTXuv46Ak