### PR TITLE
fix: the optimizer had no trust gate, and `pip install .` shipped no knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ agronaut review                  # approve/reject pending community insights
 agronaut analytics               # usage summary
 ```
 
+**Where it keeps things.** In a checkout, the knowledge base, the fetched-page cache and the
+SQLite memory DB all sit beside the source, as before. Installed non-editably, the cited
+corpus is read from `<prefix>/share/agronaut` and state goes to your XDG directories rather
+than into `site-packages` — override any of it with `AGRONAUT_CORPUS_DIR`,
+`AGRONAUT_CACHE_DIR`, or `AGRONAUT_DATA_DIR`.
+
 | Command | Needs an LLM? |
 |---|---|
 | `size` / `size-hydro` / `optimize` / `list` | **No.** Pure `aqua_model` — deterministic, offline, cited. Bad input exits non-zero at the trust gate rather than guessing. |

--- a/agronaut_agent/analytics.py
+++ b/agronaut_agent/analytics.py
@@ -24,7 +24,9 @@ _ALLOWED_FIELDS = {"tool", "goal", "channel", "ok"}
 
 _SIZING_TOOLS = {"size_aquaponics_system", "size_hydroponic_system_tool"}
 
-_DEFAULT_PATH = Path(__file__).resolve().parent.parent / "data" / "analytics.jsonl"
+from . import paths as _paths
+
+_DEFAULT_PATH = _paths.data_dir() / "analytics.jsonl"
 
 
 def _hash_uid(user_id: str) -> str:

--- a/agronaut_agent/paths.py
+++ b/agronaut_agent/paths.py
@@ -1,0 +1,84 @@
+"""Where Agronaut reads its corpus and writes its state.
+
+One module answers this, because the answer differs by how Agronaut was installed and
+getting it wrong is silent. In a checkout everything lives beside the source, which is what
+`pip install -e .` and `docker compose` both give you. Under a plain `pip install .` the
+package lands in site-packages, and site-packages is the wrong place to look for the
+knowledge base and a worse place to write a cache: often read-only, often root-owned,
+sometimes shared between users, and wiped on uninstall.
+
+Every lookup here is overridable by an environment variable, so a container or a packager
+can put the corpus and the state wherever it belongs without patching code.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# The source tree's root — the directory holding knowledge/, urls.txt and data/ in a
+# checkout. Under a wheel install this is site-packages, which is exactly the case the
+# fallbacks below exist for.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def corpus_root() -> Path:
+    """Directory containing `knowledge/` and `urls.txt`.
+
+    A missing corpus is not loud: the RAG layer logs at most a warning and then answers
+    every question with KNOWLEDGE_UNAVAILABLE, so the assistant sounds fine and cites
+    nothing. Prefer the checkout, fall back to where a wheel's data files install.
+    """
+    override = os.environ.get("AGRONAUT_CORPUS_DIR")
+    if override:
+        return Path(override)
+    if (PROJECT_ROOT / "knowledge").is_dir():
+        return PROJECT_ROOT
+    return Path(sys.prefix) / "share" / "agronaut"
+
+
+def cache_dir() -> Path:
+    """Directory for regenerable caches (the fetched-page sqlite).
+
+    Kept in the source tree for a checkout, so a working copy keeps the cache it already
+    warmed; otherwise a per-user cache directory.
+    """
+    override = os.environ.get("AGRONAUT_CACHE_DIR")
+    if override:
+        return Path(override)
+    if _is_source_tree():
+        return PROJECT_ROOT
+    base = os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache"
+    return _ensured(Path(base) / "agronaut")
+
+
+def data_dir() -> Path:
+    """Directory for state worth keeping — the memory DB and the usage log."""
+    override = os.environ.get("AGRONAUT_DATA_DIR")
+    if override:
+        return Path(override)
+    if _is_source_tree():
+        return PROJECT_ROOT / "data"
+    base = os.environ.get("XDG_DATA_HOME") or Path.home() / ".local" / "share"
+    return _ensured(Path(base) / "agronaut")
+
+
+def _ensured(path: Path) -> Path:
+    """Create the per-user directory on the way out — nothing downstream expects to have to.
+
+    Only the fallback branches call this: a checkout's own directories already exist, and an
+    explicit override is the caller's to manage.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _is_source_tree() -> bool:
+    """True in a checkout (or an editable install), false once installed into site-packages.
+
+    Writability is the wrong question: site-packages in a user-owned venv is writable, and
+    that is precisely where state must not go — wiped on uninstall, shared between users of
+    a system interpreter, and baked into container layers. The project file is the signal.
+    """
+    return (PROJECT_ROOT / "pyproject.toml").is_file()

--- a/agronaut_agent/store.py
+++ b/agronaut_agent/store.py
@@ -16,7 +16,9 @@ import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
-_DEFAULT_DB = Path(__file__).resolve().parent.parent / "data" / "agronaut.sqlite3"
+from . import paths as _paths
+
+_DEFAULT_DB = _paths.data_dir() / "agronaut.sqlite3"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS users (

--- a/agronaut_agent/tests/test_cli.py
+++ b/agronaut_agent/tests/test_cli.py
@@ -73,11 +73,41 @@ def test_list_shows_species_and_crops():
     assert "tilapia" in out and "lettuce" in out
 
 
-def test_trust_gate_survives_the_new_front_door():
-    code, out = _run(["size", "--fish", "shark", "--crop", "lettuce",
-                      "--area", "12", "--temp", "27", "--water", "3000"])
-    assert code != 0
+# The gate has to hold on EVERY sizing command, not just the one that was easy to test.
+# `optimize` shipped with no gate at all: `--area -5` returned a confident "Best ratio" with
+# negative yields at exit 0, and `--temp nan` scored identically to an optimal temperature.
+# Exit code is asserted exactly: setuptools' console script does sys.exit(main()), and
+# sys.exit(None) exits 0 — so `!= 0` would pass for a command that silently stopped
+# returning its status, and an agent shelling out would read a rejected design as success.
+_HOSTILE = [
+    ("size", ["--fish", "shark", "--crop", "lettuce", "--area", "12", "--temp", "27",
+              "--water", "3000"], "unknown fish_species"),
+    ("size", ["--fish", "tilapia", "--crop", "lettuce", "--area", "-5", "--temp", "27",
+              "--water", "3000"], "grow_area_m2"),
+    ("size-hydro", ["--crop", "unobtainium", "--area", "10", "--temp", "22",
+                    "--water", "500"], "unknown crop"),
+    ("size-hydro", ["--crop", "lettuce", "--area", "10", "--temp", "nan",
+                    "--water", "500"], "temperature_c"),
+    ("optimize", ["--area", "-5", "--temp", "28", "--water", "5000"], "grow_area_m2"),
+    ("optimize", ["--area", "10", "--temp", "nan", "--water", "5000"], "temperature_c"),
+    ("optimize", ["--area", "10", "--temp", "28", "--water", "inf"], "water_budget_lpd"),
+]
+
+
+@pytest.mark.parametrize("cmd,args,expected", _HOSTILE,
+                         ids=[f"{c}:{e}" for c, _, e in _HOSTILE])
+def test_trust_gate_survives_the_new_front_door(cmd, args, expected):
+    code, out = _run([cmd, *args])
+    assert code == 2, f"{cmd} accepted {args} and exited {code}"
     assert "VALIDATION_FAILED" in out
+    assert expected in out
+
+
+def test_unknown_objective_is_rejected_not_defaulted():
+    code, out = _run(["optimize", "--area", "10", "--temp", "28", "--water", "5000",
+                      "--objective", "maximise_vibes"])
+    assert code == 2
+    assert "maximise_vibes" in out
 
 
 def test_canonical_skill_names_still_work():

--- a/agronaut_agent/tests/test_packaging.py
+++ b/agronaut_agent/tests/test_packaging.py
@@ -8,7 +8,11 @@ KNOWLEDGE_UNAVAILABLE with only a log line to show for it.
 """
 
 import pathlib
+import shutil
+import subprocess
+import sys
 import tomllib
+import zipfile
 
 import pytest
 
@@ -50,3 +54,110 @@ def test_web_cache_does_not_land_in_the_callers_directory(tmp_path, monkeypatch)
     from srcs import chatbot
     monkeypatch.chdir(tmp_path)
     assert pathlib.Path(chatbot.CACHE_NAME).is_absolute()
+
+
+# --- the corpus has to survive a real install -------------------------------------------
+# The tests above only prove the checkout works. A wheel is what `pip install .` produces,
+# and it shipped no knowledge/*.md and no urls.txt at all: _PROJECT_ROOT resolved into
+# site-packages, the corpus was not there, and every answer came back citing nothing while
+# looking healthy. Build the artifact and assert on it.
+
+
+_BUILD_NOISE = shutil.ignore_patterns(".git", ".venv", "build", "dist", "*.egg-info",
+                                      "__pycache__", "*.sqlite", "*.sqlite3", "web_cache.sqlite")
+
+
+def _build_wheel(tmp_path) -> zipfile.ZipFile:
+    """Build a wheel from a clean copy of the tree, with pip's wheel cache disabled.
+
+    Both precautions are load-bearing. A leftover `agronaut.egg-info` in the working tree
+    feeds its SOURCES.txt into the build and silently puts the whole test suite back in the
+    wheel, and pip will happily hand back a cached wheel built before the fix — either one
+    turns this into a test that passes no matter what the packaging config says.
+    """
+    src = tmp_path / "src"
+    shutil.copytree(ROOT, src, ignore=_BUILD_NOISE)
+    out = tmp_path / "wheel"
+    subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "--no-build-isolation",
+         "--no-cache-dir", "-q", "-w", str(out), str(src)],
+        check=True, capture_output=True,
+    )
+    wheels = list(out.glob("*.whl"))
+    assert len(wheels) == 1, f"expected one wheel, got {wheels}"
+    return zipfile.ZipFile(wheels[0])
+
+
+def test_wheel_ships_the_cited_knowledge_corpus(tmp_path):
+    names = _build_wheel(tmp_path).namelist()
+    md = [n for n in names if n.endswith(".md") and "knowledge" in n]
+    assert len(md) >= 20, f"knowledge corpus missing from the wheel (found {len(md)} docs)"
+    assert any(n.endswith("urls.txt") for n in names), "urls.txt missing from the wheel"
+
+
+def test_wheel_does_not_ship_the_test_suite(tmp_path):
+    names = _build_wheel(tmp_path).namelist()
+    tests = [n for n in names if "/tests/" in n]
+    assert tests == [], f"wheel ships {len(tests)} test files"
+
+
+# --- writes must not land in the install root -------------------------------------------
+
+def test_cache_and_data_fall_back_to_user_dirs_when_the_root_is_read_only(tmp_path, monkeypatch):
+    from agronaut_agent import paths
+
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.delenv("AGRONAUT_CACHE_DIR", raising=False)
+    monkeypatch.setattr(paths, "PROJECT_ROOT", tmp_path / "not-writable")
+
+    assert paths.cache_dir() == tmp_path / "cache" / "agronaut"
+    assert paths.data_dir() == tmp_path / "data" / "agronaut"
+
+
+def test_a_writable_site_packages_is_still_not_where_state_goes(tmp_path, monkeypatch):
+    # The discriminator cannot be "is the root writable" — site-packages in a user-owned
+    # venv is writable, and that is exactly where the memory DB and the fetched-page cache
+    # must not go: wiped on uninstall, shared between users, bloating container layers.
+    from agronaut_agent import paths
+
+    fake_site_packages = tmp_path / "site-packages"
+    (fake_site_packages / "agronaut_agent").mkdir(parents=True)   # installed, no pyproject.toml
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
+    monkeypatch.delenv("AGRONAUT_CACHE_DIR", raising=False)
+    monkeypatch.delenv("AGRONAUT_DATA_DIR", raising=False)
+    monkeypatch.setattr(paths, "PROJECT_ROOT", fake_site_packages)
+
+    assert paths.cache_dir() == tmp_path / "cache" / "agronaut"
+    assert paths.data_dir() == tmp_path / "data" / "agronaut"
+
+
+def test_a_checkout_keeps_its_state_beside_the_source(tmp_path, monkeypatch):
+    from agronaut_agent import paths
+
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "pyproject.toml").write_text("")
+    monkeypatch.delenv("AGRONAUT_CACHE_DIR", raising=False)
+    monkeypatch.delenv("AGRONAUT_DATA_DIR", raising=False)
+    monkeypatch.setattr(paths, "PROJECT_ROOT", checkout)
+
+    assert paths.cache_dir() == checkout
+    assert paths.data_dir() == checkout / "data"
+
+
+def test_corpus_falls_back_to_the_installed_share_dir(tmp_path, monkeypatch):
+    from agronaut_agent import paths
+
+    monkeypatch.delenv("AGRONAUT_CORPUS_DIR", raising=False)
+    monkeypatch.setattr(paths, "PROJECT_ROOT", tmp_path / "no-corpus-here")
+    monkeypatch.setattr(paths.sys, "prefix", str(tmp_path / "venv"))
+    assert paths.corpus_root() == tmp_path / "venv" / "share" / "agronaut"
+
+
+def test_corpus_env_override_wins(tmp_path, monkeypatch):
+    from agronaut_agent import paths
+
+    monkeypatch.setenv("AGRONAUT_CORPUS_DIR", str(tmp_path / "elsewhere"))
+    assert paths.corpus_root() == tmp_path / "elsewhere"

--- a/aqua_model/__init__.py
+++ b/aqua_model/__init__.py
@@ -20,7 +20,12 @@ from .sizing import size_system
 from .hydroponics import size_hydroponic_system
 from .pilot import PilotInfo, to_pilot_proposal, projected_outcomes
 from .optimizer import optimize, OptimizeInput, OptimizeResult, Candidate, OBJECTIVES
-from .validate import validate_design_input, validate_hydroponic_input, ValidationError
+from .validate import (
+    validate_design_input,
+    validate_hydroponic_input,
+    validate_optimize_input,
+    ValidationError,
+)
 from .triage import (
     ObservationFeatures, TriageCandidate, TriageResult, format_triage, triage_symptoms,
     validate_observation_features,
@@ -42,6 +47,7 @@ __all__ = [
     "OBJECTIVES",
     "validate_design_input",
     "validate_hydroponic_input",
+    "validate_optimize_input",
     "validate_observation_features",
     "triage_symptoms",
     "format_triage",

--- a/aqua_model/optimizer.py
+++ b/aqua_model/optimizer.py
@@ -25,6 +25,7 @@ from . import massbalance as mb
 from .crops import CROPS, get_crop
 from .overrides import validate_overrides, apply_overrides
 from .species import SPECIES, get_species, temperature_feed_factor
+from .validate import ValidationError, validate_optimize_input
 
 OBJECTIVES = ("food", "protein", "water_efficiency")
 _ALLOC_STEPS = 4  # area is split into quarters across crops (bounded enumeration granularity)
@@ -147,10 +148,15 @@ def _evaluate(fish_name: str, alloc: dict[str, float], inp: OptimizeInput,
 
 
 def optimize(inp: OptimizeInput, overrides: dict | None = None) -> OptimizeResult:
+    # The trust gate applies here too. This enumerates thousands of designs and names a
+    # winner, so an unchecked number comes back as a confident, cited-looking "best ratio":
+    # a negative area used to report negative yields, and a NaN temperature scored the same
+    # as an optimal one. Reject first, enumerate second.
+    validate_optimize_input(inp.grow_area_m2, inp.temperature_c, inp.water_budget_lpd)
     if inp.objective not in OBJECTIVES:
-        raise ValueError(f"Unknown objective {inp.objective!r}. Supported: {OBJECTIVES}.")
+        raise ValidationError([f"unknown objective {inp.objective!r}; known: {list(OBJECTIVES)}"])
     if not inp.fish_palette or not inp.crop_palette:
-        raise ValueError("fish_palette and crop_palette must be non-empty.")
+        raise ValidationError(["fish_palette and crop_palette must be non-empty"])
     if overrides:
         validate_overrides(overrides)
 

--- a/aqua_model/tests/test_validate.py
+++ b/aqua_model/tests/test_validate.py
@@ -55,3 +55,47 @@ def test_multiple_errors_collected_together():
             grow_area_m2=-5, temperature_c=200, water_budget_lpd="n/a",
         )
     assert len(e.value.errors) >= 4
+
+
+# --- the optimizer shares the gate ------------------------------------------------------
+# The optimizer enumerates designs and reports a "best ratio". It used to accept its three
+# numbers unchecked, so a negative area produced a confident recommendation with negative
+# yields at exit 0, and a NaN temperature scored identically to an optimal one (every NaN
+# comparison is False, so the temperature penalty silently never applied).
+
+from aqua_model import optimize, OptimizeInput  # noqa: E402
+
+
+def _opt(**over):
+    base = dict(grow_area_m2=10.0, temperature_c=28.0, water_budget_lpd=5000.0,
+                objective="food")
+    base.update(over)
+    return optimize(OptimizeInput(**base))
+
+
+def test_optimizer_accepts_a_valid_input():
+    assert _opt().best is not None
+
+
+def test_optimizer_rejects_negative_grow_area():
+    with pytest.raises(ValidationError) as e:
+        _opt(grow_area_m2=-5.0)
+    assert "grow_area_m2" in str(e.value)
+
+
+def test_optimizer_rejects_nan_temperature():
+    with pytest.raises(ValidationError) as e:
+        _opt(temperature_c=float("nan"))
+    assert "temperature_c" in str(e.value)
+
+
+def test_optimizer_rejects_infinite_water_budget():
+    with pytest.raises(ValidationError) as e:
+        _opt(water_budget_lpd=float("inf"))
+    assert "water_budget_lpd" in str(e.value)
+
+
+def test_optimizer_rejects_unknown_objective():
+    with pytest.raises(ValidationError) as e:
+        _opt(objective="maximise_vibes")
+    assert "objective" in str(e.value)

--- a/aqua_model/validate.py
+++ b/aqua_model/validate.py
@@ -177,6 +177,37 @@ def validate_hydroponic_input(
     )
 
 
+def validate_optimize_input(grow_area_m2, temperature_c, water_budget_lpd):
+    """The optimizer's door into the model — the same bounds as `validate_design_input`.
+
+    The optimizer enumerates thousands of designs and reports a winner, so an unchecked
+    number here is worse than an unchecked one in sizing: it comes back as a confident,
+    cited-looking "best ratio". A negative area used to produce negative yields at exit 0,
+    and a NaN temperature scored identically to an optimal one because every NaN comparison
+    is False and the temperature penalty silently never applied. The range check below
+    rejects NaN and infinity for free, since neither satisfies `lo <= val <= hi`.
+
+    Returns the three validated floats; raises ValidationError listing every problem.
+    """
+    errors: list[str] = []
+    values = {
+        "grow_area_m2": _as_float(grow_area_m2, "grow_area_m2", errors),
+        "temperature_c": _as_float(temperature_c, "temperature_c", errors),
+        "water_budget_lpd": _as_float(water_budget_lpd, "water_budget_lpd", errors),
+    }
+    for field, val in values.items():
+        if val is None:
+            continue
+        lo, hi = _BOUNDS[field]
+        if not (lo <= val <= hi):
+            errors.append(f"{field}={val} out of range [{lo}, {hi}]")
+
+    if errors:
+        raise ValidationError(errors)
+
+    return values["grow_area_m2"], values["temperature_c"], values["water_budget_lpd"]
+
+
 def _as_float(value, field, errors):
     if isinstance(value, bool):  # bool is an int subclass; reject explicitly
         errors.append(f"{field} must be a number, got bool")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,20 @@ dependencies = { file = ["requirement.txt"] }
 # bot.py and app.py sit at the project root as scripts, not inside a package; `agronaut bot`
 # and `agronaut web` need them installed alongside the packages.
 py-modules = ["bot", "app"]
+# Explicitly off. Left on, it combines with a stale agronaut.egg-info/SOURCES.txt in the
+# working tree to sweep everything under a package dir into the wheel — that is how 54 test
+# files ended up shipped to site-packages.
+include-package-data = false
 
 [tool.setuptools.packages.find]
 include = ["agronaut_agent*", "agent*", "aqua_model*", "srcs*", "skills*", "scripts*"]
+# Tests are for the checkout, not for site-packages.
+exclude = ["*.tests", "*.tests.*"]
+
+# The cited knowledge base is not optional decoration — without it every answer comes back
+# KNOWLEDGE_UNAVAILABLE while the assistant still sounds confident. It lives at the repo
+# root rather than inside a package, so it ships as data files and agronaut_agent/paths.py
+# looks for it under sys.prefix when the source tree is not there.
+[tool.setuptools.data-files]
+"share/agronaut" = ["urls.txt"]
+"share/agronaut/knowledge" = ["knowledge/*.md"]

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -1772,7 +1772,11 @@ def handle_turn(user: str) -> None:
 # =============================================================================
 
 
-INDEX_CACHE_DIR = _PROJECT_ROOT / "data" / ".index_cache"
+# cache_dir(), not the corpus root: the built index is regenerable from knowledge/ + urls.txt,
+# so it belongs with the other caches. In a checkout that resolves to the project root, keeping
+# the existing data/.index_cache/ path (and its .gitignore entry); once installed it lands in a
+# per-user cache directory instead of trying to write inside site-packages.
+INDEX_CACHE_DIR = _paths.cache_dir() / "data" / ".index_cache"
 INDEX_CACHE_TTL = 7 * 86_400   # web sources are re-fetched at most weekly
 
 

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -34,13 +34,15 @@ from langchain_community.vectorstores import FAISS
 # Configuration
 # =============================================================================
 
-# Anchored to the project root, not the current directory: `agronaut` is an installed
-# command that can be run from anywhere, and a cwd-relative corpus would silently degrade
-# RAG to KNOWLEDGE_UNAVAILABLE instead of failing loudly.
-_PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+# Resolved, never cwd-relative: `agronaut` is an installed command run from anywhere, and a
+# cwd-relative corpus degrades RAG to KNOWLEDGE_UNAVAILABLE without ever raising. See
+# agronaut_agent/paths.py for why the answer depends on how Agronaut was installed.
+from agronaut_agent import paths as _paths
 
-URL_FILE = str(_PROJECT_ROOT / "urls.txt")
-KNOWLEDGE_DIR = str(_PROJECT_ROOT / "knowledge")
+_CORPUS_ROOT = _paths.corpus_root()
+
+URL_FILE = str(_CORPUS_ROOT / "urls.txt")
+KNOWLEDGE_DIR = str(_CORPUS_ROOT / "knowledge")
 WEB_LOAD_TIMEOUT = 20
 
 
@@ -50,7 +52,7 @@ CHUNK_OVERLAP = 100
 EMBEDDING_MODEL = "sentence-transformers/all-mpnet-base-v2"
 TOP_K = 3
 
-CACHE_NAME = str(_PROJECT_ROOT / "web_cache")   # absolute: see _PROJECT_ROOT above
+CACHE_NAME = str(_paths.cache_dir() / "web_cache")   # never the install root; see paths.py
 CACHE_EXPIRE = 86_400  # 1 day
 
 LOG_LEVEL = logging.INFO


### PR DESCRIPTION
Follow-up to #82. A specialist review of that merge found two things worth fixing now; the review agreed on both from three independent directions.

## 1. `optimize` never validated its inputs

```
agronaut optimize --area -5 --temp 28 --water 5000 --objective food
→ exit 0
→ Best ratio: carp + [100% sage] → food=-80.2 kg/yr, protein=-9.08 kg/yr
→ Searched 204605 combinations, 204605 feasible.
```

`optimize()` built an `OptimizeInput` straight from caller values and enumerated, never touching `aqua_model/validate.py`. The `except ValidationError` around it at both CLI surfaces **and in the LLM tool** was dead code. `--temp nan` produced output byte-identical to an optimal temperature, because every NaN comparison is False so the temperature penalty silently never applied.

This predates #82 — the pre-merge skill CLI has the identical `_cmd_optimize` — but #82 put it on the documented front door under a README table promising the opposite, so the fix belongs here. Fixing it in `optimize()` rather than in the CLI also closes the same hole in the LLM tool path, which had simply never had a `ValidationError` to catch.

The test that claimed to pin this covered one command out of four and asserted `code != 0`, which passes for `None` — and `sys.exit(None)` exits 0, so an agent shelling out would have read a rejected design as success. Now parametrized across every sizing command with hostile numbers, asserting the exact code.

## 2. A non-editable install was broken in four ways

Everything in #82 was verified under `pip install -e .`. Under `pip install .`:

| | Before | After |
|---|---|---|
| Knowledge corpus | not in the wheel at all | 21 docs + `urls.txt` under `<prefix>/share/agronaut` |
| Fetched-page cache | `site-packages/web_cache.sqlite` | `$XDG_CACHE_HOME/agronaut` |
| Memory DB + usage log | `site-packages/data/` (mkdir'd) | `$XDG_DATA_HOME/agronaut` |
| Test suite | 54 files shipped to site-packages | excluded |

The corpus one was the dangerous one: nothing raised. `parse_urls_file` logs and returns `[]`, `build_rag_index_from_urls` returns `None`, `rag.py` caches that `None` for the process — so every answer came back `KNOWLEDGE_UNAVAILABLE` while the assistant sounded confident and cited nothing.

`agronaut_agent/paths.py` now answers "where does Agronaut keep things" in one place, with an env override on every lookup (`AGRONAUT_CORPUS_DIR`, `AGRONAUT_CACHE_DIR`, `AGRONAUT_DATA_DIR`). **A checkout is unchanged** — existing warm cache and `data/` stay exactly where they are. The discriminator is the presence of `pyproject.toml`, not writability: site-packages in a user-owned venv is writable and is still the wrong place.

## Test Coverage

The three packaging tests from #82 could not fail. They re-read `pyproject.toml` and asserted it contained its own contents; the cwd-independence test resolved paths from `srcs/chatbot.py`'s own location, so `chdir` changed nothing. They now build a wheel from a clean copy of the tree with pip's cache disabled — both precautions load-bearing, since a leftover `agronaut.egg-info` silently puts the test suite back in the wheel and pip will hand back a pre-fix cached wheel — and assert on the artifact.

Mutation-checked: removing the `data-files` block makes `test_wheel_ships_the_cited_knowledge_corpus` fail with `assert 0 >= 20`.

Tests: 560 → 579 (+19). Full suite: 579 passed, 2 skipped.

## Test plan

- [x] Full suite green
- [x] `agronaut optimize --area -5 …` exits 2 with VALIDATION_FAILED
- [x] Wheel built from a clean tree contains 21 knowledge docs, `urls.txt`, and zero test files
- [x] Wheel installed non-editably in a throwaway venv: corpus resolves, cache and state land in XDG dirs, nothing in site-packages
- [x] Checkout behavior unchanged — cache and `data/` still beside the source
- [x] CI's blocking lint gate clean

## Not in this PR

Raised by the review, left alone deliberately: the `agronaut_agent → skills → agronaut_agent.serialize` import cycle (defused only by that import sitting inside `_build_parser`, which also mutates `sys.path[0]` as a side effect), `agronaut web --help --x` forwarding to Streamlit instead of printing help, `core._repl` being a private name behind the headline command, the generic top-level distribution names, and the Dockerfile never running `pip install .`. Also unresolved and needing a judgment call: `size --temp 0` for tilapia returns "FEASIBLE" at exit 0 with 4× the stocking density against a 14–36 °C envelope, and `NOT FEASIBLE` also exits 0 — anything gating on `$?` cannot tell those apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)