### PR TITLE
feat(cli): make Agronaut usable as an `agronaut` terminal command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ gate, that is a bug worth an issue on its own.
 git clone https://github.com/Rekin226/Agronaut.git
 cd Agronaut
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirement.txt
+pip install -e .                         # deps + the `agronaut` command on your PATH
 ```
 
 Run things:
@@ -62,7 +62,8 @@ pytest                                   # the full suite (~530 tests)
 pytest aqua_model/tests -q               # just the deterministic core (fast, no LLM needed)
 python -m scripts.safety_eval            # the advice-safety golden set; exits non-zero on a CRITICAL failure
 streamlit run app.py                     # the web UI (Calculator + Optimizer need no LLM at all)
-python -m skills.aquaponics_engineer.cli size-aquaponics --help   # headless CLI
+agronaut --help                          # the one command over all of the above
+python -m skills.aquaponics_engineer.cli size-aquaponics --help   # the portable skill CLI
 ```
 
 **You do not need an API key to contribute.** The Design Calculator, the Optimizer, the whole

--- a/README.md
+++ b/README.md
@@ -187,13 +187,40 @@ named volume, shared between web and bot.
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
-pip install -r requirement.txt
+pip install -e .                 # installs the deps and the `agronaut` command
 streamlit run app.py
 ```
 
 Open the sidebar **Mode** switch. The **Design Calculator** and **Optimize Ratio** modes
 work immediately (no model server). For **chat**, run Ollama locally or set a hosted
 provider (see above).
+
+(`pip install -r requirement.txt` still works if you only want the libraries — `pip install -e .`
+installs the same list and adds the command below.)
+
+### The `agronaut` command
+
+One front door over everything the project ships. It works from any directory once
+installed; bare `agronaut` is the chat REPL, because that is what most people want.
+
+```bash
+agronaut                         # chat with the agent in the terminal
+agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000
+agronaut size-hydro --crop lettuce --area 10 --temp 22 --water 500
+agronaut optimize --area 10 --temp 28 --water 5000 --objective food
+agronaut list                    # supported species, crops, objectives
+agronaut web                     # the Streamlit app (trailing flags go to streamlit,
+                                 #   e.g. agronaut web --server.port=9000)
+agronaut bot                     # the Telegram bot
+agronaut review                  # approve/reject pending community insights
+agronaut analytics               # usage summary
+```
+
+| Command | Needs an LLM? |
+|---|---|
+| `size` / `size-hydro` / `optimize` / `list` | **No.** Pure `aqua_model` — deterministic, offline, cited. Bad input exits non-zero at the trust gate rather than guessing. |
+| `chat` (the default) / `bot` | Yes — a tool-calling provider (see above). |
+| `web` | Only for the app's chat mode; the calculator and optimizer run without one. |
 
 ### Run the tests
 ```bash
@@ -215,7 +242,7 @@ The consultative agent is reachable over Telegram. Set these (in `.env` or the e
 
 ```bash
 source .venv/bin/activate
-python bot.py            # long-polls Telegram; Ctrl-C to stop
+agronaut bot             # long-polls Telegram; Ctrl-C to stop (same as `python bot.py`)
 ```
 
 ### Run on WhatsApp (Cloud API)
@@ -310,6 +337,7 @@ agent/                 # LLM-facing layer (imports aqua_model, never the reverse
   calculator_ui.py optimizer_ui.py facts.py   # Streamlit views + the UI/model seam
 
 agronaut_agent/        # the channel-agnostic brain
+  cli.py               #   the `agronaut` command — one front door, routes to the real callables
   core.py              #   handle_message / handle_image / handle_voice — the three seams
   tools.py             #   the LLM-callable tools (thin wrappers over the trust zone)
   store.py profile.py  #   SQLite memory: System Profile, notes, calibration, follow-ups
@@ -321,6 +349,7 @@ skills/                # the deterministic core as a portable agentskills.io ski
 knowledge/ urls.txt    # the curated, cited knowledge base
 docs/dpg/              # DPG compliance pack: privacy, AI transparency, safety eval
 app.py                 # Streamlit app (chat | calculator | optimizer)
+pyproject.toml         # packaging + the `agronaut` console script (deps read from requirement.txt)
 srcs/chatbot.py        # legacy RAG/state-machine layer, slated for retirement (#25)
 ```
 

--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -1,0 +1,109 @@
+"""agronaut — one terminal command over everything the project ships.
+
+Bare `agronaut` is the chat REPL, which is what most people want; the subcommands cover
+the deterministic sizing engine, the two long-running services, and the maintainer tools.
+Nothing here reimplements a feature — each command routes to the callable that already
+owns it, so this module stays a dispatcher and only a dispatcher.
+
+    agronaut                                        # chat with the agent
+    agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000
+    agronaut web                                    # the Streamlit app
+    agronaut bot                                    # the Telegram bot
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _root_importable() -> None:
+    """`bot` and `app` are top-level modules at the project root, not package members."""
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+
+
+def _cmd_chat(args) -> int:
+    from . import core  # imported late: `agronaut list` must not pay for the LLM stack
+    core._repl()
+    return 0
+
+
+def _cmd_web(args) -> int:
+    # sys.executable, not a bare "streamlit": the console script is often invoked by
+    # absolute path (systemd, cron, another venv's shell) with our bin/ not on PATH.
+    return subprocess.call([sys.executable, "-m", "streamlit", "run", str(ROOT / "app.py"),
+                            *args.streamlit_args])
+
+
+def _cmd_bot(args) -> int:
+    _root_importable()
+    import bot
+
+    bot.main()
+    return 0
+
+
+def _cmd_review(args) -> int:
+    from . import review
+
+    review.main()
+    return 0
+
+
+def _cmd_analytics(args) -> int:
+    from . import analytics
+
+    return analytics.main()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="agronaut",
+        description="Aquaponics assistant: chat, computed sizing, web app, bot.",
+        epilog="Run with no arguments to start chatting.",
+    )
+    p.set_defaults(func=_cmd_chat)  # bare `agronaut` -> chat
+    sub = p.add_subparsers(dest="cmd")
+
+    sub.add_parser("chat", help="chat with the agent in the terminal").set_defaults(func=_cmd_chat)
+
+    # Sizing commands are defined once, in the portable skill CLI, and borrowed here under
+    # shorter names so the two surfaces cannot drift apart.
+    from skills.aquaponics_engineer.cli import add_sizing_subcommands
+
+    add_sizing_subcommands(sub, aliases={"size-aquaponics": ["size"],
+                                         "size-hydroponics": ["size-hydro"]})
+
+    web = sub.add_parser("web", help="run the Streamlit web app "
+                                     "(trailing flags are passed to streamlit)")
+    web.add_argument("streamlit_args", nargs="*",
+                     help="e.g. --server.port=9000 --server.headless=true")
+    web.set_defaults(func=_cmd_web)
+    sub.add_parser("bot", help="run the Telegram bot").set_defaults(func=_cmd_bot)
+    sub.add_parser("review", help="approve/reject pending community insights").set_defaults(
+        func=_cmd_review)
+    sub.add_parser("analytics", help="summarise recorded usage").set_defaults(func=_cmd_analytics)
+    return p
+
+
+def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = _build_parser()
+    # `web` is a launcher, so everything after it belongs to Streamlit and is handed over
+    # verbatim: `--server.port=9000` is not ours to parse, and rejecting it would make this
+    # command strictly worse than the `streamlit run` it replaces.
+    if argv[:1] == ["web"] and argv[1:] not in ([], ["-h"], ["--help"]):
+        args = parser.parse_args(["web"])
+        args.streamlit_args = argv[1:]
+        return args.func(args)
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agronaut_agent/tests/test_cli.py
+++ b/agronaut_agent/tests/test_cli.py
@@ -1,0 +1,156 @@
+"""The `agronaut` command — one front door over every entrypoint the project ships.
+
+The dispatcher owns routing only: each subcommand must reach the real callable that
+already implements it (the REPL, the deterministic sizing engine, the Streamlit app, the
+bot, the maintainer tools). The trust gate has to survive the new front door — a bad
+argument still exits non-zero rather than producing a wrong design.
+"""
+
+import contextlib
+import io
+import pathlib
+import sys
+
+import pytest
+
+from agronaut_agent import cli
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _run(argv):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        code = cli.main(argv)
+    return code, buf.getvalue()
+
+
+# --- chat: the bare command is the REPL -------------------------------------------------
+
+def test_bare_command_starts_the_chat_repl(monkeypatch):
+    from agronaut_agent import core
+    called = []
+    monkeypatch.setattr(core, "_repl", lambda: called.append(True))
+    assert cli.main([]) == 0
+    assert called == [True]
+
+
+def test_chat_subcommand_starts_the_chat_repl(monkeypatch):
+    from agronaut_agent import core
+    called = []
+    monkeypatch.setattr(core, "_repl", lambda: called.append(True))
+    assert cli.main(["chat"]) == 0
+    assert called == [True]
+
+
+# --- sizing: the deterministic engine, reached through the top-level command ------------
+
+def test_size_prints_a_cited_feasible_design():
+    code, out = _run(["size", "--fish", "tilapia", "--crop", "lettuce",
+                      "--area", "12", "--temp", "27", "--water", "3000"])
+    assert code == 0
+    assert "FEASIBLE" in out
+    assert "source:" in out and "NOT modeled" in out
+
+
+def test_size_hydro_prints_the_nutrient_target():
+    code, out = _run(["size-hydro", "--crop", "lettuce",
+                      "--area", "10", "--temp", "22", "--water", "500"])
+    assert code == 0
+    assert "hydroponic" in out.lower() and "EC" in out
+
+
+def test_optimize_prints_the_best_ratio():
+    code, out = _run(["optimize", "--area", "10", "--temp", "28", "--water", "5000",
+                      "--objective", "food"])
+    assert code == 0
+    assert "Best ratio" in out
+
+
+def test_list_shows_species_and_crops():
+    code, out = _run(["list"])
+    assert code == 0
+    assert "tilapia" in out and "lettuce" in out
+
+
+def test_trust_gate_survives_the_new_front_door():
+    code, out = _run(["size", "--fish", "shark", "--crop", "lettuce",
+                      "--area", "12", "--temp", "27", "--water", "3000"])
+    assert code != 0
+    assert "VALIDATION_FAILED" in out
+
+
+def test_canonical_skill_names_still_work():
+    # The portable skill CLI's own names stay valid at the top level, so docs written
+    # against either surface keep working.
+    code, out = _run(["size-aquaponics", "--fish", "tilapia", "--crop", "lettuce",
+                      "--area", "12", "--temp", "27", "--water", "3000"])
+    assert code == 0 and "FEASIBLE" in out
+
+
+# --- the long-running services ----------------------------------------------------------
+
+def test_web_launches_streamlit_on_the_real_app_file(monkeypatch):
+    seen = {}
+
+    def _fake_call(argv):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(cli.subprocess, "call", _fake_call)
+    assert cli.main(["web"]) == 0
+    argv = seen["argv"]
+    # Launched through the running interpreter, not a bare "streamlit": an installed
+    # command is routinely invoked by absolute path, with the venv's bin/ nowhere on PATH.
+    assert argv[:3] == [sys.executable, "-m", "streamlit"]
+    assert argv[3] == "run"
+    app = pathlib.Path(argv[4])
+    assert app.is_absolute() and app.is_file() and app.name == "app.py"
+
+
+def test_web_forwards_extra_flags_to_streamlit(monkeypatch):
+    # `agronaut web --server.headless=true` has to reach Streamlit; a front door that
+    # swallows the server's own flags is worse than the command it replaces.
+    seen = {}
+
+    def _fake_call(argv):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(cli.subprocess, "call", _fake_call)
+    assert cli.main(["web", "--server.headless=true", "--server.port=9000"]) == 0
+    assert seen["argv"][-2:] == ["--server.headless=true", "--server.port=9000"]
+
+
+def test_bot_runs_the_telegram_entrypoint(monkeypatch):
+    import bot
+    called = []
+    monkeypatch.setattr(bot, "main", lambda: called.append(True))
+    assert cli.main(["bot"]) == 0
+    assert called == [True]
+
+
+# --- maintainer commands ----------------------------------------------------------------
+
+def test_review_runs_the_community_review_loop(monkeypatch):
+    from agronaut_agent import review
+    called = []
+    monkeypatch.setattr(review, "main", lambda: called.append(True))
+    assert cli.main(["review"]) == 0
+    assert called == [True]
+
+
+def test_analytics_runs_the_usage_summary(monkeypatch):
+    from agronaut_agent import analytics
+    called = []
+    monkeypatch.setattr(analytics, "main", lambda: called.append(True) or 0)
+    assert cli.main(["analytics"]) == 0
+    assert called == [True]
+
+
+# --- misuse -----------------------------------------------------------------------------
+
+def test_unknown_subcommand_exits_nonzero():
+    with pytest.raises(SystemExit) as err:
+        cli.main(["harvest"])
+    assert err.value.code != 0

--- a/agronaut_agent/tests/test_packaging.py
+++ b/agronaut_agent/tests/test_packaging.py
@@ -1,0 +1,52 @@
+"""Packaging: `pip install -e .` must put a real `agronaut` command on PATH, and that
+command must work from any directory.
+
+The second half is not cosmetic. The knowledge base and the URL corpus were addressed
+relative to the current directory, which is fine for `python -m` from the repo root and
+silently wrong for an installed command run from anywhere else: RAG degrades to
+KNOWLEDGE_UNAVAILABLE with only a log line to show for it.
+"""
+
+import pathlib
+import tomllib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="module")
+def pyproject():
+    path = ROOT / "pyproject.toml"
+    assert path.is_file(), "pyproject.toml is what makes `agronaut` installable"
+    return tomllib.loads(path.read_text())
+
+
+def test_declares_the_agronaut_console_script(pyproject):
+    scripts = pyproject["project"]["scripts"]
+    assert scripts["agronaut"] == "agronaut_agent.cli:main"
+
+
+def test_ships_every_package_the_command_imports(pyproject):
+    packages = set(pyproject["tool"]["setuptools"]["packages"]["find"]["include"])
+    for pkg in ("agronaut_agent*", "agent*", "aqua_model*", "srcs*", "skills*", "scripts*"):
+        assert pkg in packages, f"{pkg} missing — an installed `agronaut` would fail to import"
+
+
+def test_ships_the_bot_and_app_entry_modules(pyproject):
+    modules = set(pyproject["tool"]["setuptools"]["py-modules"])
+    assert {"bot", "app"} <= modules
+
+
+def test_knowledge_corpus_resolves_from_any_directory(tmp_path, monkeypatch):
+    from srcs import chatbot
+    monkeypatch.chdir(tmp_path)
+    assert pathlib.Path(chatbot.URL_FILE).is_file()
+    assert pathlib.Path(chatbot.KNOWLEDGE_DIR).is_dir()
+    assert any(pathlib.Path(chatbot.KNOWLEDGE_DIR).glob("*.md"))
+
+
+def test_web_cache_does_not_land_in_the_callers_directory(tmp_path, monkeypatch):
+    from srcs import chatbot
+    monkeypatch.chdir(tmp_path)
+    assert pathlib.Path(chatbot.CACHE_NAME).is_absolute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "agronaut"
+version = "1.0.0"
+description = "Cited, deterministic aquaponics and hydroponics design with a conversational agent"
+readme = "README.md"
+requires-python = ">=3.11"
+license = "MIT"
+authors = [{ name = "Abdoul Rachid Ouédraogo", email = "abdoulrachid03@gmail.com" }]
+keywords = ["aquaponics", "hydroponics", "agriculture", "food security", "digital public good"]
+dynamic = ["dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/Rekin226/Agronaut"
+Source = "https://github.com/Rekin226/Agronaut"
+
+[project.scripts]
+agronaut = "agronaut_agent.cli:main"
+
+[tool.setuptools.dynamic]
+# requirement.txt stays the single source of truth — it is what the Dockerfile and CI install.
+dependencies = { file = ["requirement.txt"] }
+
+[tool.setuptools]
+# bot.py and app.py sit at the project root as scripts, not inside a package; `agronaut bot`
+# and `agronaut web` need them installed alongside the packages.
+py-modules = ["bot", "app"]
+
+[tool.setuptools.packages.find]
+include = ["agronaut_agent*", "agent*", "aqua_model*", "srcs*", "skills*", "scripts*"]

--- a/skills/aquaponics_engineer/cli.py
+++ b/skills/aquaponics_engineer/cli.py
@@ -72,12 +72,20 @@ def _cmd_list(a) -> int:
     return 0
 
 
-def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="aquaponics-engineer",
-                                description="Computed, cited aquaponics/hydroponics sizing.")
-    sub = p.add_subparsers(dest="cmd", required=True)
+def add_sizing_subcommands(sub, aliases: dict | None = None) -> None:
+    """Register the four sizing commands on an existing subparser group.
 
-    sa = sub.add_parser("size-aquaponics", help="size a fish+plant system")
+    Shared so the top-level `agronaut` command and this portable skill CLI define the
+    arguments once and cannot drift apart. `aliases` maps a canonical command name to
+    extra names — `agronaut` offers shorter ones (`size`, `size-hydro`) while the skill
+    keeps the explicit names an agent reads from SKILL.md.
+    """
+    aliases = aliases or {}
+
+    def _add(name, **kw):
+        return sub.add_parser(name, aliases=aliases.get(name, []), **kw)
+
+    sa = _add("size-aquaponics", help="size a fish+plant system")
     sa.add_argument("--fish", required=True)
     sa.add_argument("--crop", required=True)
     sa.add_argument("--area", type=float, required=True, help="grow area m2")
@@ -85,22 +93,29 @@ def _build_parser() -> argparse.ArgumentParser:
     sa.add_argument("--water", type=float, required=True, help="daily water budget L")
     sa.set_defaults(func=_cmd_size_aquaponics)
 
-    sh = sub.add_parser("size-hydroponics", help="size a plant-only (no fish) system")
+    sh = _add("size-hydroponics", help="size a plant-only (no fish) system")
     sh.add_argument("--crop", required=True)
     sh.add_argument("--area", type=float, required=True)
     sh.add_argument("--temp", type=float, required=True)
     sh.add_argument("--water", type=float, required=True)
     sh.set_defaults(func=_cmd_size_hydroponics)
 
-    so = sub.add_parser("optimize", help="best fish/crop ratio under a constraint")
+    so = _add("optimize", help="best fish/crop ratio under a constraint")
     so.add_argument("--area", type=float, required=True)
     so.add_argument("--temp", type=float, required=True)
     so.add_argument("--water", type=float, required=True)
     so.add_argument("--objective", default="water_efficiency")
     so.set_defaults(func=_cmd_optimize)
 
-    sl = sub.add_parser("list", help="list supported species, crops, objectives")
+    sl = _add("list", help="list supported species, crops, objectives")
     sl.set_defaults(func=_cmd_list)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="aquaponics-engineer",
+                                description="Computed, cited aquaponics/hydroponics sizing.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    add_sizing_subcommands(sub)
     return p
 
 

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -34,8 +34,13 @@ from langchain_community.vectorstores import FAISS
 # Configuration
 # =============================================================================
 
-URL_FILE = "urls.txt"
-KNOWLEDGE_DIR = "knowledge"
+# Anchored to the project root, not the current directory: `agronaut` is an installed
+# command that can be run from anywhere, and a cwd-relative corpus would silently degrade
+# RAG to KNOWLEDGE_UNAVAILABLE instead of failing loudly.
+_PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+URL_FILE = str(_PROJECT_ROOT / "urls.txt")
+KNOWLEDGE_DIR = str(_PROJECT_ROOT / "knowledge")
 WEB_LOAD_TIMEOUT = 20
 
 
@@ -45,7 +50,7 @@ CHUNK_OVERLAP = 100
 EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
 TOP_K = 3
 
-CACHE_NAME = "web_cache"
+CACHE_NAME = str(_PROJECT_ROOT / "web_cache")   # absolute: see _PROJECT_ROOT above
 CACHE_EXPIRE = 86_400  # 1 day
 
 LOG_LEVEL = logging.INFO


### PR DESCRIPTION
## Summary

Agronaut had a terminal chat REPL and a deterministic sizing CLI, but both were reachable only as `python -m …` from the repo root. This packages the project and puts one command in front of everything.

```bash
pip install -e .
agronaut                 # chat with the agent, from any directory
```

**Packaging** (`pyproject.toml`) — console script `agronaut = agronaut_agent.cli:main`. Dependencies are read dynamically from `requirement.txt`, so there is no second list to keep in sync; Docker and CI, which install from that file, are untouched. Verified: all 18 declared deps land in the installed metadata, the commented-out optional ones stay out.

**Dispatcher** (`agronaut_agent/cli.py`) — a dispatcher and only a dispatcher. Bare `agronaut` is the chat REPL; `size` / `size-hydro` / `optimize` / `list` reach the deterministic engine; `web`, `bot`, `review`, `analytics` reach the existing entrypoints. The sizing subcommands are defined once, in `skills/aquaponics_engineer/cli.py`, and borrowed here under shorter names, so the portable skill CLI and the top-level command cannot drift. The trust gate survives the new front door: `--fish shark` still exits 2 with `VALIDATION_FAILED`.

**Path anchoring** (`srcs/chatbot.py`) — `URL_FILE`, `KNOWLEDGE_DIR` and `CACHE_NAME` were addressed relative to the current directory. Fine for `python -m` from the repo root, silently wrong for an installed command run anywhere else: RAG would degrade to `KNOWLEDGE_UNAVAILABLE` with one log line to show for it, and `web_cache.sqlite` would land wherever the user happened to be.

Two bugs the live runs caught, both fixed test-first: `agronaut web` swallowed Streamlit's own flags, and it shelled out to a bare `streamlit`, which is not on PATH when a console script is invoked by absolute path (systemd, cron, another venv).

## Test Coverage

19 new tests, no framework changes. `agronaut_agent/tests/test_cli.py` covers dispatch for every subcommand (bare invocation → REPL, each subcommand → the real callable, unknown subcommand → non-zero), the trust gate through the new front door, Streamlit flag pass-through, and the interpreter-relative launch. `agronaut_agent/tests/test_packaging.py` covers the console-script declaration, the shipped package list, and cwd-independence of the knowledge corpus. The existing skill-CLI tests are the regression guard on the shared-subparser refactor and stay green unchanged.

Tests: 541 → 560 (+19 new). Full suite: 560 passed, 2 skipped.

## Pre-Landing Review

CI's blocking lint gate (`ruff check --select E9,F63,F7,F82`) passes; the new files are clean under the full ruff ruleset too.

## Test plan

- [x] Full suite green (560 passed, 2 skipped)
- [x] `agronaut --help`, `list`, `size`, `analytics` run from a temp directory
- [x] Trust gate exits 2 on an unknown species
- [x] `agronaut web --server.port=8599` binds for real
- [x] Live chat turn through `agronaut chat` from a foreign directory
- [ ] `agronaut bot` not run live — a second long-poller would fight the running systemd service; dispatch is covered by test

🤖 Generated with [Claude Code](https://claude.com/claude-code)