### PR TITLE
feat(rag): measure retrieval before tuning it — then let the measurements overrule the plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ data/vision_corpus/
 .vscode/
 *.swp
 data/*.jsonl
+
+# Built knowledge index — derived from knowledge/ + urls.txt, rebuilt on demand
+data/.index_cache/

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ UVI/Rakocy, literature) and an explicit list of what it does **not** model
 (pH/alkalinity, micronutrients, salinity, solids, pests, cohort logic, per-crop ET).
 A confidently-wrong design can't masquerade as complete.
 
+The same rule governs the advice layer. Citation is enforced **in code**, not asked for in a
+prompt: every retrieved passage is labelled with its source before the model ever sees it. And
+retrieval is allowed to say *no* — a question the corpus cannot answer returns "no matching
+passages" rather than the three closest paragraphs wearing source labels. Ask Agronaut the capital
+of Canada and it will decline, not cite an aquaponics paper at you.
+
 ---
 
 ## The engineering model (aquaponics core)
@@ -133,6 +139,51 @@ Parametric, not machine-learned — buildable today from published equations:
   water-budget feasibility check.
 - **Optimizer** is bounded enumeration over a small species×crop palette (no heavyweight
   solver), with the even-split baseline inside the search space so it can never do worse.
+
+---
+
+## The advice layer (retrieval), and how it was tuned
+
+Sizing is computed. Troubleshooting advice is *retrieved*, from a corpus of 21 hand-written
+operator guides plus openly licensed publications — currently **1354 chunks**, led by FAO 589.
+
+Retrieval is measured, not assumed. `docs/dpg/retrieval_eval/golden_set.json` holds queries in
+real operator voice ("my tilapia are gasping at the surface", not "dissolved oxygen") plus
+off-topic controls that must be **refused**:
+
+```bash
+python -m scripts.retrieval_eval     # recall@k, precision@k, MRR, MAP@k + floor separation
+python -m scripts.corpus_report      # what each declared source actually contributes
+```
+
+Eight techniques were implemented and measured. **Four ship; four lose** — and the losses are
+recorded in `docs/dpg/retrieval_eval/techniques.json` with the conditions that would reverse them,
+which is how hybrid search went from rejected to shipped when the corpus grew:
+
+| | ships | why |
+|---|---|---|
+| Relevance floor | **on** | refuses 8/10 off-topic queries, silences 0/33 real ones |
+| Hybrid BM25 + RRF | **on** (β=0.90) | lost at 362 chunks, won at 1354: recall/MAP +0.091 |
+| Per-source cap | **on** (2) | one 992-chunk book was taking all 3 slots on 10 of 33 queries |
+| PDF cleaning | **on** | drops contents pages; running header removed from 111 chunks → 4 |
+| Header chunking · context prefix · PDF chapter labels · cross-encoder rerank | off | each measured *worse* on this corpus |
+
+Three of the four failures share one mechanism: they add topic words to chunks in a corpus where
+every document already shares a vocabulary domain, which dilutes rather than disambiguates. What
+worked was structural — refusing irrelevant passages, refusing error pages, refusing to let one
+source fill the whole answer.
+
+**Corpus licensing is mixed and deliberately explicit.** The code is MIT; FAO 589 is
+non-commercial-only. See [`docs/dpg/CORPUS.md`](docs/dpg/CORPUS.md) — commercial users should drop
+that entry from `urls.txt` and rebuild. Vet any source before adding it:
+
+```bash
+python -m scripts.corpus_report --candidate "<url>" --label "<expected topic>"
+```
+
+It checks four things, because a source can fail in four ways: unreachable, empty, **wrong
+subject** (a guessed publication ID once resolved to *"Sharks for the Aquarium"* — 28k characters
+that pass every check except being about aquaponics), or not openly licensed.
 
 ---
 
@@ -235,6 +286,11 @@ The consultative agent is reachable over Telegram. Set these (in `.env` or the e
 |---|---|
 | `TELEGRAM_BOT_TOKEN` | from [@BotFather](https://t.me/BotFather) |
 | `AGRONAUT_ALLOWED_IDS` | comma-separated Telegram user IDs allowed to use the bot (empty = open to anyone, discouraged) |
+| `AGRONAUT_RELEVANCE_MAX_DISTANCE` | how far a passage may be and still be used as context (default 1.65, `off` disables). Calibrated against the golden set; **not portable** — re-read `python -m scripts.retrieval_eval` after any corpus or embedding-model change |
+| `AGRONAUT_HYBRID` / `AGRONAUT_HYBRID_BETA` | keyword+semantic fusion, on by default at β=0.90 (β is the semantic weight) |
+| `AGRONAUT_MAX_PER_SOURCE` | how many passages one source may contribute to a single answer (default 2; `1` favours breadth, `0` disables) |
+| `AGRONAUT_INDEX_CACHE` | the built index is cached under `data/.index_cache/`, keyed by a corpus fingerprint; `off` rebuilds every time |
+| `AGRONAUT_RERANK` / `AGRONAUT_MD_HEADERS` / `AGRONAUT_PDF_SECTIONS` | techniques that measured *worse* on this corpus and ship disabled — kept because the verdict is corpus-dependent (see `docs/dpg/retrieval_eval/techniques.json`) |
 | `LLM_PROVIDER` / `NVIDIA_API_KEY` | the tool-calling brain — e.g. `nvidia` (free at [build.nvidia.com](https://build.nvidia.com)) |
 | `LLM_MODEL` | optional, e.g. `meta/llama-3.1-70b-instruct` |
 | `VLM_PROVIDER` / `VLM_MODEL` | optional photo understanding — send a picture of a sick fish or yellowing leaf and the bot describes it, then diagnoses through the same cited flow. Defaults to a hosted NVIDIA vision model; `AGRONAUT_VISION=off` disables. The vision model only *observes*: a deterministic guard strips any reading or prescription out of its description, and the diagnosis itself comes from a fixed, cited triage table (`aqua_model/triage.py`) that returns a ranked differential — never a single verdict. Photos work on Telegram, WhatsApp, and the web chat. |
@@ -341,13 +397,17 @@ agronaut_agent/        # the channel-agnostic brain
   core.py              #   handle_message / handle_image / handle_voice — the three seams
   tools.py             #   the LLM-callable tools (thin wrappers over the trust zone)
   store.py profile.py  #   SQLite memory: System Profile, notes, calibration, follow-ups
-  rag.py semantic.py   #   citation-enforced retrieval and semantic recall
+  rag.py semantic.py   #   citation-enforced retrieval (floor, hybrid, per-source cap) + recall
   channels/            #   telegram_adapter.py, whatsapp_adapter.py, base.py
 
 scripts/               # safety_eval.py (hermetic golden set, runs in CI), vision_eval.py
+                       # corpus_report.py (what each source contributes; --candidate vets one)
+                       # retrieval_eval.py (recall/precision/MRR/MAP over the retrieval golden set)
 skills/                # the deterministic core as a portable agentskills.io skill + CLI
-knowledge/ urls.txt    # the curated, cited knowledge base
+knowledge/ urls.txt    # the curated, cited knowledge base (urls.txt: CATEGORY|URL|LABEL|LICENCE)
 docs/dpg/              # DPG compliance pack: privacy, AI transparency, safety eval
+  CORPUS.md            #   corpus provenance + the code(MIT)/content(mixed) licence split
+  retrieval_eval/      #   golden set, baselines, and every technique's measured verdict
 app.py                 # Streamlit app (chat | calculator | optimizer)
 pyproject.toml         # packaging + the `agronaut` console script (deps read from requirement.txt)
 srcs/chatbot.py        # legacy RAG/state-machine layer, slated for retirement (#25)
@@ -360,7 +420,9 @@ srcs/chatbot.py        # legacy RAG/state-machine layer, slated for retirement (
 - **M1 — design calculator** ✅ deterministic sizing, cited coefficients, report, logging standard
 - **M2 — ratio optimizer** ✅ fish/crop mix for max efficiency
 - **M3 — agent orchestrator** — 🟡 the tool-calling agent is built and is what every channel
-  now runs on; demoting RAG to a pure citation tool is still open ([#25](https://github.com/Rekin226/Agronaut/issues/25))
+  now runs on. Retrieval is now measured end to end (golden set, recall/MRR/MAP, a relevance
+  floor that refuses off-topic questions) and every technique's verdict is recorded; fully
+  demoting RAG to a pure citation tool is still open ([#25](https://github.com/Rekin226/Agronaut/issues/25))
 - **Field senses** ✅ photos and voice notes on Telegram, WhatsApp and the web, behind a
   code-enforced observation guard and a cited visual-triage table
 - **M4 — digital twin** — time-series simulator calibrated on real installed systems ([#26](https://github.com/Rekin226/Agronaut/issues/26))
@@ -369,11 +431,19 @@ srcs/chatbot.py        # legacy RAG/state-machine layer, slated for retirement (
   FAO-56? ([#78](https://github.com/Rekin226/Agronaut/issues/78))
 
 **Status, honestly.** The design, optimizer, and triage core is built, tested, and enforced in
-CI (541 tests; a hermetic advice-safety golden set that fails the build on a regression). What
+CI (700+ tests; a hermetic advice-safety golden set that fails the build on a regression). What
 is *not* done is **validation against reality**: the coefficients are literature seeds meant to
 be calibrated, and the vision path has never been scored against a real photograph because
 [the corpus is empty](https://github.com/Rekin226/Agronaut/issues/72). Calibrated ≠ validated,
 and the model says so in every result it produces.
+
+The advice layer has the same shape of honesty and the same gap. Retrieval is measured against a
+33-query golden set, but that set was written by one person against the corpus it already had —
+it cannot tell you about questions nobody thought to ask. And **corpus breadth is the live
+constraint**: 21 hand-written files still answer most queries, because open-access aquaponics
+*literature* is plentiful while open *operator guidance* barely exists. Widening it is
+[#77](https://github.com/Rekin226/Agronaut/issues/77), and `docs/dpg/CORPUS.md` records which
+sources were surveyed and why they were not added.
 
 ---
 

--- a/agronaut_agent/analytics.py
+++ b/agronaut_agent/analytics.py
@@ -20,7 +20,15 @@ from pathlib import Path
 
 # Only these metadata keys are ever persisted alongside an event — anything else (notably
 # anything that could carry message content) is dropped.
-_ALLOWED_FIELDS = {"tool", "goal", "channel", "ok"}
+#
+# The retrieval fields describe the SHAPE of a retrieval, never its subject: how many passages
+# came back, how far the closest one sat, how long it took, whether the relevance floor fired.
+# No query text and no passage text can be recorded, because neither has a key here and unknown
+# keys are dropped rather than stored. That is what keeps this consistent with docs/dpg/PRIVACY.md
+# while still answering the production question the golden set cannot: is the retriever, on real
+# traffic, still behaving the way it did when its threshold was calibrated?
+_ALLOWED_FIELDS = {"tool", "goal", "channel", "ok",
+                   "outcome", "n_results", "k", "latency_ms", "top_score", "hybrid"}
 
 _SIZING_TOOLS = {"size_aquaponics_system", "size_hydroponic_system_tool"}
 

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -104,6 +104,12 @@ HARD RULES (these are your credibility):
   you are reasoning from general knowledge. Knowledge passages arrive labeled "[source: ...]" —
   when your advice uses one, NAME that source in your reply (e.g. "per FAO 589..."). Never
   strip the attribution.
+- JUDGE EACH RETRIEVED PASSAGE BEFORE YOU USE IT. Retrieval returns the closest passages it has,
+  which is not the same as passages that answer the question. If a passage is not actually about
+  what the user asked, IGNORE it — do not stretch it to fit, and do not cite it. If none of them
+  fit, say plainly that the knowledge base has nothing specific on this and answer from general
+  husbandry knowledge, flagged as such. A confident citation attached to an irrelevant passage is
+  worse than no citation, because the source makes it look verified.
   Also check search_community_knowledge for real-world operator tips, and present anything it
   returns as "reported by other operators", never as verified fact or a number.
 

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -212,6 +212,14 @@ _POOL = 20      # candidates drawn from each retriever before fusion
 # Set AGRONAUT_MAX_PER_SOURCE=1 to prioritise coverage, or 0 to disable the cap entirely.
 _MAX_PER_SOURCE = 2
 
+# Cross-encoder reranker. A bi-encoder embeds query and passage SEPARATELY, so it can only
+# compare two summaries of meaning; a cross-encoder reads the pair together and scores their
+# actual interaction. Far better, far slower — usable only on a shortlist, which is exactly what
+# the fused pool is.
+_RERANK_MODEL = os.getenv("AGRONAUT_RERANK_MODEL", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+_RERANKER = None
+_RERANK_TRIED = False
+
 
 def retrieve(query: str, k: int = 3, max_dist: float | None = None,
              hybrid: bool | None = None) -> list[dict]:
@@ -294,7 +302,69 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
             sparse = []
 
     fused = rrf_fuse(dense, sparse) if sparse else dense
+    if rerank_enabled():
+        # Rerank the shortlist BEFORE the diversity cap: the cap should displace the least
+        # relevant duplicate, which requires relevance to already be correct.
+        fused = _rerank(query, fused[:_POOL], by_key)
     return [by_key[key] for key in _diversify(fused, by_key, k)]
+
+
+def rerank_enabled() -> bool:
+    """Cross-encoder reranking ships DISABLED — measured, and the reason is specific.
+
+        variant                  hit    recall  prec    MRR     MAP     latency
+        off (fused order)        0.939  0.894   0.540   0.737   0.697   274 ms
+        on  (cross-encoder)      0.879  0.813   0.515   0.727   0.682   761 ms
+
+    Worse on every metric and 2.8x slower. The default model, ms-marco-MiniLM-L-6-v2, is trained
+    on MS MARCO — short web-search queries against web passages. Operator phrasing ("my tilapia
+    are gasping at the surface") against agronomy prose is out of that distribution, and a
+    general-purpose reranker applied out of domain can and here does score worse than the
+    domain-appropriate bi-encoder it is reordering. It is being asked to improve a shortlist that
+    is already good (MRR 0.737), which is the hardest case for it to win.
+
+    This is a statement about THIS model on THIS domain, not about reranking. A cross-encoder
+    fine-tuned on agronomy text, or simply a stronger general one, could plausibly win — the
+    machinery is here and AGRONAUT_RERANK=on turns it on, with AGRONAUT_RERANK_MODEL selecting
+    the model. Re-measure before trusting it.
+    """
+    return os.getenv("AGRONAUT_RERANK", "").lower() in {"on", "1", "true"}
+
+
+def _get_reranker():
+    """A lazily loaded CrossEncoder, or None when unavailable.
+
+    Loaded on first use rather than at import, matching semantic.default_embedder(): a model
+    download must never be the reason the agent is slow to start or fails to start at all.
+    """
+    global _RERANKER, _RERANK_TRIED
+    if _RERANK_TRIED:
+        return _RERANKER
+    _RERANK_TRIED = True
+    try:
+        from sentence_transformers import CrossEncoder
+        _RERANKER = CrossEncoder(_RERANK_MODEL)
+    except Exception as exc:  # noqa: BLE001 — reranking is additive; never break retrieval
+        logging.warning("Reranker unavailable, keeping fused order: %s", exc)
+        _RERANKER = None
+    return _RERANKER
+
+
+def _rerank(query: str, keys: list, by_key: dict) -> list:
+    """Reorder a shortlist by cross-encoder relevance, most relevant first.
+
+    Returns the input order unchanged if the model is unavailable or scoring fails, so a missing
+    reranker costs ranking quality and nothing else.
+    """
+    model = _get_reranker()
+    if model is None or len(keys) < 2:
+        return keys
+    try:
+        scores = model.predict([(query, by_key[k]["text"][:2000]) for k in keys])
+        return [k for _s, k in sorted(zip(scores, keys), key=lambda p: p[0], reverse=True)]
+    except Exception as exc:  # noqa: BLE001
+        logging.warning("Reranking failed, keeping fused order: %s", exc)
+        return keys
 
 
 def max_source_cap() -> int:

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -273,12 +273,37 @@ def index_available() -> bool:
     return _get_index() is not None
 
 
+def search_with_stats(query: str, k: int = 3) -> tuple[str, dict]:
+    """search(), plus non-identifying telemetry about how the retrieval went.
+
+    The stats deliberately contain NO query text and NO passage text — only shape and timing. The
+    production question this answers is not "what did people ask" but "is the retriever behaving
+    the way the golden set says it should": how often the floor fires, how far the closest match
+    typically sits, how long retrieval takes. A drift in those is the earliest signal that the
+    corpus or the model has moved out from under the calibrated threshold.
+    """
+    import time
+    t0 = time.perf_counter()
+    if not index_available():
+        return _UNAVAILABLE, {"outcome": "unavailable", "n_results": 0,
+                              "latency_ms": int((time.perf_counter() - t0) * 1000)}
+    hits = retrieve(query, k=k)
+    latency_ms = int((time.perf_counter() - t0) * 1000)
+    scored = [h["score"] for h in hits if h.get("score") is not None]
+    stats = {
+        "outcome": "hit" if hits else "no_match",
+        "n_results": len(hits),
+        "k": k,
+        "latency_ms": latency_ms,
+        "top_score": round(min(scored), 3) if scored else None,
+        "hybrid": hybrid_enabled(),
+    }
+    if not hits:
+        return _NO_MATCH, stats
+    return "\n\n".join(f"[source: {h['source']}]\n{h['text']}" for h in hits), stats
+
+
 def search(query: str, k: int = 3) -> str:
     """Return retrieved knowledge passages for `query`, each labeled with its source —
     citation is enforced here, not left to the model — or a clear 'no context' note."""
-    if not index_available():
-        return _UNAVAILABLE
-    hits = retrieve(query, k=k)
-    if not hits:
-        return _NO_MATCH
-    return "\n\n".join(f"[source: {h['source']}]\n{h['text']}" for h in hits)
+    return search_with_stats(query, k=k)[0]

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 
 # Maximum FAISS L2 distance a passage may have and still be offered to the model as context.
 # LOWER is closer; anything above this is treated as "nothing relevant matched".
@@ -35,6 +36,18 @@ _DEFAULT_MAX_DISTANCE = 1.65
 
 _INDEX = None          # cached FAISS index (or None if unavailable)
 _TRIED = False         # don't retry a failed/slow build every call
+_BM25 = None           # cached (BM25Okapi, [Document]) over the SAME chunks as _INDEX
+_BM25_TRIED = False
+
+# Reciprocal Rank Fusion constant. Higher values flatten the influence of a single top rank:
+# at k=0 a first place is worth 10x a tenth place, at k=60 about 1.2x. 60 is the value from the
+# original RRF paper and the usual production default.
+_RRF_K = 60
+
+# Weight on the semantic ranking; the keyword ranking gets (1 - beta). Aquaponics queries are
+# dense with exact terms an embedding can blur together — "nitrite" vs "nitrate", species names,
+# "Ich", "FCR" — so the keyword side is given real weight rather than a token share.
+_DEFAULT_BETA = 0.5
 
 
 def _get_index():
@@ -74,6 +87,87 @@ _UNAVAILABLE = ("KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer 
 _NO_MATCH = "No matching passages in the knowledge base for that query."
 
 
+def _tokenize(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", (text or "").lower())
+
+
+def _get_bm25():
+    """A BM25 index over exactly the chunks already in the FAISS index.
+
+    Built from the FAISS docstore rather than by re-reading the corpus, so the two retrievers can
+    never drift apart — a keyword hit always corresponds to a real, embedded, citable chunk.
+    """
+    global _BM25, _BM25_TRIED
+    if _BM25_TRIED:
+        return _BM25
+    _BM25_TRIED = True
+    index = _get_index()
+    if index is None:
+        return None
+    try:
+        from rank_bm25 import BM25Okapi
+        docs = list(index.docstore._dict.values())
+        if not docs:
+            return None
+        _BM25 = (BM25Okapi([_tokenize(d.page_content) for d in docs]), docs)
+    except Exception as exc:  # noqa: BLE001 — keyword search is additive; never break retrieval
+        logging.warning("BM25 index unavailable, falling back to dense-only: %s", exc)
+        _BM25 = None
+    return _BM25
+
+
+def hybrid_enabled() -> bool:
+    """Hybrid retrieval ships DISABLED, on evidence — see docs/dpg/retrieval_eval/hybrid_sweep.json.
+
+    The received wisdom is that BM25 + RRF beats dense-only. Measured on this corpus it does not,
+    at any weighting:
+
+        beta   hit    recall  prec    MRR     MAP
+        0.50   0.939  0.924   0.485   0.874   0.861
+        0.70   0.970  0.919   0.500   0.899   0.862
+        0.95   0.970  0.904   0.581   0.884   0.838
+        dense  0.970  0.919   0.626   0.909   0.869
+
+    Dense-only equals or beats every setting on every metric; the best hybrid configuration loses
+    0.126 of precision to match it elsewhere. The reason is the corpus, not the technique: 362
+    chunks that all share one vocabulary domain, so common aquaponics terms match across many
+    files and keyword rank carries little information. BM25 does fix the one dense miss
+    ("bright green and cloudy" -> algae_control.md) but breaks two other queries doing it.
+
+    The implementation is kept and tested because this is expected to invert as the corpus grows
+    and diversifies — adding FAO 589 alone would roughly quadruple it. Re-run the sweep after any
+    substantial corpus change and flip this default if the numbers move. Enable with
+    AGRONAUT_HYBRID=on.
+    """
+    return os.getenv("AGRONAUT_HYBRID", "").lower() in {"on", "1", "true"}
+
+
+def beta() -> float:
+    """Weight on the semantic ranking, 0..1. The keyword ranking gets the remainder."""
+    try:
+        b = float(os.getenv("AGRONAUT_HYBRID_BETA", "") or _DEFAULT_BETA)
+    except ValueError:
+        return _DEFAULT_BETA
+    return min(max(b, 0.0), 1.0)
+
+
+def rrf_fuse(dense: list, sparse: list, b: float | None = None, rrf_k: int = _RRF_K) -> list:
+    """Reciprocal Rank Fusion of two ranked lists of chunk keys.
+
+    RRF combines by RANK, never by score, which is what makes it usable here: a FAISS L2 distance
+    and a BM25 relevance score are not on comparable scales and normalising them against each
+    other would be arbitrary. A document earns beta/(k+rank) from the semantic list and
+    (1-beta)/(k+rank) from the keyword list, and the two are summed.
+    """
+    b = beta() if b is None else b
+    scores: dict = {}
+    for rank, key in enumerate(dense, start=1):
+        scores[key] = scores.get(key, 0.0) + b / (rrf_k + rank)
+    for rank, key in enumerate(sparse, start=1):
+        scores[key] = scores.get(key, 0.0) + (1.0 - b) / (rrf_k + rank)
+    return [key for key, _ in sorted(scores.items(), key=lambda kv: kv[1], reverse=True)]
+
+
 def max_distance() -> float:
     """The configured relevance floor. AGRONAUT_RELEVANCE_MAX_DISTANCE=off disables it."""
     raw = os.getenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", "").strip().lower()
@@ -86,18 +180,29 @@ def max_distance() -> float:
         return _DEFAULT_MAX_DISTANCE
 
 
-def retrieve(query: str, k: int = 3, max_dist: float | None = None) -> list[dict]:
+_POOL = 20      # candidates drawn from each retriever before fusion
+
+
+def retrieve(query: str, k: int = 3, max_dist: float | None = None,
+             hybrid: bool | None = None) -> list[dict]:
     """Structured retrieval: the ranked passages for `query`, each as
     {"text", "source", "score"}.
 
     Split out from search() so retrieval quality can be MEASURED (scripts/retrieval_eval.py)
     rather than only rendered. The similarity score is carried through instead of discarded —
-    a relevance floor needs it, and so does any reranking stage.
+    a relevance floor needs it, and so would any reranking stage.
 
-    Passages further than `max_dist` are dropped. Without that floor the retriever always returns
-    its top k, so an off-topic question gets three confident, source-labelled passages that cannot
-    answer it — the exact shape of a grounded-looking hallucination. Pass float("inf") to measure
-    unfiltered behaviour.
+    Retrieval is hybrid: a semantic pool and a BM25 keyword pool are fused by reciprocal rank.
+    The two signals fail differently, which is the entire point. The one query dense retrieval
+    missed outright — "my water has gone bright green and cloudy" — is ranked second by BM25,
+    because `algae_control.md` says "green water" in as many words while the embedding drifted
+    toward other water-appearance problems.
+
+    THE RELEVANCE FLOOR REMAINS A DENSE-SIDE DECISION, and deliberately so. It is calibrated on
+    L2 distance, a BM25-only hit has no distance to compare, and BM25 will always rank SOMETHING
+    first however off-topic the question. So the floor decides IF the corpus can answer at all;
+    fusion only decides the order of what it returns. If nothing clears the floor, nothing is
+    returned, whatever the keyword scores say.
 
     Returns [] both when the index is unavailable and when nothing survives filtering; callers
     that must tell those apart should check `index_available()`.
@@ -109,24 +214,57 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None) -> list[dict
     import srcs.chatbot as core
 
     try:
-        pairs = index.similarity_search_with_score(query, k=max(k * 2, k))
+        pairs = index.similarity_search_with_score(query, k=max(_POOL, k * 2))
     except Exception as exc:
         logging.warning("knowledge search failed: %s", exc)
         return []
-    hits = []
+
+    # Dense candidates: boilerplate removed, relevance floor applied. This is the gate.
+    dense: list = []
+    by_key: dict = {}
     for doc, score in pairs:
         if core._is_boilerplate_text(doc.page_content):
             continue
         if float(score) > limit:
             continue
-        hits.append({
-            "text": doc.page_content.strip(),
-            "source": _source_label(doc.metadata),
-            "score": float(score),
-        })
-        if len(hits) >= k:
-            break
-    return hits
+        key = (_source_label(doc.metadata), doc.page_content[:120])
+        if key not in by_key:
+            by_key[key] = {"text": doc.page_content.strip(),
+                           "source": _source_label(doc.metadata), "score": float(score)}
+            dense.append(key)
+    if not dense:
+        return []       # the corpus cannot answer this; keyword scores must not override that
+
+    use_hybrid = hybrid_enabled() if hybrid is None else hybrid
+    if not use_hybrid:
+        return [by_key[key] for key in dense[:k]]
+
+    sparse: list = []
+    bm = _get_bm25()
+    if bm is not None:
+        bm25, docs = bm
+        try:
+            scores = bm25.get_scores(_tokenize(query))
+            order = sorted(range(len(docs)), key=lambda i: scores[i], reverse=True)[:_POOL]
+            for i in order:
+                if scores[i] <= 0:
+                    continue
+                doc = docs[i]
+                if core._is_boilerplate_text(doc.page_content):
+                    continue
+                key = (_source_label(doc.metadata), doc.page_content[:120])
+                if key not in by_key:
+                    # A keyword-only hit carries no L2 distance. Record it as exactly that
+                    # rather than inventing a comparable number.
+                    by_key[key] = {"text": doc.page_content.strip(),
+                                   "source": _source_label(doc.metadata), "score": None}
+                sparse.append(key)
+        except Exception as exc:  # noqa: BLE001 — degrade to dense-only, never break the turn
+            logging.warning("BM25 scoring failed: %s", exc)
+            sparse = []
+
+    fused = rrf_fuse(dense, sparse) if sparse else dense
+    return [by_key[key] for key in fused[:k]]
 
 
 def index_available() -> bool:

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -8,6 +8,30 @@ missing deps), retrieval degrades to an empty result rather than crashing the ag
 from __future__ import annotations
 
 import logging
+import os
+
+# Maximum FAISS L2 distance a passage may have and still be offered to the model as context.
+# LOWER is closer; anything above this is treated as "nothing relevant matched".
+#
+# Measured on docs/dpg/retrieval_eval/golden_set.json (33 operator queries, 10 off-topic controls):
+#   - rejects 9/10 off-topic queries
+#   - silences 0/33 real queries
+#   - hit_rate, recall@3, precision@3, MRR and MAP@3 all UNCHANGED
+# So it removes most grounded-looking hallucinations at no measured retrieval cost.
+#
+# It is a heuristic, NOT a guarantee, and the margin is thinner than it first appears. With only
+# three controls the bands looked cleanly separated (worst on-topic 1.554 vs closest off-topic
+# 1.717). Widening to ten controls surfaced "best way to remove red wine from a carpet" at 1.553 —
+# INSIDE the on-topic band — because stain removal is genuinely close in embedding space to
+# algae_control.md's advice on removing growth from surfaces. The bands overlap; a query near the
+# boundary can still fall the wrong way.
+#
+# The durable fix for that overlap is a better-separated corpus and a complementary keyword
+# signal, not a cleverer threshold. This number is a property of THIS embedding model over THIS
+# corpus and does not port: `python -m scripts.retrieval_eval` reprints the separation on every
+# run and says outright when the bands overlap. Re-read it after any corpus change; override with
+# AGRONAUT_RELEVANCE_MAX_DISTANCE (or "off" to disable).
+_DEFAULT_MAX_DISTANCE = 1.65
 
 _INDEX = None          # cached FAISS index (or None if unavailable)
 _TRIED = False         # don't retry a failed/slow build every call
@@ -45,22 +69,78 @@ def _source_label(metadata: dict) -> str:
     return src
 
 
-def search(query: str, k: int = 3) -> str:
-    """Return retrieved knowledge passages for `query`, each labeled with its source —
-    citation is enforced here, not left to the model — or a clear 'no context' note."""
+_UNAVAILABLE = ("KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general "
+                "husbandry knowledge and say so.")
+_NO_MATCH = "No matching passages in the knowledge base for that query."
+
+
+def max_distance() -> float:
+    """The configured relevance floor. AGRONAUT_RELEVANCE_MAX_DISTANCE=off disables it."""
+    raw = os.getenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", "").strip().lower()
+    if raw in {"off", "none", "disabled"}:
+        return float("inf")
+    try:
+        return float(raw) if raw else _DEFAULT_MAX_DISTANCE
+    except ValueError:
+        logging.warning("Bad AGRONAUT_RELEVANCE_MAX_DISTANCE=%r; using default", raw)
+        return _DEFAULT_MAX_DISTANCE
+
+
+def retrieve(query: str, k: int = 3, max_dist: float | None = None) -> list[dict]:
+    """Structured retrieval: the ranked passages for `query`, each as
+    {"text", "source", "score"}.
+
+    Split out from search() so retrieval quality can be MEASURED (scripts/retrieval_eval.py)
+    rather than only rendered. The similarity score is carried through instead of discarded —
+    a relevance floor needs it, and so does any reranking stage.
+
+    Passages further than `max_dist` are dropped. Without that floor the retriever always returns
+    its top k, so an off-topic question gets three confident, source-labelled passages that cannot
+    answer it — the exact shape of a grounded-looking hallucination. Pass float("inf") to measure
+    unfiltered behaviour.
+
+    Returns [] both when the index is unavailable and when nothing survives filtering; callers
+    that must tell those apart should check `index_available()`.
+    """
+    limit = max_distance() if max_dist is None else max_dist
     index = _get_index()
     if index is None:
-        return "KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general husbandry knowledge and say so."
+        return []
     import srcs.chatbot as core
 
     try:
         pairs = index.similarity_search_with_score(query, k=max(k * 2, k))
     except Exception as exc:
         logging.warning("knowledge search failed: %s", exc)
-        return "KNOWLEDGE_UNAVAILABLE — no curated context retrieved; answer from general husbandry knowledge and say so."
-    docs = [d for (d, _score) in pairs if not core._is_boilerplate_text(d.page_content)][:k]
-    if not docs:
-        return "No matching passages in the knowledge base for that query."
-    return "\n\n".join(
-        f"[source: {_source_label(d.metadata)}]\n{d.page_content.strip()}" for d in docs
-    )
+        return []
+    hits = []
+    for doc, score in pairs:
+        if core._is_boilerplate_text(doc.page_content):
+            continue
+        if float(score) > limit:
+            continue
+        hits.append({
+            "text": doc.page_content.strip(),
+            "source": _source_label(doc.metadata),
+            "score": float(score),
+        })
+        if len(hits) >= k:
+            break
+    return hits
+
+
+def index_available() -> bool:
+    """Whether a knowledge index could be built at all — distinguishes 'nothing matched'
+    from 'retrieval is broken/offline', which the caller reports differently."""
+    return _get_index() is not None
+
+
+def search(query: str, k: int = 3) -> str:
+    """Return retrieved knowledge passages for `query`, each labeled with its source —
+    citation is enforced here, not left to the model — or a clear 'no context' note."""
+    if not index_available():
+        return _UNAVAILABLE
+    hits = retrieve(query, k=k)
+    if not hits:
+        return _NO_MATCH
+    return "\n\n".join(f"[source: {h['source']}]\n{h['text']}" for h in hits)

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -14,23 +14,25 @@ import re
 # Maximum FAISS L2 distance a passage may have and still be offered to the model as context.
 # LOWER is closer; anything above this is treated as "nothing relevant matched".
 #
-# Measured on docs/dpg/retrieval_eval/golden_set.json (33 operator queries, 10 off-topic controls):
-#   - rejects 9/10 off-topic queries
-#   - silences 0/33 real queries
-#   - hit_rate, recall@3, precision@3, MRR and MAP@3 all UNCHANGED
-# So it removes most grounded-looking hallucinations at no measured retrieval cost.
+# Measured on docs/dpg/retrieval_eval/golden_set.json (33 operator queries, 10 off-topic controls),
+# corpus of 1354 chunks: rejects 8/10 off-topic queries, silences 0/33 real ones.
 #
-# It is a heuristic, NOT a guarantee, and the margin is thinner than it first appears. With only
-# three controls the bands looked cleanly separated (worst on-topic 1.554 vs closest off-topic
-# 1.717). Widening to ten controls surfaced "best way to remove red wine from a carpet" at 1.553 —
-# INSIDE the on-topic band — because stain removal is genuinely close in embedding space to
-# algae_control.md's advice on removing growth from surfaces. The bands overlap; a query near the
-# boundary can still fall the wrong way.
+# THE BANDS OVERLAP AND CANNOT BE SEPARATED. Worst on-topic distance is 1.548; the CLOSEST
+# off-topic match is 1.426 ("best way to remove red wine from a carpet", which lands near
+# algae_control.md's advice on removing growth from surfaces). Adding FAO 589 widened this gap in
+# the wrong direction — a 275-page book covering everything from plumbing to food safety is
+# semantically near almost any question. No single global threshold can catch that query without
+# also silencing real ones.
 #
-# The durable fix for that overlap is a better-separated corpus and a complementary keyword
-# signal, not a cleverer threshold. This number is a property of THIS embedding model over THIS
-# corpus and does not port: `python -m scripts.retrieval_eval` reprints the separation on every
-# run and says outright when the bands overlap. Re-read it after any corpus change; override with
+# 1.65 rather than a tighter 1.58: the tighter value would reject one more control (neg-06, at
+# 1.616) but leaves only 0.032 of headroom above the worst real query, versus 0.10 at 1.65. On a
+# 33-query sample that trades a threefold cut in safety margin for one extra rejection, and
+# "silences 0 real queries" is the property that must not break. A real question is refused
+# service; an off-topic one merely gets an honest "no matching passages".
+#
+# This number is a property of THIS embedding model over THIS corpus and does not port.
+# `python -m scripts.retrieval_eval` reprints the separation on every run and says outright when
+# the bands overlap. Re-read it after any corpus change. Override with
 # AGRONAUT_RELEVANCE_MAX_DISTANCE (or "off" to disable).
 _DEFAULT_MAX_DISTANCE = 1.65
 
@@ -44,10 +46,22 @@ _BM25_TRIED = False
 # original RRF paper and the usual production default.
 _RRF_K = 60
 
-# Weight on the semantic ranking; the keyword ranking gets (1 - beta). Aquaponics queries are
-# dense with exact terms an embedding can blur together — "nitrite" vs "nitrate", species names,
-# "Ich", "FCR" — so the keyword side is given real weight rather than a token share.
-_DEFAULT_BETA = 0.5
+# Weight on the semantic ranking; the keyword ranking gets (1 - beta).
+#
+# 0.90 is measured, not chosen. On the 362-chunk corpus hybrid LOST at every weighting and shipped
+# disabled. Adding FAO 589 grew the corpus to 1354 chunks, and re-running the sweep — which the
+# recorded evidence explicitly said to do after substantial corpus growth — flipped the result:
+#
+#     beta   hit    recall  prec    MRR     MAP
+#     0.50   0.758  0.727   0.444   0.561   0.543
+#     0.70   0.818  0.773   0.475   0.646   0.606
+#     0.90   0.848  0.788   0.495   0.692   0.636   <- ships
+#     dense  0.848  0.697   0.490   0.682   0.545
+#
+# Note how LITTLE keyword weight is right: 10%. Enough to break ties a 992-chunk book would
+# otherwise win on volume, not enough to let common aquaponics vocabulary dominate the ranking.
+# At 0.5 — the intuitive "balanced" setting — hybrid is still clearly worse than dense.
+_DEFAULT_BETA = 0.90
 
 
 def _get_index():
@@ -117,29 +131,19 @@ def _get_bm25():
 
 
 def hybrid_enabled() -> bool:
-    """Hybrid retrieval ships DISABLED, on evidence — see docs/dpg/retrieval_eval/hybrid_sweep.json.
+    """Hybrid retrieval ships ENABLED — see docs/dpg/retrieval_eval/hybrid_sweep.json.
 
-    The received wisdom is that BM25 + RRF beats dense-only. Measured on this corpus it does not,
-    at any weighting:
+    It did not start that way, and the reversal is the useful part. On the original 362-chunk
+    corpus hybrid lost to dense-only at EVERY weighting and was shipped disabled, with the
+    evidence recorded and a note to re-run the sweep after substantial corpus growth. Adding FAO
+    589 took the corpus to 1354 chunks; re-running the sweep flipped the decision (MAP +0.091,
+    recall +0.091 at beta=0.90).
 
-        beta   hit    recall  prec    MRR     MAP
-        0.50   0.939  0.924   0.485   0.874   0.861
-        0.70   0.970  0.919   0.500   0.899   0.862
-        0.95   0.970  0.904   0.581   0.884   0.838
-        dense  0.970  0.919   0.626   0.909   0.869
-
-    Dense-only equals or beats every setting on every metric; the best hybrid configuration loses
-    0.126 of precision to match it elsewhere. The reason is the corpus, not the technique: 362
-    chunks that all share one vocabulary domain, so common aquaponics terms match across many
-    files and keyword rank carries little information. BM25 does fix the one dense miss
-    ("bright green and cloudy" -> algae_control.md) but breaks two other queries doing it.
-
-    The implementation is kept and tested because this is expected to invert as the corpus grows
-    and diversifies — adding FAO 589 alone would roughly quadruple it. Re-run the sweep after any
-    substantial corpus change and flip this default if the numbers move. Enable with
-    AGRONAUT_HYBRID=on.
+    Nothing about the technique changed. The corpus did. A 992-chunk book competing with 82 chunks
+    of targeted operator guidance is precisely the situation a keyword signal is for: it breaks
+    ties that dense similarity resolves by volume. Disable with AGRONAUT_HYBRID=off.
     """
-    return os.getenv("AGRONAUT_HYBRID", "").lower() in {"on", "1", "true"}
+    return os.getenv("AGRONAUT_HYBRID", "").lower() not in {"off", "0", "false"}
 
 
 def beta() -> float:
@@ -181,6 +185,32 @@ def max_distance() -> float:
 
 
 _POOL = 20      # candidates drawn from each retriever before fusion
+
+# At most this many passages from any ONE source in a single result set.
+#
+# The observed failure when a 992-chunk book joined an 82-chunk curated corpus was not subtle:
+# FAO 589 took all three slots on 10 of 33 queries, so a targeted operator answer that existed in
+# knowledge/ never reached the model. Ranking alone cannot fix that — the book genuinely IS
+# similar, and has twelve times as many chances to be. A per-source cap spends one slot on breadth
+# instead, which is what a researcher does by reflex: read two sources, not three pages of one.
+#
+# Measured (1354-chunk corpus, hybrid on):
+#
+#     cap    hit    recall  prec    MRR     MAP
+#     1      0.970  0.919   0.404   0.747   0.710
+#     2      0.939  0.894   0.540   0.737   0.697   <- ships
+#     none   0.848  0.788   0.495   0.692   0.636
+#
+# cap=1 restores the pre-FAO hit_rate exactly and wins MRR/MAP, so it is a defensible choice and
+# is one env var away. It ships at 2 because part of cap=1's advantage is an artefact of the
+# metric rather than a real gain: `relevant` is labelled at DOCUMENT granularity, so one FAO
+# passage scores identically to three, and the metric cannot see that some queries (feeding rates,
+# pest treatments) are genuinely best answered by several passages from the same chapter. cap=2
+# keeps most of the recall while returning materially less irrelevant context to the model
+# (precision 0.540 vs 0.404), and still allows a source with real depth to contribute twice.
+#
+# Set AGRONAUT_MAX_PER_SOURCE=1 to prioritise coverage, or 0 to disable the cap entirely.
+_MAX_PER_SOURCE = 2
 
 
 def retrieve(query: str, k: int = 3, max_dist: float | None = None,
@@ -264,7 +294,48 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
             sparse = []
 
     fused = rrf_fuse(dense, sparse) if sparse else dense
-    return [by_key[key] for key in fused[:k]]
+    return [by_key[key] for key in _diversify(fused, by_key, k)]
+
+
+def max_source_cap() -> int:
+    """Configured per-source cap; 0 disables it."""
+    raw = os.getenv("AGRONAUT_MAX_PER_SOURCE", "").strip()
+    if not raw:
+        return _MAX_PER_SOURCE
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        logging.warning("Bad AGRONAUT_MAX_PER_SOURCE=%r; using default", raw)
+        return _MAX_PER_SOURCE
+
+
+def _diversify(ranked: list, by_key: dict, k: int, max_per_source: int | None = None) -> list:
+    """Take the top k, allowing at most `max_per_source` passages from any single source.
+
+    Applied AFTER fusion, so relevance still decides the order and diversity only decides who is
+    displaced. A source that is genuinely the only answer still fills its cap; it simply cannot
+    fill the entire window. If the cap cannot be honoured — because too few distinct sources
+    matched at all — the remaining slots are filled from the original ranking rather than returned
+    short, since a capped-but-empty result would be worse than a repetitive one.
+    """
+    cap = max_source_cap() if max_per_source is None else max_per_source
+    if cap <= 0:
+        return ranked[:k]
+    picked, counts = [], {}
+    for key in ranked:
+        src = by_key[key]["source"]
+        if counts.get(src, 0) >= cap:
+            continue
+        counts[src] = counts.get(src, 0) + 1
+        picked.append(key)
+        if len(picked) == k:
+            return picked
+    for key in ranked:                      # backfill rather than return a short result
+        if key not in picked:
+            picked.append(key)
+            if len(picked) == k:
+                break
+    return picked[:k]
 
 
 def index_available() -> bool:

--- a/agronaut_agent/tests/test_corpus_hygiene.py
+++ b/agronaut_agent/tests/test_corpus_hygiene.py
@@ -187,3 +187,48 @@ def test_challenge_title_detection():
               "Access Denied", "Checking your browser before accessing"]:
         assert _is_challenge_title(t), t
     assert not _is_challenge_title("Important Water Quality Parameters in Aquaponics Systems")
+
+
+# --- dependency contract -----------------------------------------------------
+
+def test_lazily_imported_dependencies_are_actually_installed():
+    """rank_bm25 and pypdf are imported inside try/except so that a missing one degrades
+    gracefully rather than killing a live turn. That is right at runtime and dangerous in CI:
+    with both absent the whole suite still passed, because every test only asserted the graceful
+    degradation. PDF ingestion returned no chunks and BM25 fell back to dense-only, silently, and
+    nothing failed.
+
+    This asserts the dependency contract directly, so a fresh install missing them breaks loudly
+    here instead of quietly shipping two inert features.
+    """
+    import pypdf  # noqa: F401
+    import rank_bm25  # noqa: F401
+
+
+def test_lazy_dependencies_are_declared_in_requirements():
+    """Installed on this machine is not the same as declared. requirement.txt is what CI, Docker
+    and `pip install -e .` actually install (pyproject reads it as the single source of truth)."""
+    import pathlib
+    req = (pathlib.Path(__file__).resolve().parents[2] / "requirement.txt").read_text().lower()
+    for dep in ("rank_bm25", "pypdf"):
+        assert dep in req, f"{dep} is imported by the code but not declared in requirement.txt"
+
+
+def test_pdf_extraction_actually_works():
+    """A functional round-trip, not a graceful-degradation check: build a real PDF and read its
+    text back. Without pypdf this fails instead of silently yielding zero chunks."""
+    import io
+    from pypdf import PdfWriter
+
+    from srcs.chatbot import _pdf_documents
+
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    buf = io.BytesIO()
+    writer.write(buf)
+    docs = _pdf_documents(buf.getvalue(), "https://example.org/doc.pdf")
+    # A blank page yields no text, but parsing must succeed and metadata must be well formed.
+    assert isinstance(docs, list)
+    for d in docs:
+        assert d.metadata["source"] == "https://example.org/doc.pdf"
+        assert isinstance(d.metadata["page"], int)

--- a/agronaut_agent/tests/test_corpus_hygiene.py
+++ b/agronaut_agent/tests/test_corpus_hygiene.py
@@ -1,0 +1,189 @@
+"""Guards on what is allowed INTO the index.
+
+Measured on the real corpus: three MDPI sources returned HTTP 403, and the "Access Denied - You
+don't have permission" body was indexed as a retrievable, citable passage. It is 231 characters,
+so it clears the 200-character boilerplate floor, and it contains none of the boilerplate
+keywords. Only the HTTP status distinguishes it from content.
+
+The vetting tests cover the other way a corpus rots: a source that is reachable, substantial and
+well-formed, but is the wrong document or is not openly licensed.
+
+All hermetic: no network, no index, no embedding model.
+"""
+
+import pytest
+
+
+# --- what gets in: HTTP status must gate indexing ----------------------------
+
+class _Resp:
+    def __init__(self, status=200, content=b"hello", ctype="text/html"):
+        self.status_code = status
+        self.content = content
+        self.headers = {"Content-Type": ctype}
+
+
+@pytest.fixture
+def fake_requests(monkeypatch):
+    """Swap the `requests` module srcs.chatbot imports inside _probe_url."""
+    import sys, types
+
+    def _install(resp=None, raises=None):
+        mod = types.ModuleType("requests")
+
+        def get(url, **kw):
+            if raises:
+                raise raises
+            return resp
+        mod.get = get
+        monkeypatch.setitem(sys.modules, "requests", mod)
+    return _install
+
+
+def test_error_page_body_is_never_indexed(fake_requests):
+    """A 403 page must yield NO documents — this is the bug that put 'Access Denied' text
+    into the knowledge base as a citable passage."""
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(status=403, content=b"Access Denied. You don't have permission."))
+    assert _probe_url("https://example.org/paywalled") is None
+
+
+@pytest.mark.parametrize("status", [400, 401, 404, 429, 500, 503])
+def test_all_non_2xx_statuses_are_rejected(fake_requests, status):
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(status=status))
+    assert _probe_url("https://example.org/x") is None
+
+
+@pytest.mark.parametrize("status", [200, 201, 204])
+def test_2xx_is_accepted(fake_requests, status):
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(status=status))
+    assert _probe_url("https://example.org/x") is not None
+
+
+def test_transport_failure_defers_rather_than_dropping_the_source(fake_requests):
+    """One flaky request must not silently remove a healthy source from the corpus: the probe
+    yields to the loader's own error handling instead of returning None."""
+    from srcs.chatbot import _probe_url
+    fake_requests(raises=OSError("connection reset"))
+    probe = _probe_url("https://example.org/x")
+    assert probe is not None and probe["content"] == b""
+
+
+def test_pdf_detected_by_magic_bytes_not_url_suffix(fake_requests):
+    """FAO serves publications from extension-less bitstream endpoints, so a `.pdf` suffix
+    check would miss them entirely."""
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(content=b"%PDF-1.7 ...", ctype="application/octet-stream"))
+    assert _probe_url("https://openknowledge.fao.org/server/api/core/bitstreams/x/content")["is_pdf"]
+
+
+def test_pdf_detected_by_content_type(fake_requests):
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(content=b"whatever", ctype="application/pdf"))
+    assert _probe_url("https://example.org/download")["is_pdf"]
+
+
+def test_html_is_not_mistaken_for_pdf(fake_requests):
+    from srcs.chatbot import _probe_url
+    fake_requests(_Resp(content=b"<html><body>hi</body></html>", ctype="text/html"))
+    assert not _probe_url("https://example.org/page")["is_pdf"]
+
+
+def test_unreadable_pdf_bytes_degrade_to_empty_not_crash():
+    from srcs.chatbot import _pdf_documents
+    assert _pdf_documents(b"not actually a pdf", "https://example.org/x") == []
+# --- vetting a proposed source before it enters the corpus -------------------
+
+from scripts.corpus_report import (  # noqa: E402
+    _drift, _drift_in_text, _tokens, detect_licence, detect_licence_in_text,
+)
+
+
+def test_cc_licence_detected_in_html():
+    html = '<a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>'
+    assert detect_licence(html) == "CC BY 4.0"
+
+
+def test_no_licence_in_plain_html():
+    assert detect_licence("<html><body>nothing here</body></html>") == ""
+
+
+def test_licence_matched_across_pdf_line_breaks():
+    """PDF extraction wraps lines mid-sentence. A licence phrase split by a newline must still
+    match — this silently rejected FAO 589 until whitespace was normalised first."""
+    text = ("© FAO, 2014 FAO encourages the use, reproduction and dissemination\nof material in "
+            "this\ninformation product. Except where otherwise indicated...")
+    assert detect_licence_in_text(text).startswith("FAO permissive")
+
+
+def test_cc_by_detected_in_pdf_text():
+    assert detect_licence_in_text("Licensed under CC BY 4.0 by the authors.") == "CC BY 4.0"
+
+
+def test_licence_found_past_the_front_matter():
+    """The rights statement sits on page 4 of a full publication, behind thousands of characters
+    of title pages — a narrow scan window misses it."""
+    text = ("front matter " * 900) + " reproduction and dissemination of material in this information product"
+    assert detect_licence_in_text(text).startswith("FAO permissive")
+
+
+def test_topic_drift_catches_the_wrong_publication():
+    """A publication ID that silently resolves to a different article is the failure mode that
+    passes every other check: reachable, substantial, well-formed — and about sharks."""
+    meta = {"title": "Sharks for the Aquarium and Considerations for Their Selection",
+            "final_url": "https://ask.ifas.ufl.edu/publication/FA179"}
+    assert _drift("aquaponics water quality guide", meta) == "DRIFT"
+
+
+def test_on_topic_page_is_not_flagged():
+    meta = {"title": "Important Water Quality Parameters in Aquaponics Systems",
+            "final_url": "https://pubs.nmsu.edu/_circulars/CR680/"}
+    assert _drift("aquaponics water quality parameters", meta) == ""
+
+
+def test_unlabelled_source_is_reported_not_silently_passed():
+    """An unlabelled URL cannot be drift-checked at all, which is itself the risk worth naming."""
+    assert _drift("", {"title": "anything"}) == "unlabeled"
+
+
+def test_pdf_drift_uses_document_text_not_html_title():
+    """PDFs have no <title>, so drift must be judged on their opening text — otherwise every
+    PDF is falsely rejected."""
+    body = "Small-scale aquaponic food production. Integrated fish and plant farming. FAO 2014."
+    assert _drift_in_text("aquaponic food production", body) == ""
+    assert _drift_in_text("bicycle maintenance", body) == "DRIFT"
+
+
+def test_stopwords_cannot_manufacture_a_topic_match():
+    """'guide'/'university'/'the' appear in half the titles on the internet; matching on them
+    would let any page pass the topic check."""
+    assert not (_tokens("the university guide") & {"aquaponics", "tilapia"})
+
+
+def test_bot_challenge_title_does_not_fake_topic_drift():
+    """Cloudflare served 'Client Challenge' to the metadata request while the content request
+    succeeded with 215 real chunks. Judging identity on the title alone flagged a healthy source
+    as the wrong document."""
+    from scripts.corpus_report import _drift
+    meta = {"title": "Client Challenge", "final_url": "https://doi.org/10.1007/S10462-024-11003-X"}
+    body = "Smart aquaponics systems are gaining popularity as they contribute to food production"
+    assert _drift("smart aquaponics systematic literature review", meta, body) == ""
+
+
+def test_body_evidence_cannot_excuse_genuine_drift():
+    """The body is the strongest evidence of identity — which means it must still catch a source
+    that really is the wrong document."""
+    from scripts.corpus_report import _drift
+    meta = {"title": "Sharks for the Aquarium", "final_url": "https://ask.ifas.ufl.edu/x"}
+    body = "Selecting sharks for home aquaria requires attention to tank volume and temperament."
+    assert _drift("aquaponics water quality", meta, body) == "DRIFT"
+
+
+def test_challenge_title_detection():
+    from scripts.corpus_report import _is_challenge_title
+    for t in ["Just a moment...", "Client Challenge", "Attention Required! | Cloudflare",
+              "Access Denied", "Checking your browser before accessing"]:
+        assert _is_challenge_title(t), t
+    assert not _is_challenge_title("Important Water Quality Parameters in Aquaponics Systems")

--- a/agronaut_agent/tests/test_hybrid_retrieval.py
+++ b/agronaut_agent/tests/test_hybrid_retrieval.py
@@ -1,0 +1,156 @@
+"""Hybrid BM25 + reciprocal rank fusion — the fusion arithmetic, and the guarantees it must not break.
+
+Hybrid ships DISABLED. Measured over the golden set, dense-only equals or beats every weighting on
+every metric (docs/dpg/retrieval_eval/hybrid_sweep.json), because 362 chunks sharing one
+vocabulary domain give BM25 little to discriminate on. The implementation is kept and tested
+because that balance is expected to invert as the corpus grows — so it must be correct and
+inert now, and correct and available later.
+
+The critical property under test is that fusion CANNOT weaken the relevance floor. BM25 always
+ranks something first, however off-topic the question, so if keyword hits could enter results on
+their own the floor's off-topic guarantee would silently evaporate.
+"""
+
+import pytest
+
+from agronaut_agent import rag
+
+
+# --- fusion arithmetic (pure) ------------------------------------------------
+
+def test_rrf_rewards_agreement_between_the_two_rankings():
+    """A document BOTH retrievers surface must outrank one only a single retriever surfaced.
+
+    Note this is about presence on both lists, not about being mid-ranked on both: at k=60 the
+    per-rank differences are tiny, so 1st+3rd actually edges out 2nd+2nd (1/61 + 1/63 > 2/62).
+    Agreement is what RRF rewards; exact rank barely matters once k is large.
+    """
+    fused = rag.rrf_fuse(dense=["both", "dense_only"], sparse=["both"], b=0.5)
+    assert fused[0] == "both"
+
+
+def test_rrf_respects_beta_weighting():
+    """beta=1.0 is dense-only ordering; beta=0.0 is keyword-only ordering."""
+    assert rag.rrf_fuse(["x", "y"], ["y", "x"], b=1.0)[0] == "x"
+    assert rag.rrf_fuse(["x", "y"], ["y", "x"], b=0.0)[0] == "y"
+
+
+def test_rrf_includes_documents_found_by_only_one_retriever():
+    fused = rag.rrf_fuse(dense=["a"], sparse=["z"], b=0.5)
+    assert set(fused) == {"a", "z"}
+
+
+def test_rrf_k_controls_how_much_a_top_rank_dominates():
+    """The knob that stops one retriever's top hit from steamrolling the other's ranking.
+
+    "spike" is 1st on the semantic list and absent from the keyword list. "steady" is 3rd on both.
+    Padding differs between the lists so no filler can appear twice and win on agreement, and
+    beta=0.6 keeps a keyword 1st place from tying the semantic 1st place.
+
+        k=0   spike = 0.6/1 = 0.600   steady = 0.6/3 + 0.4/3 = 0.333  -> spike
+        k=60  spike = 0.6/61 = 0.010  steady = 1.0/63       = 0.016   -> steady
+
+    A large k is what makes agreement between retrievers matter more than one confident hit.
+    """
+    dense = ["spike", "dense_pad", "steady"]
+    sparse = ["kw_pad_1", "kw_pad_2", "steady"]
+    assert rag.rrf_fuse(dense, sparse, b=0.6, rrf_k=0)[0] == "spike"
+    assert rag.rrf_fuse(dense, sparse, b=0.6, rrf_k=60)[0] == "steady"
+
+
+def test_rrf_handles_empty_lists():
+    assert rag.rrf_fuse([], [], b=0.5) == []
+    assert rag.rrf_fuse(["a"], [], b=0.5) == ["a"]
+
+
+def test_beta_is_clamped_and_falls_back_on_bad_config(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_HYBRID_BETA", "5")
+    assert rag.beta() == 1.0
+    monkeypatch.setenv("AGRONAUT_HYBRID_BETA", "-2")
+    assert rag.beta() == 0.0
+    monkeypatch.setenv("AGRONAUT_HYBRID_BETA", "nonsense")
+    assert rag.beta() == rag._DEFAULT_BETA
+    monkeypatch.delenv("AGRONAUT_HYBRID_BETA")
+    assert rag.beta() == rag._DEFAULT_BETA
+
+
+def test_hybrid_is_off_unless_explicitly_enabled(monkeypatch):
+    """Shipping default. An unset variable must mean OFF here — the sweep says dense-only wins."""
+    monkeypatch.delenv("AGRONAUT_HYBRID", raising=False)
+    assert not rag.hybrid_enabled()
+    monkeypatch.setenv("AGRONAUT_HYBRID", "on")
+    assert rag.hybrid_enabled()
+
+
+# --- fusion must not weaken the relevance floor ------------------------------
+
+class _Doc:
+    def __init__(self, text, **md):
+        self.page_content = text + " " + ("aquaponics husbandry detail. " * 12)
+        self.metadata = md
+
+
+class _Index:
+    def __init__(self, scored):
+        self._scored = scored
+        self.docstore = type("_S", (), {"_dict": {i: d for i, (d, _) in enumerate(scored)}})()
+
+    def similarity_search_with_score(self, query, k=3):
+        return self._scored[:k]
+
+
+@pytest.fixture
+def index_with(monkeypatch):
+    def _install(scored):
+        monkeypatch.setattr(rag, "_INDEX", _Index(scored))
+        monkeypatch.setattr(rag, "_TRIED", True)
+        monkeypatch.setattr(rag, "_BM25", None)
+        monkeypatch.setattr(rag, "_BM25_TRIED", False)
+    return _install
+
+
+def test_keyword_hits_cannot_resurrect_an_off_topic_query(index_with, monkeypatch):
+    """THE critical guarantee. Every passage is beyond the floor, so the corpus cannot answer.
+    BM25 will still rank something first — it always does — and that must not produce a result."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc("Algae removal from surfaces."), 1.90),
+                (_Doc("Nitrite management."), 1.95)])
+    assert rag.retrieve("how do I remove a red wine stain", k=3, hybrid=True) == []
+    assert rag.search("how do I remove a red wine stain") == rag._NO_MATCH
+
+
+def test_hybrid_disabled_returns_dense_order(index_with, monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc("Closest.", source_path="/r/knowledge/a.md"), 0.10),
+                (_Doc("Further.", source_path="/r/knowledge/b.md"), 0.20)])
+    hits = rag.retrieve("q", k=2, hybrid=False)
+    assert [h["source"] for h in hits] == ["knowledge/a.md", "knowledge/b.md"]
+
+
+def test_keyword_only_hit_reports_no_distance_rather_than_a_fake_one(index_with, monkeypatch):
+    """A BM25 hit has no L2 distance. Inventing a comparable number would corrupt any later
+    decision that reads the score — the floor included."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc("Nitrite stresses tilapia gills badly.", source_path="/r/knowledge/n.md"), 0.2),
+                (_Doc("Green water means suspended algae bloom.", source_path="/r/knowledge/algae.md"), 1.9)])
+    hits = rag.retrieve("green water algae bloom", k=3, hybrid=True)
+    for h in hits:
+        assert h["score"] is None or isinstance(h["score"], float)
+    assert any(h["score"] == 0.2 for h in hits)
+
+
+def test_bm25_failure_degrades_to_dense_rather_than_breaking_the_turn(index_with, monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc("Relevant passage.", source_path="/r/knowledge/a.md"), 0.10)])
+    monkeypatch.setattr(rag, "_BM25", None)
+    monkeypatch.setattr(rag, "_BM25_TRIED", True)      # simulate an unavailable keyword index
+    hits = rag.retrieve("q", k=3, hybrid=True)
+    assert [h["source"] for h in hits] == ["knowledge/a.md"]
+
+
+def test_citation_labels_survive_fusion(index_with, monkeypatch):
+    """Fusion reorders passages; it must never strip the attribution that makes them citable."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc("Aeration prevents DO crashes.", source_type="web",
+                      url_label="FAO 589"), 0.30)])
+    assert "[source: FAO 589]" in rag.search("aeration")

--- a/agronaut_agent/tests/test_hybrid_retrieval.py
+++ b/agronaut_agent/tests/test_hybrid_retrieval.py
@@ -154,3 +154,39 @@ def test_citation_labels_survive_fusion(index_with, monkeypatch):
     index_with([(_Doc("Aeration prevents DO crashes.", source_type="web",
                       url_label="FAO 589"), 0.30)])
     assert "[source: FAO 589]" in rag.search("aeration")
+
+
+def test_bm25_index_actually_builds_and_ranks(monkeypatch):
+    """A functional check, not a degradation check.
+
+    Every other test here tolerates a missing rank_bm25 by design, so with the package absent the
+    whole file still passed while hybrid retrieval was completely inert. This one exercises the
+    real BM25 path: the index must build from the FAISS docstore and rank the document containing
+    the query's exact terms first.
+    """
+    import rank_bm25  # noqa: F401 — the point is that this must be installed
+
+    docs = [
+        _Doc("Green water means suspended single-celled algae blooming in the tank.",
+             source_path="/r/knowledge/algae.md"),
+        _Doc("Feed the fish twice daily and remove uneaten pellets promptly.",
+             source_path="/r/knowledge/feed.md"),
+    ]
+    monkeypatch.setattr(rag, "_INDEX", type("_I", (), {
+        "docstore": type("_S", (), {"_dict": dict(enumerate(docs))})()})())
+    monkeypatch.setattr(rag, "_TRIED", True)
+    monkeypatch.setattr(rag, "_BM25", None)
+    monkeypatch.setattr(rag, "_BM25_TRIED", False)
+
+    built = rag._get_bm25()
+    assert built is not None, "BM25 index failed to build — is rank_bm25 installed?"
+    bm25, indexed = built
+    scores = bm25.get_scores(rag._tokenize("green water algae bloom"))
+    best = max(range(len(indexed)), key=lambda i: scores[i])
+    assert "algae" in indexed[best].metadata["source_path"]
+
+
+def test_tokenizer_is_case_and_punctuation_insensitive():
+    """BM25 matches on exact tokens, so "Nitrite," and "nitrite" must normalise to one term or
+    keyword search silently misses the terminology it exists to catch."""
+    assert rag._tokenize("Nitrite, pH 6.8 — DO!") == ["nitrite", "ph", "6", "8", "do"]

--- a/agronaut_agent/tests/test_hybrid_retrieval.py
+++ b/agronaut_agent/tests/test_hybrid_retrieval.py
@@ -74,12 +74,24 @@ def test_beta_is_clamped_and_falls_back_on_bad_config(monkeypatch):
     assert rag.beta() == rag._DEFAULT_BETA
 
 
-def test_hybrid_is_off_unless_explicitly_enabled(monkeypatch):
-    """Shipping default. An unset variable must mean OFF here — the sweep says dense-only wins."""
+def test_hybrid_is_on_by_default(monkeypatch):
+    """Shipping default, and it was reversed on evidence.
+
+    On the 362-chunk corpus hybrid lost at every weighting and shipped OFF. Adding FAO 589 took
+    the corpus to 1354 chunks and re-running the sweep flipped it: MAP +0.091 and recall +0.091 at
+    beta=0.90. The technique did not change; the corpus did.
+    """
     monkeypatch.delenv("AGRONAUT_HYBRID", raising=False)
-    assert not rag.hybrid_enabled()
-    monkeypatch.setenv("AGRONAUT_HYBRID", "on")
     assert rag.hybrid_enabled()
+    monkeypatch.setenv("AGRONAUT_HYBRID", "off")
+    assert not rag.hybrid_enabled()
+
+
+def test_default_beta_is_the_measured_optimum():
+    """0.90, not the intuitive 0.5. Only 10% keyword weight — enough to break ties a 992-chunk
+    book wins on volume, not enough to let shared aquaponics vocabulary dominate. At 0.5 hybrid
+    is still clearly worse than dense-only."""
+    assert rag._DEFAULT_BETA == 0.90
 
 
 # --- fusion must not weaken the relevance floor ------------------------------

--- a/agronaut_agent/tests/test_index_cache.py
+++ b/agronaut_agent/tests/test_index_cache.py
@@ -1,0 +1,138 @@
+"""The built knowledge index is cached, so the corpus fingerprint must be exactly right.
+
+Rebuilding the index costs a network fetch per source plus embedding every chunk. That was
+tolerable for 365 chunks of HTML, but the corpus is growing toward publication-scale PDFs — FAO
+589 alone is 56 MB, 275 pages, 47 s just to download. Caching it is what makes such a source
+viable at all.
+
+A cache is only safe if it invalidates when it should. A stale index is worse than a slow one:
+it silently answers from a corpus the operator has already changed, and nothing in the output
+reveals it. These tests pin the invalidation rules.
+"""
+
+import pathlib
+
+import pytest
+
+from srcs import chatbot
+
+
+@pytest.fixture
+def corpus(tmp_path, monkeypatch):
+    """A throwaway corpus whose fingerprint we can perturb one variable at a time."""
+    kb = tmp_path / "knowledge"
+    kb.mkdir()
+    (kb / "a.md").write_text("# Ammonia\nKeep ammonia low.")
+    (kb / "b.md").write_text("# pH\nKeep pH stable.")
+    urls = tmp_path / "urls.txt"
+    urls.write_text("CAT|https://example.org/x|Example|CC BY 4.0\n")
+    monkeypatch.setattr(chatbot, "KNOWLEDGE_DIR", str(kb))
+    monkeypatch.setattr(chatbot, "URL_FILE", str(urls))
+    return {"kb": kb, "urls": urls}
+
+
+def test_fingerprint_is_stable_for_an_unchanged_corpus(corpus):
+    assert chatbot._corpus_fingerprint() == chatbot._corpus_fingerprint()
+
+
+def test_editing_a_knowledge_file_invalidates_the_cache(corpus):
+    before = chatbot._corpus_fingerprint()
+    (corpus["kb"] / "a.md").write_text("# Ammonia\nKeep ammonia BELOW 0.5 mg/L.")
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_adding_a_knowledge_file_invalidates_the_cache(corpus):
+    before = chatbot._corpus_fingerprint()
+    (corpus["kb"] / "c.md").write_text("# Nitrite\nNitrite stresses fish.")
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_removing_a_knowledge_file_invalidates_the_cache(corpus):
+    before = chatbot._corpus_fingerprint()
+    (corpus["kb"] / "b.md").unlink()
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_renaming_a_file_invalidates_even_with_identical_content(corpus):
+    """The filename IS the citation label an operator sees, so a rename changes the output
+    even when not one byte of the text differs."""
+    before = chatbot._corpus_fingerprint()
+    (corpus["kb"] / "a.md").rename(corpus["kb"] / "ammonia.md")
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_changing_urls_invalidates_the_cache(corpus):
+    before = chatbot._corpus_fingerprint()
+    corpus["urls"].write_text("CAT|https://example.org/y|Other|CC BY 4.0\n")
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_changing_the_embedding_model_invalidates_the_cache(corpus, monkeypatch):
+    """Vectors from a different model are not comparable, so reusing them would silently
+    corrupt every distance the retriever computes — including the relevance floor."""
+    before = chatbot._corpus_fingerprint()
+    monkeypatch.setattr(chatbot, "EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+    assert chatbot._corpus_fingerprint() != before
+
+
+@pytest.mark.parametrize("attr,value", [("CHUNK_SIZE", 1200), ("CHUNK_OVERLAP", 250)])
+def test_changing_chunk_geometry_invalidates_the_cache(corpus, monkeypatch, attr, value):
+    before = chatbot._corpus_fingerprint()
+    monkeypatch.setattr(chatbot, attr, value)
+    assert chatbot._corpus_fingerprint() != before
+
+
+def test_cache_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_INDEX_CACHE", "off")
+    assert not chatbot._index_cache_enabled()
+    assert chatbot._load_cached_index("anyfingerprint") is None
+    monkeypatch.setenv("AGRONAUT_INDEX_CACHE", "on")
+    assert chatbot._index_cache_enabled()
+
+
+def test_missing_cache_returns_none_rather_than_raising(monkeypatch, tmp_path):
+    monkeypatch.delenv("AGRONAUT_INDEX_CACHE", raising=False)
+    monkeypatch.setattr(chatbot, "INDEX_CACHE_DIR", tmp_path / "nope")
+    assert chatbot._load_cached_index("deadbeef") is None
+
+
+def test_expired_cache_is_ignored(monkeypatch, tmp_path):
+    """A TTL bounds staleness the fingerprint cannot see: a web publisher can edit a source
+    without urls.txt changing, and detecting that would require the very fetch the cache avoids."""
+    import os, time
+    monkeypatch.delenv("AGRONAUT_INDEX_CACHE", raising=False)
+    monkeypatch.setattr(chatbot, "INDEX_CACHE_DIR", tmp_path)
+    d = tmp_path / "abc"
+    d.mkdir()
+    (d / "index.faiss").write_bytes(b"stale")
+    old = time.time() - (chatbot.INDEX_CACHE_TTL + 3600)
+    os.utime(d / "index.faiss", (old, old))
+    assert chatbot._load_cached_index("abc") is None
+
+
+def test_corrupt_cache_falls_through_to_a_rebuild(monkeypatch, tmp_path):
+    """An unreadable cache must never be the reason retrieval is unavailable."""
+    monkeypatch.delenv("AGRONAUT_INDEX_CACHE", raising=False)
+    monkeypatch.setattr(chatbot, "INDEX_CACHE_DIR", tmp_path)
+    d = tmp_path / "abc"
+    d.mkdir()
+    (d / "index.faiss").write_bytes(b"this is not a FAISS index")
+    assert chatbot._load_cached_index("abc") is None
+
+
+def test_save_failure_is_not_fatal(monkeypatch, tmp_path):
+    """Caching is an optimisation. If it fails, the freshly built index must still be returned."""
+    monkeypatch.delenv("AGRONAUT_INDEX_CACHE", raising=False)
+    monkeypatch.setattr(chatbot, "INDEX_CACHE_DIR", tmp_path / "x")
+
+    class _Boom:
+        def save_local(self, path):
+            raise OSError("disk full")
+
+    chatbot._save_cached_index(_Boom(), "abc")   # must not raise
+
+
+def test_cache_is_not_committed():
+    """The index is derived data — rebuildable from knowledge/ and urls.txt, and large."""
+    root = pathlib.Path(__file__).resolve().parents[2]
+    assert "data/.index_cache/" in (root / ".gitignore").read_text()

--- a/agronaut_agent/tests/test_index_cache.py
+++ b/agronaut_agent/tests/test_index_cache.py
@@ -136,3 +136,19 @@ def test_cache_is_not_committed():
     """The index is derived data — rebuildable from knowledge/ and urls.txt, and large."""
     root = pathlib.Path(__file__).resolve().parents[2]
     assert "data/.index_cache/" in (root / ".gitignore").read_text()
+
+
+@pytest.mark.parametrize("var", ["AGRONAUT_MD_HEADERS", "AGRONAUT_MD_CRUMB", "AGRONAUT_PDF_CLEAN"])
+def test_chunking_flags_invalidate_the_cache(corpus, monkeypatch, var):
+    """A chunking flag changes what text lands in each vector, so an index built under one setting
+    is wrong under the other. Leaving these out of the fingerprint made an ablation appear to
+    measure a setting while it was actually re-reading the previous run's index.
+
+    AGRONAUT_MD_CRUMB is here because it was MISSED the first time this was fixed, and the only
+    thing that revealed it was an ablation reporting byte-identical numbers for two variants that
+    should have differed. Every flag that changes chunk text belongs in the fingerprint.
+    """
+    monkeypatch.setenv(var, "on")
+    on = chatbot._corpus_fingerprint()
+    monkeypatch.setenv(var, "off")
+    assert chatbot._corpus_fingerprint() != on

--- a/agronaut_agent/tests/test_markdown_chunking.py
+++ b/agronaut_agent/tests/test_markdown_chunking.py
@@ -1,0 +1,124 @@
+"""Markdown-header-aware chunking and the context prefix.
+
+Ships DISABLED. Measured over the golden set the baseline character splitter wins on every metric
+except precision (docs/dpg/retrieval_eval/chunking_ablation.json), because 95% of this corpus's
+sections are SMALLER than the 800-character chunk window — splitting on headings fragments a
+corpus the recursive splitter was already packing sensibly.
+
+It is kept and tested because that reasoning inverts for documents whose sections EXCEED the chunk
+window, which is exactly the book-length PDFs the corpus is growing toward. So it has to be
+correct and inert now, and correct and available later.
+"""
+
+import pytest
+
+from srcs import chatbot
+
+
+class _Doc:
+    def __init__(self, text, **md):
+        self.page_content = text
+        self.metadata = md
+
+
+SAMPLE = """# Nitrogen Cycle and Cycling
+
+Intro paragraph about the cycle.
+
+## Target readings
+
+- Ammonia: keep it below 0.5 mg/L
+- Nitrite: keep it below 0.5 mg/L
+
+## Ammonia spike — safe actions
+
+Stop feeding for 24 hours and perform a partial water change.
+"""
+
+
+def test_disabled_by_default(monkeypatch):
+    """The shipping default. Unset must mean OFF — the ablation says the baseline wins."""
+    monkeypatch.delenv("AGRONAUT_MD_HEADERS", raising=False)
+    assert not chatbot.markdown_headers_enabled()
+    monkeypatch.setenv("AGRONAUT_MD_HEADERS", "on")
+    assert chatbot.markdown_headers_enabled()
+
+
+def test_splits_on_authored_section_boundaries(monkeypatch):
+    monkeypatch.delenv("AGRONAUT_MD_CRUMB", raising=False)
+    chunks = chatbot._markdown_header_chunks(_Doc(SAMPLE, source_type="local_file"))
+    assert len(chunks) >= 3
+    joined = [c.page_content for c in chunks]
+    # The two sections must not end up in one chunk — that merge is the failure mode header
+    # splitting exists to prevent.
+    assert not any("Target readings" in c and "safe actions" in c for c in joined)
+
+
+def test_context_prefix_gives_an_orphan_bullet_its_subject(monkeypatch):
+    """"keep it below 0.5 mg/L" is nearly meaningless embedded alone. The prefix is what makes it
+    carry its subject — the one part of this technique the ablation showed genuinely helps."""
+    monkeypatch.delenv("AGRONAUT_MD_CRUMB", raising=False)
+    chunks = chatbot._markdown_header_chunks(_Doc(SAMPLE, source_type="local_file"))
+    target = next(c for c in chunks if "0.5 mg/L" in c.page_content)
+    assert "Nitrogen Cycle and Cycling" in target.page_content
+    assert "Target readings" in target.page_content
+
+
+def test_context_prefix_can_be_disabled_for_ablation(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_MD_CRUMB", "off")
+    chunks = chatbot._markdown_header_chunks(_Doc(SAMPLE, source_type="local_file"))
+    target = next(c for c in chunks if "0.5 mg/L" in c.page_content)
+    assert not target.page_content.startswith("Nitrogen Cycle and Cycling — Target readings\n")
+
+
+def test_heading_metadata_is_preserved_for_filtering(monkeypatch):
+    monkeypatch.delenv("AGRONAUT_MD_CRUMB", raising=False)
+    chunks = chatbot._markdown_header_chunks(
+        _Doc(SAMPLE, source_type="local_file", source_path="/r/knowledge/nitrogen.md"))
+    target = next(c for c in chunks if "0.5 mg/L" in c.page_content)
+    assert target.metadata["h1"] == "Nitrogen Cycle and Cycling"
+    assert target.metadata["h2"] == "Target readings"
+    # original metadata must survive — source_path is what produces the citation label
+    assert target.metadata["source_path"] == "/r/knowledge/nitrogen.md"
+
+
+def test_document_without_headings_survives_intact():
+    """No headings means nothing to split on. What matters is that the text and its metadata come
+    through unaltered — the splitter may hand back an equivalent object rather than the same one."""
+    doc = _Doc("Just a flat paragraph with no headings at all.", source_type="local_file")
+    out = chatbot._markdown_header_chunks(doc)
+    assert len(out) == 1
+    assert out[0].page_content.strip() == doc.page_content.strip()
+    assert out[0].metadata["source_type"] == "local_file"
+
+
+def test_prefix_is_not_duplicated_when_headings_are_kept():
+    """strip_headers=False means the heading is already in the body; prefixing again would embed
+    the same words twice and skew the vector."""
+    chunks = chatbot._markdown_header_chunks(_Doc(SAMPLE, source_type="local_file"))
+    for c in chunks:
+        assert c.page_content.count("Target readings") <= 2
+
+
+def test_only_local_files_are_header_split(monkeypatch):
+    """Web and PDF documents have no reliable heading structure, so they must reach the character
+    splitter untouched."""
+    monkeypatch.setenv("AGRONAUT_MD_HEADERS", "on")
+    web = _Doc(SAMPLE, source_type="web")
+    local = _Doc(SAMPLE, source_type="local_file")
+    prepared = []
+    for d in (web, local):
+        if d.metadata.get("source_type") == "local_file":
+            prepared.extend(chatbot._markdown_header_chunks(d))
+        else:
+            prepared.append(d)
+    assert web in prepared
+    assert len(prepared) > 2
+
+
+def test_malformed_markdown_does_not_lose_the_document(monkeypatch):
+    """A parsing failure must never silently drop a knowledge file from the corpus."""
+    monkeypatch.setattr(chatbot, "_crumb_enabled", lambda: True)
+    doc = _Doc("#\n\n##\n\n" + "\x00 weird bytes", source_type="local_file")
+    out = chatbot._markdown_header_chunks(doc)
+    assert out, "document was dropped entirely"

--- a/agronaut_agent/tests/test_pdf_cleaning.py
+++ b/agronaut_agent/tests/test_pdf_cleaning.py
@@ -1,0 +1,139 @@
+"""Cleaning publication PDFs before they are chunked.
+
+A book is not a web page. Extracting FAO 589 raw gives 275 pages that include a table of contents,
+a list of figures, blank "GENERAL NOTES" pages — and, on every single page, a running header. Left
+alone that header lands in 111 of 1034 chunks: about 70 characters of the book's own title
+repeated across the corpus, pulling each vector toward the title and away from what the chunk is
+actually about. It is the highest-volume noise a PDF contributes and the easiest to remove.
+
+Measured on FAO 589: 13 structural pages dropped, running header present in 4/992 chunks instead
+of 111/1034.
+"""
+
+import pytest
+
+from srcs import chatbot
+
+
+class _Doc:
+    def __init__(self, text, page=1):
+        self.page_content = text
+        self.metadata = {"source": "https://example.org/x.pdf", "page": page}
+
+
+# --- running headers ---------------------------------------------------------
+
+def _book(n=20):
+    """A publication whose every page carries the same header with a varying page number."""
+    return [_Doc(f"Small-scale aquaponic food production — Integrated fish and plant farming{i}\n"
+                 f"Real prose about topic {i} that differs on every page and carries the meaning.",
+                 page=i) for i in range(1, n + 1)]
+
+
+def test_running_header_is_removed_from_every_page():
+    out = chatbot._strip_running_headers(_book())
+    assert not any("Small-scale aquaponic food production" in d.page_content for d in out)
+
+
+def test_page_numbers_do_not_defeat_repetition_detection():
+    """The header differs by exactly its page number, so counting raw lines finds 20 unique
+    strings and removes nothing. Numbers must be normalised away before counting."""
+    counts = {chatbot._normalise_for_repetition(d.page_content.splitlines()[0]) for d in _book()}
+    assert len(counts) == 1
+
+
+def test_real_content_survives():
+    out = chatbot._strip_running_headers(_book())
+    assert all(f"topic {d.metadata['page']}" in d.page_content for d in out)
+
+
+def test_a_phrase_recurring_in_prose_is_not_treated_as_furniture():
+    """"Aquaponics" appears throughout a book about aquaponics. Only text on a large FRACTION of
+    pages as its own repeated line is furniture — otherwise the filter eats the subject matter."""
+    docs = [_Doc(f"Aquaponics needs careful management of nutrient {i}.", page=i)
+            for i in range(1, 21)]
+    out = chatbot._strip_running_headers(docs)
+    assert all("Aquaponics" in d.page_content for d in out)
+
+
+def test_short_repeated_lines_are_kept():
+    """A very short repeated line is as likely to be data as furniture; require some length."""
+    docs = [_Doc(f"pH\nMeasurement number {i} taken at dawn.", page=i) for i in range(1, 21)]
+    out = chatbot._strip_running_headers(docs)
+    assert all("pH" in d.page_content for d in out)
+
+
+def test_no_furniture_leaves_documents_untouched():
+    docs = [_Doc(f"Wholly distinct page {i} with nothing repeated.", page=i) for i in range(1, 6)]
+    before = [d.page_content for d in docs]
+    assert [d.page_content for d in chatbot._strip_running_headers(docs)] == before
+
+
+# --- contents / index pages --------------------------------------------------
+
+TOC = """vi
+3.3 Other major components of water quality: algae and parasites 28
+3.3.1 Photosynthetic activity of algae 28
+3.3.2 Parasites, bacteria and other small organisms living in the water 29
+3.4 Sources of aquaponic water  29
+3.4.1 Rainwater 30
+3.4.2 Cistern or aquifer water 30
+3.5 Manipulating pH  31"""
+
+PROSE = """of constant water height. Instead, as the water continues to fall through the standpipe,
+the bell, which sits over the standpipe something like a hat, acts as an air tight lock and
+produces a siphon effect. This suction within the bell starts the siphon. Once started,
+all the water from the bed starts to rapidly flush down the standpipe as the bell keeps
+its air tight seal. The draining through the standpipe is faster than the constant inflow
+from the fish tank. When the water in the grow bed drains all the way down to bottom."""
+
+
+def test_contents_page_is_detected():
+    assert chatbot._looks_like_contents_page(TOC)
+
+
+def test_prose_is_not_mistaken_for_contents():
+    """The costly false positive: dropping a real page of knowledge because a few lines happen
+    to end in a number."""
+    assert not chatbot._looks_like_contents_page(PROSE)
+
+
+def test_prose_with_incidental_trailing_numbers_survives():
+    text = ("Keep dissolved oxygen above 5\n"
+            "Target pH sits near 6.8\n"
+            "The biofilter needs surface area, and the media provides it in proportion to the\n"
+            "volume of the bed, which is why media choice matters more than bed depth alone.\n"
+            "Feeding rate drives the whole system and should be adjusted slowly over days.")
+    assert not chatbot._looks_like_contents_page(text)
+
+
+def test_short_page_is_not_a_contents_page():
+    assert not chatbot._looks_like_contents_page("GENERAL NOTES")
+
+
+# --- the combined pass -------------------------------------------------------
+
+def test_cleaning_drops_structure_and_keeps_knowledge():
+    docs = _book(10) + [_Doc(TOC, page=11), _Doc(PROSE, page=12)]
+    out = chatbot._clean_pdf_documents(docs)
+    pages = {d.metadata["page"] for d in out}
+    assert 11 not in pages, "contents page survived"
+    assert 12 in pages, "prose page was dropped"
+    assert not any("Small-scale aquaponic food production" in d.page_content for d in out)
+
+
+def test_cleaning_can_be_disabled_for_ablation(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_PDF_CLEAN", "off")
+    docs = _book(10) + [_Doc(TOC, page=11)]
+    assert len(chatbot._clean_pdf_documents(docs)) == 11
+
+
+def test_cleaning_is_on_by_default(monkeypatch):
+    """Unlike hybrid and header chunking, this defaults ON: a table of contents is not knowledge
+    under any corpus conditions, so there is nothing to trade off."""
+    monkeypatch.delenv("AGRONAUT_PDF_CLEAN", raising=False)
+    assert chatbot.pdf_cleaning_enabled()
+
+
+def test_empty_input_is_safe():
+    assert chatbot._clean_pdf_documents([]) == []

--- a/agronaut_agent/tests/test_pdf_cleaning.py
+++ b/agronaut_agent/tests/test_pdf_cleaning.py
@@ -137,3 +137,55 @@ def test_cleaning_is_on_by_default(monkeypatch):
 
 def test_empty_input_is_safe():
     assert chatbot._clean_pdf_documents([]) == []
+
+
+# --- chapter labelling -------------------------------------------------------
+
+def test_chapter_is_read_from_the_running_header():
+    """A PDF has no headings to split on — extraction flattens the typography away. What survives
+    is the running header: "51Design of aquaponic units" carries the chapter and page as one
+    string."""
+    docs = [_Doc("51Design of aquaponic units\nProse about media beds.", page=51)]
+    out = chatbot._label_pdf_chapters(docs)
+    assert out[0].metadata["chapter"] == "Design of aquaponic units"
+
+
+def test_chapter_forward_fills_across_following_pages():
+    """Detection alone reached 76 of 262 pages, because even pages carry the book title instead.
+    A chapter continues until the next one starts — forward-filling took coverage to 95%."""
+    docs = [_Doc("51Design of aquaponic units\nFirst page.", page=51),
+            _Doc("Continuation prose with no header of its own.", page=52),
+            _Doc("More continuation prose.", page=53),
+            _Doc("75Plants in aquaponics\nA new chapter starts.", page=75),
+            _Doc("Prose belonging to the new chapter.", page=76)]
+    out = chatbot._label_pdf_chapters(docs)
+    assert [d.metadata["chapter"] for d in out] == [
+        "Design of aquaponic units", "Design of aquaponic units", "Design of aquaponic units",
+        "Plants in aquaponics", "Plants in aquaponics"]
+
+
+def test_header_line_is_removed_once_captured():
+    """The header is furniture once its content is metadata — leaving it would embed the page
+    number alongside the chapter name."""
+    docs = chatbot._label_pdf_chapters([_Doc("51Design of aquaponic units\nReal prose.", page=51)])
+    assert "51Design" not in docs[0].page_content
+
+
+def test_pages_before_any_chapter_are_left_alone():
+    docs = chatbot._label_pdf_chapters([_Doc("Front matter with no chapter yet.", page=1)])
+    assert "chapter" not in docs[0].metadata
+
+
+def test_prose_is_not_mistaken_for_a_chapter_header():
+    """A body line beginning with a number must not hijack the chapter for every page after it."""
+    docs = chatbot._label_pdf_chapters([_Doc("5 percent of body weight is a typical ration.", page=9)])
+    assert "chapter" not in docs[0].metadata
+
+
+def test_chapter_labelling_ships_disabled(monkeypatch):
+    """Measured worse on every metric: prefixing chunks with a generic chapter name adds words
+    that appear in every chunk about that topic, which dilutes rather than disambiguates."""
+    monkeypatch.delenv("AGRONAUT_PDF_SECTIONS", raising=False)
+    assert not chatbot.pdf_sections_enabled()
+    monkeypatch.setenv("AGRONAUT_PDF_SECTIONS", "on")
+    assert chatbot.pdf_sections_enabled()

--- a/agronaut_agent/tests/test_rag_citations.py
+++ b/agronaut_agent/tests/test_rag_citations.py
@@ -80,10 +80,36 @@ def test_unavailable_index_message_unchanged(monkeypatch):
 
 
 def test_urls_txt_has_no_duplicates():
-    lines = [ln.strip().rstrip("/").lower() for ln in
-             Path(__file__).resolve().parents[2].joinpath("urls.txt").read_text().splitlines()
-             if ln.strip()]
-    assert len(lines) == len(set(lines)), "urls.txt contains duplicate entries"
+    """No source may be indexed twice — duplicate chunks crowd out other documents in the top k.
+
+    Asserted over PARSED entries rather than raw lines: comment lines legitimately repeat (urls.txt
+    keeps a commented record of de-indexed references), and a raw-line check both trips over that
+    and misses the duplicate that actually matters — the same URL declared once bare and once in
+    CATEGORY|URL|LABEL form.
+    """
+    from srcs.chatbot import parse_urls_file
+    root = Path(__file__).resolve().parents[2]
+    urls = [e["url"].rstrip("/").lower() for e in parse_urls_file(str(root / "urls.txt"))]
+    assert len(urls) == len(set(urls)), "urls.txt declares the same source more than once"
+
+
+def test_every_indexed_source_declares_a_licence():
+    """Agronaut is a Digital Public Good: it may only index openly licensed text. An unlicensed
+    entry is a compliance problem, and empirically also a retrievability one — every source
+    measured that returned usable full text was openly licensed."""
+    from srcs.chatbot import parse_urls_file
+    root = Path(__file__).resolve().parents[2]
+    for e in parse_urls_file(str(root / "urls.txt")):
+        assert e["licence"], f"{e['url']} is indexed without a declared licence"
+
+
+def test_every_indexed_source_declares_a_label():
+    """The LABEL is what an operator sees in a citation, and it is what makes topic drift
+    detectable — an unlabelled source can silently become a different document."""
+    from srcs.chatbot import parse_urls_file
+    root = Path(__file__).resolve().parents[2]
+    for e in parse_urls_file(str(root / "urls.txt")):
+        assert e["label"], f"{e['url']} is indexed without a citable label"
 
 
 def test_system_prompt_requires_naming_sources():

--- a/agronaut_agent/tests/test_rag_citations.py
+++ b/agronaut_agent/tests/test_rag_citations.py
@@ -115,3 +115,17 @@ def test_every_indexed_source_declares_a_label():
 def test_system_prompt_requires_naming_sources():
     from agronaut_agent.core import SYSTEM_PROMPT
     assert "[source:" in SYSTEM_PROMPT
+
+
+def test_system_prompt_requires_judging_passage_relevance():
+    """Retrieval returns the CLOSEST passages, which is not the same as passages that answer the
+    question. The relevance floor is a coarse filter and provably cannot separate every case:
+    "best way to remove red wine from a carpet" lands nearer the corpus than five genuine operator
+    queries, and distance, pool margin, score spread and BM25 were each measured and none of them
+    separate it. The model is the fine filter, so the prompt has to tell it to filter — otherwise
+    an irrelevant passage arrives wearing a source label, which makes it look verified."""
+    from agronaut_agent.core import SYSTEM_PROMPT
+    assert "JUDGE EACH RETRIEVED PASSAGE" in SYSTEM_PROMPT
+    lowered = SYSTEM_PROMPT.lower()
+    assert "ignore it" in lowered          # told what to DO with an irrelevant passage
+    assert "nothing specific" in lowered   # and what to say when none fit

--- a/agronaut_agent/tests/test_rag_citations.py
+++ b/agronaut_agent/tests/test_rag_citations.py
@@ -52,9 +52,15 @@ def test_every_passage_carries_its_source(fake_index):
     assert "[source: knowledge/water_quality.md]" in out   # local file → repo-relative label
     assert "[source: https://doi.org/10.3390/w9030182]" in out
     assert "Nitrite above 1 mg/L" in out
-    # every passage block is labeled — no orphan passages without a source
-    blocks = [b for b in out.split("\n\n") if b.strip()]
-    assert all("[source:" in b for b in blocks)
+    # Every passage is preceded by ITS OWN label — asserted directly rather than by splitting
+    # the output on blank lines. Real knowledge passages are markdown and contain blank lines of
+    # their own, so a split-based check over-fragments and only passes because these fixtures
+    # happen not to; it would silently stop testing anything on production text.
+    from agronaut_agent import rag as _rag
+    for h in _rag.retrieve("nitrite stress", k=3):
+        assert f"[source: {h['source']}]\n{h['text']}" in out
+    assert out.startswith("[source:")
+    assert out.count("[source:") == len(_rag.retrieve("nitrite stress", k=3))
 
 
 def test_web_label_preferred_over_raw_url(fake_index):

--- a/agronaut_agent/tests/test_relevance_floor.py
+++ b/agronaut_agent/tests/test_relevance_floor.py
@@ -1,0 +1,87 @@
+"""The relevance floor: what the retriever is allowed to hand back as grounded context.
+
+Without a floor the retriever always returns its top k, so "what is the capital of Canada" came
+back with three confident, source-labelled passages from aquaponics papers — a grounded-LOOKING
+answer to a question the corpus cannot answer. That is the most dangerous failure mode a cited
+RAG system has, because the citation makes it more convincing, not less.
+
+Hermetic: a fake index supplies the distances, so no embedding model or network is involved.
+"""
+
+import pytest
+
+from agronaut_agent import rag
+
+
+# --- what gets out: the relevance floor --------------------------------------
+
+class _Doc:
+    def __init__(self, text, **md):
+        self.page_content = text
+        self.metadata = md
+
+
+def _long(text):
+    # retrieve() drops passages under 200 chars as boilerplate; keep fixtures realistic.
+    return text + " " + ("aquaponics husbandry detail. " * 12)
+
+
+class _ScoredIndex:
+    """Fake index returning (doc, distance) pairs — FAISS L2, so LOWER is closer."""
+    def __init__(self, scored):
+        self._scored = scored
+
+    def similarity_search_with_score(self, query, k=3):
+        return self._scored[:k]
+
+
+@pytest.fixture
+def index_with(monkeypatch):
+    def _install(scored):
+        monkeypatch.setattr(rag, "_INDEX", _ScoredIndex(scored))
+        monkeypatch.setattr(rag, "_TRIED", True)
+    return _install
+
+
+def test_distant_passages_are_dropped(index_with, monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([
+        (_Doc(_long("Nitrite stresses tilapia gills."), source_path="/r/knowledge/water.md"), 1.20),
+        (_Doc(_long("Unrelated systematic review prose."), source="https://doi.org/x"), 1.90),
+    ])
+    hits = rag.retrieve("nitrite", k=3)
+    assert [h["source"] for h in hits] == ["knowledge/water.md"]
+
+
+def test_all_distant_yields_the_honest_no_match_message(index_with, monkeypatch):
+    """An off-topic question must produce 'no matching passages', NOT three confident
+    source-labelled passages that cannot answer it."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc(_long("Aquaponics survey prose."), source="https://doi.org/y"), 1.80)])
+    assert rag.search("what is the capital of Canada") == rag._NO_MATCH
+
+
+def test_floor_can_be_disabled_for_measurement(index_with, monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    index_with([(_Doc(_long("Far away passage."), source="https://doi.org/y"), 9.9)])
+    assert rag.retrieve("x", k=3) == []
+    assert len(rag.retrieve("x", k=3, max_dist=float("inf"))) == 1
+
+
+def test_env_override_and_off_switch(monkeypatch):
+    monkeypatch.setenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", "0.5")
+    assert rag.max_distance() == 0.5
+    monkeypatch.setenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", "off")
+    assert rag.max_distance() == float("inf")
+    monkeypatch.setenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", "nonsense")
+    assert rag.max_distance() == rag._DEFAULT_MAX_DISTANCE   # bad config must not break a turn
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE")
+    assert rag.max_distance() == rag._DEFAULT_MAX_DISTANCE
+
+
+def test_floor_default_sits_between_the_measured_bands():
+    """The default is only meaningful if it lies inside the gap measured on the golden set:
+    worst on-topic 1.554, closest off-topic 1.717."""
+    assert 1.554 < rag._DEFAULT_MAX_DISTANCE < 1.717
+
+

--- a/agronaut_agent/tests/test_reranking.py
+++ b/agronaut_agent/tests/test_reranking.py
@@ -1,0 +1,96 @@
+"""Cross-encoder reranking of the retrieved shortlist.
+
+A bi-encoder embeds query and passage separately, so it compares two summaries of meaning. A
+cross-encoder reads the pair together and scores their actual interaction — far better, far
+slower, and therefore usable only on a shortlist. The fused pool is exactly that shortlist.
+
+These tests inject a fake model: the real one is a ~90 MB download and its judgements are not
+this module's contract. What IS the contract is that reranking reorders, that it runs before the
+diversity cap, and that its absence costs ranking quality and nothing else.
+"""
+
+import pytest
+
+from agronaut_agent import rag
+
+
+class _FakeCE:
+    """Scores by how many query words appear in the passage."""
+    def predict(self, pairs):
+        return [sum(w in p.lower() for w in q.lower().split()) for q, p in pairs]
+
+
+class _BoomCE:
+    def predict(self, pairs):
+        raise RuntimeError("model exploded mid-batch")
+
+
+def _by_key(items):
+    return {k: {"source": s, "text": txt, "score": 0.5} for k, s, txt in items}
+
+
+KEYS = [("a", "knowledge/x.md", "nothing relevant here at all"),
+        ("b", "knowledge/y.md", "nitrite spike in a new aquaponic system"),
+        ("c", "knowledge/z.md", "spike")]
+
+
+def test_reranking_reorders_by_pair_relevance(monkeypatch):
+    monkeypatch.setattr(rag, "_RERANKER", _FakeCE())
+    monkeypatch.setattr(rag, "_RERANK_TRIED", True)
+    bk = _by_key(KEYS)
+    out = rag._rerank("nitrite spike", ["a", "b", "c"], bk)
+    assert out[0] == "b"
+
+
+def test_missing_model_keeps_the_fused_order(monkeypatch):
+    """A reranker that will not load must cost ranking quality and nothing else."""
+    monkeypatch.setattr(rag, "_RERANKER", None)
+    monkeypatch.setattr(rag, "_RERANK_TRIED", True)
+    assert rag._rerank("q", ["a", "b", "c"], _by_key(KEYS)) == ["a", "b", "c"]
+
+
+def test_scoring_failure_keeps_the_fused_order(monkeypatch):
+    """A model that loads but throws mid-batch must not lose the results already retrieved."""
+    monkeypatch.setattr(rag, "_RERANKER", _BoomCE())
+    monkeypatch.setattr(rag, "_RERANK_TRIED", True)
+    assert rag._rerank("q", ["a", "b", "c"], _by_key(KEYS)) == ["a", "b", "c"]
+
+
+def test_single_item_is_not_reranked(monkeypatch):
+    """Nothing to reorder — must not pay for a model call."""
+    called = {"n": 0}
+
+    class _Counting:
+        def predict(self, pairs):
+            called["n"] += 1
+            return [1.0] * len(pairs)
+
+    monkeypatch.setattr(rag, "_RERANKER", _Counting())
+    monkeypatch.setattr(rag, "_RERANK_TRIED", True)
+    assert rag._rerank("q", ["a"], _by_key(KEYS)) == ["a"]
+    assert called["n"] == 0
+
+
+def test_reranking_ships_disabled(monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RERANK", raising=False)
+    assert not rag.rerank_enabled()
+    monkeypatch.setenv("AGRONAUT_RERANK", "on")
+    assert rag.rerank_enabled()
+
+
+def test_passage_is_truncated_before_scoring(monkeypatch):
+    """Cross-encoders have a short input window; an unbounded passage silently truncates inside
+    the model or errors. Bound it here where the limit is visible."""
+    seen = {}
+
+    class _Capture:
+        def predict(self, pairs):
+            seen["max"] = max(len(p) for _q, p in pairs)
+            return [1.0] * len(pairs)
+
+    monkeypatch.setattr(rag, "_RERANKER", _Capture())
+    monkeypatch.setattr(rag, "_RERANK_TRIED", True)
+    bk = {"a": {"source": "s", "text": "x" * 9000, "score": 0.1},
+          "b": {"source": "t", "text": "y" * 9000, "score": 0.2}}
+    rag._rerank("q", ["a", "b"], bk)
+    assert seen["max"] <= 2000

--- a/agronaut_agent/tests/test_retrieval_eval.py
+++ b/agronaut_agent/tests/test_retrieval_eval.py
@@ -117,15 +117,43 @@ def test_run_accepts_an_injected_retriever():
     assert all(n["top_score"] is None for n in report["negative_controls"])
 
 
-def test_golden_set_references_only_real_files():
-    """A golden set that points at a deleted knowledge file silently caps recall below 1.0
-    and looks like a retrieval regression. Fail loudly instead."""
+def test_golden_set_references_only_real_sources():
+    """Ground truth must name sources that actually exist in the corpus.
+
+    A label pointing at a deleted knowledge file — or a web source whose LABEL was edited in
+    urls.txt — silently caps recall below 1.0 and reads as a retrieval regression rather than a
+    stale annotation. Both kinds are checked: local entries look like paths and must exist on
+    disk; anything else must match a declared web source's citation label exactly, because that
+    label is what `_source_label` returns and therefore what the metrics compare against.
+    """
+    import sys
     root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(root))
+    from srcs.chatbot import parse_urls_file
+
+    web_labels = {e["label"] for e in parse_urls_file(str(root / "urls.txt")) if e["label"]}
     golden = json.loads((root / "docs/dpg/retrieval_eval/golden_set.json").read_text())
     for q in golden["queries"]:
         assert q["relevant"], f"{q['id']} has no relevant sources"
         for src in q["relevant"]:
-            assert (root / src).exists(), f"{q['id']} references missing {src}"
+            if src.startswith("knowledge/"):
+                assert (root / src).exists(), f"{q['id']} references missing file {src}"
+            else:
+                assert src in web_labels, (
+                    f"{q['id']} references {src!r}, which is not a declared source label in "
+                    "urls.txt — did the LABEL change?")
+
+
+def test_relabelled_queries_carry_their_evidence():
+    """Ground truth was re-annotated after FAO 589 entered the corpus. Every addition must record
+    WHY, quoting the passage that justified it — otherwise relabelling is indistinguishable from
+    tuning the ruler to fit the result."""
+    root = Path(__file__).resolve().parents[2]
+    golden = json.loads((root / "docs/dpg/retrieval_eval/golden_set.json").read_text())
+    annotated = [q for q in golden["queries"] if "annotation_note" in q]
+    assert annotated, "expected re-annotated queries to be marked"
+    for q in annotated:
+        assert len(q["annotation_note"]) > 40, f"{q['id']} annotation is not substantive"
 
 
 def test_golden_set_ids_are_unique():

--- a/agronaut_agent/tests/test_retrieval_eval.py
+++ b/agronaut_agent/tests/test_retrieval_eval.py
@@ -1,0 +1,135 @@
+"""The retrieval metrics must be arithmetically right before any tuning decision rests on them.
+
+These tests pin the METRIC MATH, not the model: every case passes plain lists of source labels,
+so there is no index, no embedding model and no network. A retriever tuned against a miscomputed
+recall number is worse than an untuned one, because the number looks like evidence.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.retrieval_eval import (
+    aggregate, average_precision, dedupe, precision_at_k, recall_at_k,
+    reciprocal_rank, run, score_query,
+)
+
+A, B, C, D = "knowledge/a.md", "knowledge/b.md", "knowledge/c.md", "knowledge/d.md"
+
+
+def test_dedupe_keeps_first_occurrence_order():
+    # Three chunks from the same file are ONE retrieved document, ranked where it first appeared.
+    assert dedupe([A, A, B, A, C]) == [A, B, C]
+
+
+def test_dedupe_empty():
+    assert dedupe([]) == []
+
+
+def test_precision_is_over_returned_documents_not_k():
+    # All three returned docs are relevant -> perfect precision, regardless of k.
+    assert precision_at_k([A, B, C], {A, B, C}) == 1.0
+    assert precision_at_k([A, B, C], {A}) == pytest.approx(1 / 3)
+    assert precision_at_k([], {A}) == 0.0
+
+
+def test_recall_is_over_the_relevant_set():
+    assert recall_at_k([A], {A, B}) == 0.5
+    assert recall_at_k([A, B], {A, B}) == 1.0
+    assert recall_at_k([C], {A, B}) == 0.0
+    assert recall_at_k([A], set()) == 0.0        # no ground truth -> no credit, no crash
+
+
+def test_reciprocal_rank_tracks_position_of_first_hit():
+    assert reciprocal_rank([A, B, C], {A}) == 1.0
+    assert reciprocal_rank([B, A, C], {A}) == 0.5
+    assert reciprocal_rank([B, C, A], {A}) == pytest.approx(1 / 3)
+    assert reciprocal_rank([B, C, D], {A}) == 0.0
+
+
+def test_average_precision_rewards_ranking_relevant_docs_higher():
+    """Same two relevant docs retrieved, different order -> the better ranking must score higher.
+    This is the property that distinguishes MAP from plain recall."""
+    good = average_precision([A, B, C], {A, B}, k=3)   # relevant at ranks 1,2
+    bad = average_precision([C, A, B], {A, B}, k=3)    # relevant at ranks 2,3
+    assert good > bad
+    assert good == pytest.approx((1 / 1 + 2 / 2) / 2)  # 1.0
+    assert bad == pytest.approx((1 / 2 + 2 / 3) / 2)
+
+
+def test_average_precision_denominator_caps_at_k():
+    # 4 relevant docs but only k=2 slots: retrieving 2 of them at the top is a perfect score,
+    # otherwise the metric would punish a retriever for a limit it was given.
+    assert average_precision([A, B], {A, B, C, D}, k=2) == pytest.approx(1.0)
+
+
+def test_average_precision_no_relevant_set():
+    assert average_precision([A], set(), k=3) == 0.0
+
+
+def test_score_query_truncates_to_k_after_dedupe():
+    """Dedupe happens BEFORE the top-k cut. Three chunks of A then B must not let A's
+    duplicates push B out of a k=2 window."""
+    r = score_query([A, A, A, B], [B], k=2)
+    assert r["retrieved"] == [A, B]
+    assert r["hit"] is True
+    assert r["rr"] == 0.5
+
+
+def test_score_query_complete_miss():
+    r = score_query([C, D], [A, B], k=3)
+    assert r["hit"] is False
+    assert r["recall"] == 0.0 and r["rr"] == 0.0 and r["ap"] == 0.0
+
+
+def test_aggregate_averages_across_queries():
+    rows = [
+        {"hit": True, "precision": 1.0, "recall": 1.0, "rr": 1.0, "ap": 1.0},
+        {"hit": False, "precision": 0.0, "recall": 0.0, "rr": 0.0, "ap": 0.0},
+    ]
+    agg = aggregate(rows, k=3)
+    assert agg["hit_rate"] == 0.5
+    assert agg["MRR"] == 0.5
+    assert agg["recall@k"] == 0.5
+    assert agg["queries"] == 2 and agg["k"] == 3
+
+
+def test_aggregate_empty_does_not_divide_by_zero():
+    assert aggregate([], k=3)["hit_rate"] == 0.0
+
+
+def test_run_accepts_an_injected_retriever():
+    """The whole harness runs without an index: a perfect fake retriever must score 1.0,
+    which proves the plumbing (golden set -> retrieve -> metrics) is wired correctly."""
+    golden = json.loads(
+        (Path(__file__).resolve().parents[2] / "docs/dpg/retrieval_eval/golden_set.json").read_text())
+    by_query = {q["query"]: q["relevant"] for q in golden["queries"]}
+
+    def perfect(query, k):
+        return [{"source": s, "score": 0.1, "text": "x"} for s in by_query.get(query, [])][:k]
+
+    report = run(retrieve=perfect)
+    assert report["summary"]["hit_rate"] == 1.0
+    assert report["summary"]["precision@k"] == 1.0
+    assert report["summary"]["recall@k"] == pytest.approx(1.0)
+    # negative controls have no relevant set, so the fake returns nothing for them
+    assert all(n["top_score"] is None for n in report["negative_controls"])
+
+
+def test_golden_set_references_only_real_files():
+    """A golden set that points at a deleted knowledge file silently caps recall below 1.0
+    and looks like a retrieval regression. Fail loudly instead."""
+    root = Path(__file__).resolve().parents[2]
+    golden = json.loads((root / "docs/dpg/retrieval_eval/golden_set.json").read_text())
+    for q in golden["queries"]:
+        assert q["relevant"], f"{q['id']} has no relevant sources"
+        for src in q["relevant"]:
+            assert (root / src).exists(), f"{q['id']} references missing {src}"
+
+
+def test_golden_set_ids_are_unique():
+    root = Path(__file__).resolve().parents[2]
+    golden = json.loads((root / "docs/dpg/retrieval_eval/golden_set.json").read_text())
+    ids = [q["id"] for q in golden["queries"]] + [q["id"] for q in golden["negative_controls"]]
+    assert len(ids) == len(set(ids))

--- a/agronaut_agent/tests/test_retrieval_telemetry.py
+++ b/agronaut_agent/tests/test_retrieval_telemetry.py
@@ -1,0 +1,111 @@
+"""Retrieval telemetry — useful in production, and incapable of leaking what was asked.
+
+The golden set says how the retriever behaves on 33 curated queries. It cannot say how it behaves
+on real traffic: how often the relevance floor fires, how far the closest match typically sits,
+whether latency has drifted. Those are the earliest signals that the corpus or the embedding model
+has moved out from under a threshold calibrated in L2 distance units.
+
+The privacy constraint is absolute (docs/dpg/PRIVACY.md): counts and shape, never content. These
+tests assert that the allowlist actually enforces it rather than merely documenting it.
+"""
+
+import json
+
+import pytest
+
+from agronaut_agent import rag
+from agronaut_agent.analytics import Analytics
+
+
+@pytest.fixture
+def sink(tmp_path):
+    return Analytics(path=tmp_path / "a.jsonl")
+
+
+def _rows(a):
+    return [json.loads(l) for l in a.path.read_text().splitlines()]
+
+
+def test_query_text_cannot_be_recorded(sink):
+    """The single most important property. Even a caller explicitly passing the query must not
+    be able to persist it — unknown keys are dropped, not stored."""
+    sink.record("retrieval", user_id="u1", query="my tilapia are dying in tank 3",
+                text="retrieved passage body", outcome="hit", n_results=3)
+    row = _rows(sink)[0]
+    assert "query" not in row and "text" not in row
+    assert "tilapia" not in json.dumps(row)
+    assert row["outcome"] == "hit" and row["n_results"] == 3
+
+
+def test_shape_fields_are_recorded(sink):
+    sink.record("retrieval", user_id="u1", outcome="no_match", n_results=0, k=3,
+                latency_ms=42, top_score=1.71, hybrid=False)
+    row = _rows(sink)[0]
+    assert row["outcome"] == "no_match"
+    assert row["latency_ms"] == 42 and row["top_score"] == 1.71
+    assert row["hybrid"] is False
+
+
+def test_user_is_recorded_only_as_a_hash(sink):
+    sink.record("retrieval", user_id="telegram:123456789", outcome="hit")
+    row = _rows(sink)[0]
+    assert "123456789" not in json.dumps(row)
+    assert len(row["uid"]) == 12
+
+
+# --- stats produced by the retriever itself ---------------------------------
+
+class _Doc:
+    def __init__(self, text, **md):
+        self.page_content = text + " " + ("aquaponics husbandry detail. " * 12)
+        self.metadata = md
+
+
+class _Index:
+    def __init__(self, scored):
+        self._scored = scored
+        self.docstore = type("_S", (), {"_dict": {}})()
+
+    def similarity_search_with_score(self, query, k=3):
+        return self._scored[:k]
+
+
+def test_stats_report_a_hit(monkeypatch):
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    monkeypatch.setattr(rag, "_INDEX", _Index([(_Doc("Nitrite.", source_path="/r/knowledge/n.md"), 0.4)]))
+    monkeypatch.setattr(rag, "_TRIED", True)
+    text, stats = rag.search_with_stats("nitrite", k=3)
+    assert "[source: knowledge/n.md]" in text
+    assert stats["outcome"] == "hit" and stats["n_results"] == 1
+    assert stats["top_score"] == 0.4
+    assert isinstance(stats["latency_ms"], int)
+
+
+def test_stats_report_the_floor_firing(monkeypatch):
+    """An off-topic question must be observable as such in production, not just in the eval."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    monkeypatch.setattr(rag, "_INDEX", _Index([(_Doc("Unrelated.", source="https://x"), 1.95)]))
+    monkeypatch.setattr(rag, "_TRIED", True)
+    text, stats = rag.search_with_stats("capital of Canada", k=3)
+    assert text == rag._NO_MATCH
+    assert stats["outcome"] == "no_match" and stats["n_results"] == 0
+    assert stats["top_score"] is None
+
+
+def test_stats_report_an_unavailable_index(monkeypatch):
+    monkeypatch.setattr(rag, "_INDEX", None)
+    monkeypatch.setattr(rag, "_TRIED", True)
+    text, stats = rag.search_with_stats("anything")
+    assert "KNOWLEDGE_UNAVAILABLE" in text
+    assert stats["outcome"] == "unavailable"
+
+
+def test_search_contract_is_unchanged(monkeypatch):
+    """search() is the seam the tool and the citation tests depend on; adding telemetry must not
+    alter a single character of what it returns."""
+    monkeypatch.delenv("AGRONAUT_RELEVANCE_MAX_DISTANCE", raising=False)
+    monkeypatch.setattr(rag, "_INDEX", _Index([(_Doc("Aeration.", source_type="web",
+                                                     url_label="FAO 589"), 0.3)]))
+    monkeypatch.setattr(rag, "_TRIED", True)
+    assert rag.search("aeration") == rag.search_with_stats("aeration")[0]
+    assert "[source: FAO 589]" in rag.search("aeration")

--- a/agronaut_agent/tests/test_source_diversity.py
+++ b/agronaut_agent/tests/test_source_diversity.py
@@ -1,0 +1,93 @@
+"""The per-source cap: one source may not fill the whole result window.
+
+When FAO 589 (992 chunks) joined an 82-chunk curated corpus, it took all three slots on 10 of 33
+golden-set queries — so a targeted operator answer that existed in knowledge/ never reached the
+model at all. Ranking cannot fix that on its own: the book genuinely is similar, and it has twelve
+times as many chances to be. Capping per-source occupancy spends one slot on breadth.
+
+Measured effect (1354 chunks, hybrid on): hit_rate 0.848 -> 0.939, recall 0.788 -> 0.894,
+precision 0.495 -> 0.540. Every metric improved — the largest single gain in this work.
+"""
+
+import pytest
+
+from agronaut_agent import rag
+
+
+def _keys(n, source):
+    return [(source, f"chunk-{i}") for i in range(n)]
+
+
+def _by_key(keys):
+    return {k: {"source": k[0], "text": k[1], "score": 0.1} for k in keys}
+
+
+def test_one_source_cannot_fill_the_whole_window():
+    """The exact observed failure: a single book occupying every slot."""
+    ranked = _keys(5, "FAO 589")
+    picked = rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=2)
+    assert len(picked) == 3
+    # Only FAO exists here, so backfill is correct — returning 2 would be worse than 3.
+    assert all(k[0] == "FAO 589" for k in picked)
+
+
+def test_cap_lets_a_second_source_through():
+    ranked = _keys(4, "FAO 589") + _keys(1, "knowledge/algae_control.md")
+    picked = rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=2)
+    sources = [k[0] for k in picked]
+    assert sources.count("FAO 589") == 2
+    assert "knowledge/algae_control.md" in sources
+
+
+def test_relevance_order_is_preserved_within_the_cap():
+    """Diversity decides who is displaced, not who ranks first — fusion already decided that."""
+    ranked = _keys(3, "A") + _keys(3, "B")
+    picked = rag._diversify(ranked, _by_key(ranked), k=4, max_per_source=2)
+    assert picked[:2] == _keys(3, "A")[:2]
+
+
+def test_backfill_rather_than_a_short_result():
+    """If too few distinct sources matched, fill the window from the original ranking. A
+    capped-but-empty result is worse than a repetitive one — the model gets less to work with."""
+    ranked = _keys(5, "only-source")
+    picked = rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=1)
+    assert len(picked) == 3
+
+
+def test_no_duplicates_after_backfill():
+    ranked = _keys(4, "A")
+    picked = rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=1)
+    assert len(set(picked)) == len(picked)
+
+
+def test_cap_of_zero_disables_diversification():
+    ranked = _keys(5, "A")
+    assert rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=0) == ranked[:3]
+
+
+def test_fewer_candidates_than_k_is_safe():
+    ranked = _keys(2, "A")
+    assert len(rag._diversify(ranked, _by_key(ranked), k=5, max_per_source=1)) == 2
+
+
+def test_empty_ranking_is_safe():
+    assert rag._diversify([], {}, k=3, max_per_source=2) == []
+
+
+def test_default_cap_and_env_override(monkeypatch):
+    monkeypatch.delenv("AGRONAUT_MAX_PER_SOURCE", raising=False)
+    assert rag.max_source_cap() == 2
+    monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "1")
+    assert rag.max_source_cap() == 1
+    monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "0")
+    assert rag.max_source_cap() == 0
+    monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "nonsense")
+    assert rag.max_source_cap() == 2       # bad config must not break a turn
+
+
+def test_citation_labels_are_what_the_cap_counts():
+    """The cap groups by the CITATION label, which is what an operator sees. Grouping by chunk id
+    or URL would let the same work occupy every slot under different identifiers."""
+    ranked = [("FAO 589", "a"), ("FAO 589", "b"), ("knowledge/x.md", "c")]
+    picked = rag._diversify(ranked, _by_key(ranked), k=3, max_per_source=1)
+    assert [k[0] for k in picked][:2] == ["FAO 589", "knowledge/x.md"]

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -361,7 +361,14 @@ def search_knowledge_base(query: str) -> str:
     """Retrieve passages from Agronaut's curated aquaponics knowledge (local docs + cited
     sources) for qualitative troubleshooting and husbandry guidance (symptoms, water
     quality, pests). Use for explanation — NOT for sizing numbers (use the sizing tool)."""
-    return rag.search(query)
+    text, stats = rag.search_with_stats(query)
+    try:
+        from .analytics import Analytics
+        cur = runtime.get_current()
+        Analytics().record("retrieval", user_id=cur[1] if cur else None, **stats)
+    except Exception:  # noqa: BLE001 — telemetry must never break a live turn
+        pass
+    return text
 
 
 @tool

--- a/docs/dpg/CORPUS.md
+++ b/docs/dpg/CORPUS.md
@@ -84,6 +84,38 @@ when a declared source has gone dead or drifted:
 python -m scripts.corpus_report
 ```
 
+## Sources evaluated and not added
+
+Corpus breadth is the real weakness — 21 hand-written files still answer most queries. A survey
+for openly licensed prose to widen it produced this, and it is recorded so the search is not
+repeated from scratch:
+
+| candidate | result |
+|---|---|
+| MDPI *Water* 15/24/4310 | **REJECTED** — HTTP 403; the gate flagged both the status and topic drift (`title='Access Denied'`) |
+| CSIR/CGIAR tilapia **pond** farming manual | **REVIEW** — 84 chunks, on topic, but carries only "© First Edition 2020"; no licence in the PDF and none exposed by the CGSpace bitstream API |
+| CSIR/CGIAR tilapia **cage** farming manual | **REVIEW** — same, 64 chunks |
+| PMC12527044, AI-driven fish welfare monitoring | **ACCEPT by the gate, not added by judgement** — CC BY 4.0 and 123 chunks, but it is another IoT/ML paper, and IoT/ML prose is already what off-topic queries land on. Adding it would deepen a known weakness, not fix one |
+
+Two things this establishes:
+
+1. **An ACCEPT verdict is a licence-and-reachability check, not a usefulness check.** The gate
+   cannot tell whether a source fills a gap or deepens an existing imbalance. That judgement stays
+   human, and PMC12527044 is the worked example: it passes every automated test and was still the
+   wrong thing to add.
+
+2. **The bottleneck is not source discovery.** Open-access aquaponics literature is plentiful; open
+   *operator guidance* is not. What the corpus needs is practical husbandry prose — the kind in
+   `knowledge/*.md` — and that is mostly either paywalled, unlicensed, or has never been written
+   down. The hand-written files exist precisely because that gap is real, and measurement confirms
+   they carry the load: **23% of the corpus answering 94% of retrieved passages** before FAO 589
+   was added.
+
+The practical route to breadth is therefore writing it, not scraping it — which is what
+[issue #77](https://github.com/Rekin226/Agronaut/issues/77) asks for. Anyone with a licence
+confirmation for the two CSIR manuals should reopen that question: they are on topic, substantial,
+and fill exactly the husbandry gap.
+
 ## Known limitations
 
 - **Web drift is bounded, not detected.** A publisher can edit a source without `urls.txt`

--- a/docs/dpg/CORPUS.md
+++ b/docs/dpg/CORPUS.md
@@ -1,0 +1,100 @@
+# Knowledge corpus — provenance, licensing, and how a source gets in
+
+Agronaut's advice layer retrieves from a curated corpus. This records what is in it, under what
+terms, and the gate every source has to pass. It exists because a cited answer is only as
+trustworthy as the thing it cites, and because a corpus rots quietly if nobody measures it.
+
+## The licence asymmetry — read this first
+
+**Agronaut's code is MIT. Parts of its knowledge corpus are not.**
+
+| Layer | Licence | Implication |
+|---|---|---|
+| Code (`aqua_model/`, `agronaut_agent/`, `agent/`, `srcs/`) | MIT | Commercial use permitted |
+| `knowledge/*.md` | First-party, MIT with the repo | Commercial use permitted |
+| Springer / PLOS sources | CC BY 4.0 | Commercial use permitted |
+| **FAO 589** | **FAO permissive — non-commercial only** | **Commercial redistribution of that text is NOT permitted** |
+
+FAO 589 was published in 2014, before FAO adopted Creative Commons (their CC policy applies to
+material from roughly November 2019 onward). Its grant reads:
+
+> "FAO encourages the use, reproduction and dissemination of material in this information product
+> ... for private study, research and teaching, or for use in non-commercial products or services,
+> provided that appropriate acknowledgement of FAO as the source and copyright holder is given."
+
+That is functionally equivalent to **CC BY-NC**. The DPG Alliance accepts CC BY-NC and CC BY-NC-SA
+(it prefers CC BY / CC BY-SA / CC0 but does not require them), so this does not block DPG status.
+It is **not** conformant with the stricter Open Definition, which rejects non-commercial clauses.
+
+**What this means in practice:** anyone running Agronaut commercially should remove the FAO entry
+from `urls.txt` and rebuild the index. Retrieval degrades gracefully — the corpus simply gets
+smaller. Nothing in the code depends on that source existing.
+
+## What is in the corpus
+
+| Source | Licence | Role |
+|---|---|---|
+| 21 × `knowledge/*.md` | First-party | **The answer layer.** Hand-written operator guidance |
+| FAO 589 (Somerville et al., 2014) | FAO permissive (NC) | **The depth layer.** 275-page canonical reference |
+| Applications, technologies and evaluation methods in smart aquaponics (Artif Intell Rev, 2024) | CC BY 4.0 | Systematic review; IoT/ML framing |
+| Love et al. (2014), An International Survey of Aquaponics Practitioners (PLOS ONE) | CC BY 4.0 | Practitioner survey data |
+
+### The answer layer is not the biggest layer, and that is fine
+
+Measured over the 33-query golden set **before** FAO 589 was added:
+
+| | share of corpus | share of returned passages | queries answered |
+|---|---|---|---|
+| `knowledge/*.md` | 23% | **94%** | **32/33** |
+| scraped papers | 77% | 6% | 1/33 |
+
+The hand-written files were 23% of the index and did 94% of the work. Volume is not the same as
+usefulness, and a corpus should not be judged by chunk count. The scraped papers earn their place
+as depth and as citable authority, not as the thing that answers a troubleshooting question.
+
+## How a source gets in
+
+Every source must clear an automated gate before being added to `urls.txt`:
+
+```bash
+python -m scripts.corpus_report --candidate "<url>" --label "<what it should be about>"
+```
+
+It checks four things, because a source can fail in four different ways:
+
+1. **Reachable** — a non-2xx response is never indexed. Three MDPI DOIs returned HTTP 403 and their
+   `"Access Denied — You don't have permission"` body was being indexed as a citable passage; at
+   231 characters it clears the boilerplate floor and matches none of its keywords, so only the
+   HTTP status distinguishes it from content.
+2. **Substantial** — a source contributing zero chunks is a network fetch pretending to be
+   citation depth. Nine of the original fourteen DOIs were exactly this.
+3. **On topic** — the dangerous failure. A guessed UF/IFAS publication ID resolved to *"Sharks for
+   the Aquarium"*: 28,635 characters that pass every automated check except being about the right
+   subject.
+4. **Openly licensed** — see above. Empirically this correlates with retrievability: every source
+   measured that returned usable full text was openly licensed; every paywalled one returned
+   nothing.
+
+Verdicts are `ACCEPT`, `REVIEW` (a human licensing or quality call), or `REJECT`.
+
+Audit the whole corpus at any time — this is also a CI-suitable regression gate, exiting non-zero
+when a declared source has gone dead or drifted:
+
+```bash
+python -m scripts.corpus_report
+```
+
+## Known limitations
+
+- **Web drift is bounded, not detected.** A publisher can edit a source without `urls.txt`
+  changing. The index cache fingerprint cannot see that — detecting it would require the fetch the
+  cache exists to avoid — so a 7-day TTL bounds staleness instead.
+- **Coverage is narrow.** 21 hand-written files maintained by one operator. Breadth, not source
+  quality, is the corpus's real weakness.
+- **Extension services are frequently unreachable.** Oklahoma State's aquaponics fact sheets sit
+  behind Cloudflare (HTTP 403, "Just a moment..."), and FAO's own repository landing pages are
+  JavaScript-driven and yield ~322 characters. Direct PDF endpoints work; HTML landing pages
+  usually do not.
+- **Numeric datasets are a different pipeline.** Kaggle/Mendeley sensor data belongs in `data/`
+  via `scripts/fetch_aquaponics_data.py`, feeding calibration — NOT the RAG index. Embedding CSV
+  rows would pollute retrieval while answering no operator question.

--- a/docs/dpg/retrieval_eval/baseline_dense.json
+++ b/docs/dpg/retrieval_eval/baseline_dense.json
@@ -1,0 +1,611 @@
+{
+  "summary": {
+    "queries": 33,
+    "k": 3,
+    "hit_rate": 0.9696969696969697,
+    "precision@k": 0.6262626262626263,
+    "recall@k": 0.9191919191919191,
+    "MRR": 0.9090909090909091,
+    "MAP@k": 0.8686868686868687,
+    "latency_ms_mean": 522.6692134535617
+  },
+  "per_query": [
+    {
+      "retrieved": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-01",
+      "query": "my tilapia are all gasping at the surface early in the morning",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 0.8959375023841858
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-02",
+      "query": "fish crowding near the water inlet and breathing fast",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.8161635398864746
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/common_system_failures.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "stress-01",
+      "query": "fish are moving slowly and barely touching their food",
+      "relevant": [
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.6871860027313232
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-01",
+      "query": "ammonia reading jumped to 4 ppm what do I do right now",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 0.8181362152099609
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-02",
+      "query": "brand new setup three weeks in and nitrite is climbing",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 1.0304288864135742
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-03",
+      "query": "how long before the bacteria establish themselves",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 1.2353334426879883
+    },
+    {
+      "retrieved": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "ph-01",
+      "query": "the pH keeps sliding down every week no matter what I add",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 0.8413991928100586
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/ph_and_alkalinity.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "ph-02",
+      "query": "how do I bring up the buffering capacity safely",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 1.3183010816574097
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_deficiency_cheatsheet.md",
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-01",
+      "query": "lettuce leaves going yellow between the veins but the veins stay green",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "top_score": 0.5887277722358704
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md",
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-02",
+      "query": "the oldest leaves are turning pale first while new growth looks fine",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "top_score": 0.8162521123886108
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/common_system_failures.md",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "algae-01",
+      "query": "my water has gone bright green and cloudy",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.0651259422302246
+    },
+    {
+      "retrieved": [
+        "knowledge/algae_control.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "algae-02",
+      "query": "stringy green growth clogging the pipes and screens",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.2165082693099976
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "fail-01",
+      "query": "we lost power for six hours overnight what should I check first",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 1.3383744955062866
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.3333333333333333,
+      "rr": 0.5,
+      "ap": 0.16666666666666666,
+      "id": "fail-02",
+      "query": "I think I have been giving them too much food and now the water is murky",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.123023271560669
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-01",
+      "query": "little white dots all over my fish like grains of salt",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 0.7301387786865234
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md",
+        "knowledge/plant_pests_and_ipm.md",
+        "https://doi.org/10.1007/S10462-024-11003-X"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-02",
+      "query": "can I use a copper based treatment with plants in the loop",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 1.0919899940490723
+    },
+    {
+      "retrieved": [
+        "knowledge/feed_and_feeding.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "feed-01",
+      "query": "how much should I be giving them each day",
+      "relevant": [
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.2183464765548706
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pump-01",
+      "query": "the pump is rated for plenty but barely trickles at the top of the tower",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.9262655377388
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pump-02",
+      "query": "how do I work out the flow I actually need",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.9937251806259155
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-01",
+      "query": "should I go with rafts or the thin channel setup",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 0.9254881143569946
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-02",
+      "query": "I have almost no floor space what layout works",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.4159350395202637
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "water-01",
+      "query": "our tap water smells strongly of chlorine can I top up with it",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 0.8954066038131714
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "water-02",
+      "query": "the well water here is extremely hard",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 1.1220040321350098
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "solids-01",
+      "query": "dark sludge piling up in the bottom of the tank",
+      "relevant": [
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "top_score": 0.9865351915359497
+    },
+    {
+      "retrieved": [
+        "knowledge/regulations_and_permits.md",
+        "https://doi.org/10.1371/journal.pone.0102662"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "reg-01",
+      "query": "do I need any kind of licence before I can sell the fish",
+      "relevant": [
+        "knowledge/regulations_and_permits.md"
+      ],
+      "top_score": 0.8532036542892456
+    },
+    {
+      "retrieved": [
+        "https://doi.org/10.1371/journal.pone.0102662",
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "safety-01",
+      "query": "is produce grown on fish waste actually safe to eat",
+      "relevant": [
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "top_score": 0.7736780643463135
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pest-01",
+      "query": "tiny green insects covering my basil what can I spray",
+      "relevant": [
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "top_score": 1.0603309869766235
+    },
+    {
+      "retrieved": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "econ-01",
+      "query": "what are the running costs going to look like",
+      "relevant": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "top_score": 1.0173242092132568
+    },
+    {
+      "retrieved": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "econ-02",
+      "query": "is this ever going to break even",
+      "relevant": [
+        "knowledge/economics_and_costs.md",
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.5123841762542725
+    },
+    {
+      "retrieved": [
+        "knowledge/feasibility_and_business_case.md",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "econ-03",
+      "query": "putting together a funding proposal what should it cover",
+      "relevant": [
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.1042566299438477
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-01",
+      "query": "water hits 34 degrees in the afternoon here",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.2017155885696411
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-02",
+      "query": "which species suits a cold winter",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.0294992923736572
+    },
+    {
+      "retrieved": [
+        "knowledge/water_quality_ranges.md",
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "https://doi.org/10.1007/S10462-024-11003-X"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "range-01",
+      "query": "what levels should I be aiming for overall",
+      "relevant": [
+        "knowledge/water_quality_ranges.md"
+      ],
+      "top_score": 1.5543122291564941
+    }
+  ],
+  "negative_controls": [
+    {
+      "id": "neg-01",
+      "query": "how do I fix a slipping bicycle chain",
+      "top_score": 1.7171915769577026,
+      "returned": [
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/common_system_failures.md",
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ]
+    },
+    {
+      "id": "neg-02",
+      "query": "what is the capital of Canada",
+      "top_score": 1.7648371458053589,
+      "returned": [
+        "https://doi.org/10.1371/journal.pone.0102662",
+        "https://doi.org/10.1007/S10462-024-11003-X",
+        "https://doi.org/10.1371/journal.pone.0102662"
+      ]
+    },
+    {
+      "id": "neg-03",
+      "query": "write me a python function to reverse a linked list",
+      "top_score": 1.7574958801269531,
+      "returned": [
+        "https://doi.org/10.1007/S10462-024-11003-X",
+        "https://doi.org/10.1007/S10462-024-11003-X",
+        "https://doi.org/10.1007/S10462-024-11003-X"
+      ]
+    }
+  ]
+}

--- a/docs/dpg/retrieval_eval/baseline_fao.json
+++ b/docs/dpg/retrieval_eval/baseline_fao.json
@@ -7,7 +7,7 @@
     "recall@k": 0.8939393939393939,
     "MRR": 0.7373737373737373,
     "MAP@k": 0.696969696969697,
-    "latency_ms_mean": 244.0918610522975,
+    "latency_ms_mean": 1364.5086501703852,
     "floor_silenced_on_topic": 0,
     "floor_rejected_off_topic": 8,
     "negative_controls": 10

--- a/docs/dpg/retrieval_eval/baseline_fao.json
+++ b/docs/dpg/retrieval_eval/baseline_fao.json
@@ -1,0 +1,741 @@
+{
+  "summary": {
+    "queries": 33,
+    "k": 3,
+    "hit_rate": 0.9393939393939394,
+    "precision@k": 0.5404040404040403,
+    "recall@k": 0.8939393939393939,
+    "MRR": 0.7373737373737373,
+    "MAP@k": 0.696969696969697,
+    "latency_ms_mean": 244.0918610522975,
+    "floor_silenced_on_topic": 0,
+    "floor_rejected_off_topic": 8,
+    "negative_controls": 10
+  },
+  "per_query": [
+    {
+      "retrieved": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-01",
+      "query": "my tilapia are all gasping at the surface early in the morning",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 0.8959376811981201,
+      "raw_top_score": 0.8959376811981201,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.5,
+      "rr": 0.5,
+      "ap": 0.25,
+      "id": "do-02",
+      "query": "fish crowding near the water inlet and breathing fast",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.7474802732467651,
+      "raw_top_score": 0.7474802732467651,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "stress-01",
+      "query": "fish are moving slowly and barely touching their food",
+      "relevant": [
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.6871860027313232,
+      "raw_top_score": 0.6871860027313232,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-01",
+      "query": "ammonia reading jumped to 4 ppm what do I do right now",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 0.8181362152099609,
+      "raw_top_score": 0.8181362152099609,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-02",
+      "query": "brand new setup three weeks in and nitrite is climbing",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 0.9735503196716309,
+      "raw_top_score": 0.9735503196716309,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-03",
+      "query": "how long before the bacteria establish themselves",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.0436968803405762,
+      "raw_top_score": 1.0436968803405762,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "ph-01",
+      "query": "the pH keeps sliding down every week no matter what I add",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 0.8036634922027588,
+      "raw_top_score": 0.8036634922027588,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.3333333333333333,
+      "ap": 0.3333333333333333,
+      "id": "ph-02",
+      "query": "how do I bring up the buffering capacity safely",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 1.3183008432388306,
+      "raw_top_score": 1.3183008432388306,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_deficiency_cheatsheet.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 0.8333333333333333,
+      "id": "plant-01",
+      "query": "lettuce leaves going yellow between the veins but the veins stay green",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "top_score": 0.5887277722358704,
+      "raw_top_score": 0.5887277722358704,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-02",
+      "query": "the oldest leaves are turning pale first while new growth looks fine",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "top_score": 0.8162521123886108,
+      "raw_top_score": 0.8162521123886108,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "algae-01",
+      "query": "my water has gone bright green and cloudy",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.0503394603729248,
+      "raw_top_score": 1.0503394603729248,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/algae_control.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "algae-02",
+      "query": "stringy green growth clogging the pipes and screens",
+      "relevant": [
+        "knowledge/algae_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.1393007040023804,
+      "raw_top_score": 1.1393007040023804,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "fail-01",
+      "query": "we lost power for six hours overnight what should I check first",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 1.3383744955062866,
+      "raw_top_score": 1.3383744955062866,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "fail-02",
+      "query": "I think I have been giving them too much food and now the water is murky",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.092172384262085,
+      "raw_top_score": 1.092172384262085,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-01",
+      "query": "little white dots all over my fish like grains of salt",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 0.7301387786865234,
+      "raw_top_score": 0.7301387786865234,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "disease-02",
+      "query": "can I use a copper based treatment with plants in the loop",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 1.005014419555664,
+      "raw_top_score": 1.005014419555664,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "feed-01",
+      "query": "how much should I be giving them each day",
+      "relevant": [
+        "knowledge/feed_and_feeding.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.1389633417129517,
+      "raw_top_score": 1.1389633417129517,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "pump-01",
+      "query": "the pump is rated for plenty but barely trickles at the top of the tower",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 1.0091389417648315,
+      "raw_top_score": 1.0091389417648315,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "pump-02",
+      "query": "how do I work out the flow I actually need",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.8910391926765442,
+      "raw_top_score": 0.8910391926765442,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/system_types_and_design.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "type-01",
+      "query": "should I go with rafts or the thin channel setup",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.1507134437561035,
+      "raw_top_score": 1.1507134437561035,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-02",
+      "query": "I have almost no floor space what layout works",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.4159350395202637,
+      "raw_top_score": 1.4159350395202637,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "water-01",
+      "query": "our tap water smells strongly of chlorine can I top up with it",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 0.8689041137695312,
+      "raw_top_score": 0.8689041137695312,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "water-02",
+      "query": "the well water here is extremely hard",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 1.0372191667556763,
+      "raw_top_score": 1.0372191667556763,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 0.8333333333333333,
+      "id": "solids-01",
+      "query": "dark sludge piling up in the bottom of the tank",
+      "relevant": [
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "top_score": 0.9865351915359497,
+      "raw_top_score": 0.9865351915359497,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/regulations_and_permits.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "reg-01",
+      "query": "do I need any kind of licence before I can sell the fish",
+      "relevant": [
+        "knowledge/regulations_and_permits.md"
+      ],
+      "top_score": 0.8532036542892456,
+      "raw_top_score": 0.8532036542892456,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "safety-01",
+      "query": "is produce grown on fish waste actually safe to eat",
+      "relevant": [
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "top_score": 0.6161458492279053,
+      "raw_top_score": 0.6161458492279053,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pest-01",
+      "query": "tiny green insects covering my basil what can I spray",
+      "relevant": [
+        "knowledge/plant_pests_and_ipm.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 0.6313092708587646,
+      "raw_top_score": 0.6313092708587646,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "econ-01",
+      "query": "what are the running costs going to look like",
+      "relevant": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "top_score": 0.8659825325012207,
+      "raw_top_score": 0.8659825325012207,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.5,
+      "rr": 0.5,
+      "ap": 0.25,
+      "id": "econ-02",
+      "query": "is this ever going to break even",
+      "relevant": [
+        "knowledge/economics_and_costs.md",
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.371431827545166,
+      "raw_top_score": 1.371431827545166,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/feasibility_and_business_case.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "econ-03",
+      "query": "putting together a funding proposal what should it cover",
+      "relevant": [
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.1042566299438477,
+      "raw_top_score": 1.1042566299438477,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-01",
+      "query": "water hits 34 degrees in the afternoon here",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.1499556303024292,
+      "raw_top_score": 1.1499556303024292,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-02",
+      "query": "which species suits a cold winter",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.0294992923736572,
+      "raw_top_score": 1.0294992923736572,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_quality_ranges.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "range-01",
+      "query": "what levels should I be aiming for overall",
+      "relevant": [
+        "knowledge/water_quality_ranges.md"
+      ],
+      "top_score": 1.5484751462936401,
+      "raw_top_score": 1.5484751462936401,
+      "floor_returned_nothing": false
+    }
+  ],
+  "negative_controls": [
+    {
+      "id": "neg-01",
+      "query": "how do I fix a slipping bicycle chain",
+      "top_score": 1.6716821193695068,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-02",
+      "query": "what is the capital of Canada",
+      "top_score": 1.704360008239746,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-03",
+      "query": "write me a python function to reverse a linked list",
+      "top_score": 1.7292786836624146,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-04",
+      "query": "what time does the pharmacy close today",
+      "top_score": 1.6874148845672607,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-05",
+      "query": "recommend a good science fiction novel",
+      "top_score": 1.7044744491577148,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-06",
+      "query": "how do I change a flat car tyre",
+      "top_score": 1.616103172302246,
+      "returned": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "rejected_by_floor": false
+    },
+    {
+      "id": "neg-07",
+      "query": "explain the offside rule in football",
+      "top_score": 1.6666005849838257,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-08",
+      "query": "best way to remove red wine from a carpet",
+      "top_score": 1.425750732421875,
+      "returned": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/algae_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "rejected_by_floor": false
+    },
+    {
+      "id": "neg-09",
+      "query": "convert 500 euros to yen",
+      "top_score": 1.6639702320098877,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-10",
+      "query": "who won the world cup in 1998",
+      "top_score": 1.7689282894134521,
+      "returned": [],
+      "rejected_by_floor": true
+    }
+  ]
+}

--- a/docs/dpg/retrieval_eval/baseline_floor.json
+++ b/docs/dpg/retrieval_eval/baseline_floor.json
@@ -1,0 +1,722 @@
+{
+  "summary": {
+    "queries": 33,
+    "k": 3,
+    "hit_rate": 0.9696969696969697,
+    "precision@k": 0.6262626262626263,
+    "recall@k": 0.9191919191919191,
+    "MRR": 0.9090909090909091,
+    "MAP@k": 0.8686868686868687,
+    "latency_ms_mean": 346.4188597581321,
+    "floor_silenced_on_topic": 0,
+    "floor_rejected_off_topic": 9,
+    "negative_controls": 10
+  },
+  "per_query": [
+    {
+      "retrieved": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-01",
+      "query": "my tilapia are all gasping at the surface early in the morning",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 0.8959375023841858,
+      "raw_top_score": 0.8959375023841858,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-02",
+      "query": "fish crowding near the water inlet and breathing fast",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.8161635398864746,
+      "raw_top_score": 0.8161635398864746,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/common_system_failures.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "stress-01",
+      "query": "fish are moving slowly and barely touching their food",
+      "relevant": [
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.6871860027313232,
+      "raw_top_score": 0.6871860027313232,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-01",
+      "query": "ammonia reading jumped to 4 ppm what do I do right now",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 0.8181362152099609,
+      "raw_top_score": 0.8181362152099609,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-02",
+      "query": "brand new setup three weeks in and nitrite is climbing",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 1.0304288864135742,
+      "raw_top_score": 1.0304288864135742,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-03",
+      "query": "how long before the bacteria establish themselves",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 1.2353334426879883,
+      "raw_top_score": 1.2353334426879883,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "ph-01",
+      "query": "the pH keeps sliding down every week no matter what I add",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 0.8413991928100586,
+      "raw_top_score": 0.8413991928100586,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/ph_and_alkalinity.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "ph-02",
+      "query": "how do I bring up the buffering capacity safely",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 1.3183010816574097,
+      "raw_top_score": 1.3183010816574097,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_deficiency_cheatsheet.md",
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-01",
+      "query": "lettuce leaves going yellow between the veins but the veins stay green",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "top_score": 0.5887277722358704,
+      "raw_top_score": 0.5887277722358704,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md",
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-02",
+      "query": "the oldest leaves are turning pale first while new growth looks fine",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "top_score": 0.8162521123886108,
+      "raw_top_score": 0.8162521123886108,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/common_system_failures.md",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "algae-01",
+      "query": "my water has gone bright green and cloudy",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.0651259422302246,
+      "raw_top_score": 1.0651259422302246,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/algae_control.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "algae-02",
+      "query": "stringy green growth clogging the pipes and screens",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.2165082693099976,
+      "raw_top_score": 1.2165082693099976,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "fail-01",
+      "query": "we lost power for six hours overnight what should I check first",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 1.3383744955062866,
+      "raw_top_score": 1.3383744955062866,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 0.3333333333333333,
+      "rr": 0.5,
+      "ap": 0.16666666666666666,
+      "id": "fail-02",
+      "query": "I think I have been giving them too much food and now the water is murky",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.123023271560669,
+      "raw_top_score": 1.123023271560669,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-01",
+      "query": "little white dots all over my fish like grains of salt",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 0.7301387786865234,
+      "raw_top_score": 0.7301387786865234,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md",
+        "knowledge/plant_pests_and_ipm.md",
+        "https://doi.org/10.1007/S10462-024-11003-X"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-02",
+      "query": "can I use a copper based treatment with plants in the loop",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 1.0919899940490723,
+      "raw_top_score": 1.0919899940490723,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/feed_and_feeding.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "feed-01",
+      "query": "how much should I be giving them each day",
+      "relevant": [
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.2183464765548706,
+      "raw_top_score": 1.2183464765548706,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pump-01",
+      "query": "the pump is rated for plenty but barely trickles at the top of the tower",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.9262655377388,
+      "raw_top_score": 0.9262655377388,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pump-02",
+      "query": "how do I work out the flow I actually need",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.9937251806259155,
+      "raw_top_score": 0.9937251806259155,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-01",
+      "query": "should I go with rafts or the thin channel setup",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 0.9254881143569946,
+      "raw_top_score": 0.9254881143569946,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-02",
+      "query": "I have almost no floor space what layout works",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.4159350395202637,
+      "raw_top_score": 1.4159350395202637,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "water-01",
+      "query": "our tap water smells strongly of chlorine can I top up with it",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 0.8954066038131714,
+      "raw_top_score": 0.8954066038131714,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/water_source_and_treatment.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "water-02",
+      "query": "the well water here is extremely hard",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 1.1220040321350098,
+      "raw_top_score": 1.1220040321350098,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "solids-01",
+      "query": "dark sludge piling up in the bottom of the tank",
+      "relevant": [
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "top_score": 0.9865351915359497,
+      "raw_top_score": 0.9865351915359497,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/regulations_and_permits.md",
+        "https://doi.org/10.1371/journal.pone.0102662"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "reg-01",
+      "query": "do I need any kind of licence before I can sell the fish",
+      "relevant": [
+        "knowledge/regulations_and_permits.md"
+      ],
+      "top_score": 0.8532036542892456,
+      "raw_top_score": 0.8532036542892456,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "https://doi.org/10.1371/journal.pone.0102662",
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "safety-01",
+      "query": "is produce grown on fish waste actually safe to eat",
+      "relevant": [
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "top_score": 0.7736780643463135,
+      "raw_top_score": 0.7736780643463135,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pest-01",
+      "query": "tiny green insects covering my basil what can I spray",
+      "relevant": [
+        "knowledge/plant_pests_and_ipm.md"
+      ],
+      "top_score": 1.0603309869766235,
+      "raw_top_score": 1.0603309869766235,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "econ-01",
+      "query": "what are the running costs going to look like",
+      "relevant": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "top_score": 1.0173242092132568,
+      "raw_top_score": 1.0173242092132568,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "econ-02",
+      "query": "is this ever going to break even",
+      "relevant": [
+        "knowledge/economics_and_costs.md",
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.5123841762542725,
+      "raw_top_score": 1.5123841762542725,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/feasibility_and_business_case.md",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "hit": true,
+      "precision": 0.5,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "econ-03",
+      "query": "putting together a funding proposal what should it cover",
+      "relevant": [
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.1042566299438477,
+      "raw_top_score": 1.1042566299438477,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-01",
+      "query": "water hits 34 degrees in the afternoon here",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.2017155885696411,
+      "raw_top_score": 1.2017155885696411,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "hit": true,
+      "precision": 1.0,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-02",
+      "query": "which species suits a cold winter",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.0294992923736572,
+      "raw_top_score": 1.0294992923736572,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/water_quality_ranges.md",
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "https://doi.org/10.1007/S10462-024-11003-X"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "range-01",
+      "query": "what levels should I be aiming for overall",
+      "relevant": [
+        "knowledge/water_quality_ranges.md"
+      ],
+      "top_score": 1.5543122291564941,
+      "raw_top_score": 1.5543122291564941,
+      "floor_returned_nothing": false
+    }
+  ],
+  "negative_controls": [
+    {
+      "id": "neg-01",
+      "query": "how do I fix a slipping bicycle chain",
+      "top_score": 1.7171915769577026,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-02",
+      "query": "what is the capital of Canada",
+      "top_score": 1.7648371458053589,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-03",
+      "query": "write me a python function to reverse a linked list",
+      "top_score": 1.7574958801269531,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-04",
+      "query": "what time does the pharmacy close today",
+      "top_score": 1.6874147653579712,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-05",
+      "query": "recommend a good science fiction novel",
+      "top_score": 1.7044743299484253,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-06",
+      "query": "how do I change a flat car tyre",
+      "top_score": 1.8106987476348877,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-07",
+      "query": "explain the offside rule in football",
+      "top_score": 1.7396923303604126,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-08",
+      "query": "best way to remove red wine from a carpet",
+      "top_score": 1.5532822608947754,
+      "returned": [
+        "knowledge/algae_control.md"
+      ],
+      "rejected_by_floor": false
+    },
+    {
+      "id": "neg-09",
+      "query": "convert 500 euros to yen",
+      "top_score": 1.8460793495178223,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-10",
+      "query": "who won the world cup in 1998",
+      "top_score": 1.78805410861969,
+      "returned": [],
+      "rejected_by_floor": true
+    }
+  ]
+}

--- a/docs/dpg/retrieval_eval/chunking_ablation.json
+++ b/docs/dpg/retrieval_eval/chunking_ablation.json
@@ -1,42 +1,83 @@
 {
-  "description": "Ablation of markdown-header-aware chunking and the context prefix, over docs/dpg/retrieval_eval/golden_set.json. Recorded so shipping this DISABLED is reproducible.",
-  "corpus": {
-    "chunks_baseline": 362,
-    "local_sections": 123,
-    "mean_section_chars": 381,
-    "median_section_chars": 365,
-    "chunk_size": 800,
-    "sections_smaller_than_chunk_window": "117/123 (95%)"
-  },
-  "variants": [
+  "description": "Ablation of markdown-header chunking and its context prefix. Run on two corpus sizes. Baseline wins both times, but the CONTEXT PREFIX reverses sign between them, which is the interesting part.",
+  "runs": [
     {
-      "id": "A",
-      "name": "baseline \u2014 recursive character splitter only",
-      "hit_rate": 0.97,
-      "recall@k": 0.919,
-      "precision@k": 0.626,
-      "MRR": 0.909,
-      "MAP@k": 0.869
+      "corpus": {
+        "chunks": 362,
+        "local_sections": 123,
+        "mean_section_chars": 381,
+        "chunk_size": 800,
+        "sections_smaller_than_chunk_window": "117/123 (95%)"
+      },
+      "variants": [
+        {
+          "id": "A",
+          "name": "baseline \u2014 recursive character splitter",
+          "hit_rate": 0.97,
+          "recall@k": 0.919,
+          "precision@k": 0.626,
+          "MRR": 0.909,
+          "MAP@k": 0.869
+        },
+        {
+          "id": "B",
+          "name": "header split, no context prefix",
+          "hit_rate": 0.939,
+          "recall@k": 0.889,
+          "precision@k": 0.606,
+          "MRR": 0.843,
+          "MAP@k": 0.793
+        },
+        {
+          "id": "C",
+          "name": "header split + context prefix",
+          "hit_rate": 0.909,
+          "recall@k": 0.879,
+          "precision@k": 0.722,
+          "MRR": 0.848,
+          "MAP@k": 0.818
+        }
+      ],
+      "note": "Prefix HELPED: C gains 0.116 precision and 0.025 MAP over B."
     },
     {
-      "id": "B",
-      "name": "header split, no context prefix",
-      "hit_rate": 0.939,
-      "recall@k": 0.889,
-      "precision@k": 0.606,
-      "MRR": 0.843,
-      "MAP@k": 0.793
-    },
-    {
-      "id": "C",
-      "name": "header split + 'Title \u2014 Section' context prefix",
-      "hit_rate": 0.909,
-      "recall@k": 0.879,
-      "precision@k": 0.722,
-      "MRR": 0.848,
-      "MAP@k": 0.818
+      "corpus": {
+        "chunks": 1354,
+        "note": "FAO 589 added (992 chunks)"
+      },
+      "variants": [
+        {
+          "id": "A",
+          "name": "baseline \u2014 recursive character splitter",
+          "hit_rate": 0.848,
+          "recall@k": 0.788,
+          "precision@k": 0.495,
+          "MRR": 0.692,
+          "MAP@k": 0.636
+        },
+        {
+          "id": "B",
+          "name": "header split, no context prefix",
+          "hit_rate": 0.818,
+          "recall@k": 0.753,
+          "precision@k": 0.475,
+          "MRR": 0.692,
+          "MAP@k": 0.631
+        },
+        {
+          "id": "C",
+          "name": "header split + context prefix",
+          "hit_rate": 0.758,
+          "recall@k": 0.667,
+          "precision@k": 0.444,
+          "MRR": 0.621,
+          "MAP@k": 0.538
+        }
+      ],
+      "note": "Prefix HURT: C loses 0.060 hit_rate and 0.093 MAP against B \u2014 the opposite sign."
     }
   ],
-  "conclusion": "Baseline wins on every metric except precision. The ablation separates two effects that are usually bundled: the SPLIT costs quality (B loses on all five metrics), while the CONTEXT PREFIX genuinely helps (C gains 0.116 precision and 0.025 MAP over B). The mechanism is corpus geometry, not the technique: 95% of sections are SMALLER than the 800-char chunk window (mean 381 chars), so the recursive splitter was already packing ~2 related sections per chunk and header splitting fragments that useful co-occurrence into context-poor pieces. Ships DISABLED (AGRONAUT_MD_HEADERS=off by default).",
-  "when_to_revisit": "This is expected to invert for documents whose sections are LARGER than the chunk window \u2014 exactly the book-length PDFs the corpus is growing toward. FAO 589 is 275 pages; blind 800-char windows across a book ignore every structural boundary in it. Re-run this ablation once such a source is indexed, and consider enabling header chunking for PDF sources specifically while leaving the short hand-authored corpus on the character splitter."
+  "conclusion": "Baseline wins on both corpora, so header chunking stays DISABLED (AGRONAUT_MD_HEADERS=off). The prefix's reversal is the finding worth keeping: on a small uniform corpus, prefixing a chunk with 'Title - Section' disambiguated it among 21 similar files; once a 992-chunk book joined the index, those same added words made curated chunks read as generic aquaponics prose and compete WORSE against it. A preprocessing step's value is a property of the corpus it runs on, not of the step.",
+  "why_header_chunking_still_loses": "95% of the hand-authored corpus's sections are SMALLER than the 800-char chunk window (mean 381), so the recursive splitter already packs ~2 related sections per chunk and header splitting fragments that co-occurrence. Note this implementation only splits MARKDOWN; FAO 589 reaches the character splitter either way, so this ablation does NOT test structural chunking of the PDF itself. That remains unimplemented and is the more promising direction for book-length sources.",
+  "methodology_note": "The first attempt at this second run reported BYTE-IDENTICAL numbers for B and C. The cause was the index-cache fingerprint not covering AGRONAUT_MD_CRUMB, so variant C silently re-read variant B's index. Suspiciously identical results were the only symptom. All three chunking flags are now in the fingerprint, with a test per flag."
 }

--- a/docs/dpg/retrieval_eval/chunking_ablation.json
+++ b/docs/dpg/retrieval_eval/chunking_ablation.json
@@ -1,0 +1,42 @@
+{
+  "description": "Ablation of markdown-header-aware chunking and the context prefix, over docs/dpg/retrieval_eval/golden_set.json. Recorded so shipping this DISABLED is reproducible.",
+  "corpus": {
+    "chunks_baseline": 362,
+    "local_sections": 123,
+    "mean_section_chars": 381,
+    "median_section_chars": 365,
+    "chunk_size": 800,
+    "sections_smaller_than_chunk_window": "117/123 (95%)"
+  },
+  "variants": [
+    {
+      "id": "A",
+      "name": "baseline \u2014 recursive character splitter only",
+      "hit_rate": 0.97,
+      "recall@k": 0.919,
+      "precision@k": 0.626,
+      "MRR": 0.909,
+      "MAP@k": 0.869
+    },
+    {
+      "id": "B",
+      "name": "header split, no context prefix",
+      "hit_rate": 0.939,
+      "recall@k": 0.889,
+      "precision@k": 0.606,
+      "MRR": 0.843,
+      "MAP@k": 0.793
+    },
+    {
+      "id": "C",
+      "name": "header split + 'Title \u2014 Section' context prefix",
+      "hit_rate": 0.909,
+      "recall@k": 0.879,
+      "precision@k": 0.722,
+      "MRR": 0.848,
+      "MAP@k": 0.818
+    }
+  ],
+  "conclusion": "Baseline wins on every metric except precision. The ablation separates two effects that are usually bundled: the SPLIT costs quality (B loses on all five metrics), while the CONTEXT PREFIX genuinely helps (C gains 0.116 precision and 0.025 MAP over B). The mechanism is corpus geometry, not the technique: 95% of sections are SMALLER than the 800-char chunk window (mean 381 chars), so the recursive splitter was already packing ~2 related sections per chunk and header splitting fragments that useful co-occurrence into context-poor pieces. Ships DISABLED (AGRONAUT_MD_HEADERS=off by default).",
+  "when_to_revisit": "This is expected to invert for documents whose sections are LARGER than the chunk window \u2014 exactly the book-length PDFs the corpus is growing toward. FAO 589 is 275 pages; blind 800-char windows across a book ignore every structural boundary in it. Re-run this ablation once such a source is indexed, and consider enabling header chunking for PDF sources specifically while leaving the short hand-authored corpus on the character splitter."
+}

--- a/docs/dpg/retrieval_eval/golden_set.json
+++ b/docs/dpg/retrieval_eval/golden_set.json
@@ -35,15 +35,19 @@
       "id": "n-02",
       "query": "brand new setup three weeks in and nitrite is climbing",
       "relevant": [
-        "knowledge/nitrogen_cycle_and_cycling.md"
-      ]
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "annotation_note": "returns nitrite-spike causes and remedies verbatim: 'immediate water exchange (20-50%), addition of zeolite ... add biofilter media, improve oxygenation'"
     },
     {
       "id": "n-03",
       "query": "how long before the bacteria establish themselves",
       "relevant": [
-        "knowledge/nitrogen_cycle_and_cycling.md"
-      ]
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "annotation_note": "answers the question directly: 'Normally, this is a 3-6 week process that involves introducing an ammonia source'"
     },
     {
       "id": "ph-01",
@@ -85,8 +89,10 @@
       "id": "algae-02",
       "query": "stringy green growth clogging the pipes and screens",
       "relevant": [
-        "knowledge/algae_control.md"
-      ]
+        "knowledge/algae_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "annotation_note": "'FIGURE 3.9 Algae growing on plastic pipe ... Preventing algae is relatively easy. All water surfaces should be shaded.'"
     },
     {
       "id": "fail-01",
@@ -123,8 +129,10 @@
       "id": "feed-01",
       "query": "how much should I be giving them each day",
       "relevant": [
-        "knowledge/feed_and_feeding.md"
-      ]
+        "knowledge/feed_and_feeding.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "annotation_note": "gives the feeding rate directly: 'Juvenile fish can be fed about 3 percent of their body weight per day.'"
     },
     {
       "id": "pump-01",
@@ -172,8 +180,10 @@
       "id": "solids-01",
       "query": "dark sludge piling up in the bottom of the tank",
       "relevant": [
-        "knowledge/solids_and_mineralization.md"
-      ]
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "annotation_note": "its 'Solids accumulation / clogging' section names the exact symptom: 'foul smell, black sludge, possible H2S'"
     },
     {
       "id": "reg-01",
@@ -193,8 +203,10 @@
       "id": "pest-01",
       "query": "tiny green insects covering my basil what can I spray",
       "relevant": [
-        "knowledge/plant_pests_and_ipm.md"
-      ]
+        "knowledge/plant_pests_and_ipm.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "annotation_note": "Appendix 2 plant pest control: natural soaps, garlic oil, named aphid treatments"
     },
     {
       "id": "econ-01",
@@ -282,5 +294,6 @@
       "query": "who won the world cup in 1998"
     }
   ],
-  "_negative_controls_note": "Off-topic queries that MUST NOT return a confident citation. Their score distribution is what calibrates the relevance floor: the floor is only trustworthy if the off-topic band separates cleanly from the worst on-topic score. More controls = a more honest margin."
+  "_negative_controls_note": "Off-topic queries that MUST NOT return a confident citation. Their score distribution is what calibrates the relevance floor: the floor is only trustworthy if the off-topic band separates cleanly from the worst on-topic score. More controls = a more honest margin.",
+  "_ground_truth_note": "Ground truth is a property of the CORPUS, not of the queries, so it must be re-established whenever the corpus changes. Adding FAO 589 dropped hit_rate from 0.970 to 0.667 \u2014 but reading the passages actually returned showed 6 of those 11 'misses' were the retriever finding a genuinely correct answer this file had not yet been told about (FAO answers 'how much should I feed them' with '3 percent of body weight per day'). Those 6 were relabelled, each with the quoted evidence in annotation_note. The other 5 (algae-01, fail-02, disease-02, type-02, safety-01) were left as misses because the returned passages genuinely do not answer them \u2014 relabelling those would be tuning the ruler to fit the result."
 }

--- a/docs/dpg/retrieval_eval/golden_set.json
+++ b/docs/dpg/retrieval_eval/golden_set.json
@@ -1,0 +1,286 @@
+{
+  "description": "Retrieval golden set for Agronaut's knowledge base. Queries are written in OPERATOR voice \u2014 symptom-first, messy, and deliberately NOT phrased in the vocabulary of the documents that should answer them. That vocabulary gap is the point: a retriever that only matches document titles scores well on keyword-shaped queries and fails real users. `relevant` lists the source files a correct retrieval should surface; a query may legitimately have more than one.",
+  "k": 3,
+  "queries": [
+    {
+      "id": "do-01",
+      "query": "my tilapia are all gasping at the surface early in the morning",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ]
+    },
+    {
+      "id": "do-02",
+      "query": "fish crowding near the water inlet and breathing fast",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ]
+    },
+    {
+      "id": "stress-01",
+      "query": "fish are moving slowly and barely touching their food",
+      "relevant": [
+        "knowledge/fish_stress_diagnosis.md"
+      ]
+    },
+    {
+      "id": "n-01",
+      "query": "ammonia reading jumped to 4 ppm what do I do right now",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ]
+    },
+    {
+      "id": "n-02",
+      "query": "brand new setup three weeks in and nitrite is climbing",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ]
+    },
+    {
+      "id": "n-03",
+      "query": "how long before the bacteria establish themselves",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ]
+    },
+    {
+      "id": "ph-01",
+      "query": "the pH keeps sliding down every week no matter what I add",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ]
+    },
+    {
+      "id": "ph-02",
+      "query": "how do I bring up the buffering capacity safely",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ]
+    },
+    {
+      "id": "plant-01",
+      "query": "lettuce leaves going yellow between the veins but the veins stay green",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ]
+    },
+    {
+      "id": "plant-02",
+      "query": "the oldest leaves are turning pale first while new growth looks fine",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md"
+      ]
+    },
+    {
+      "id": "algae-01",
+      "query": "my water has gone bright green and cloudy",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ]
+    },
+    {
+      "id": "algae-02",
+      "query": "stringy green growth clogging the pipes and screens",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ]
+    },
+    {
+      "id": "fail-01",
+      "query": "we lost power for six hours overnight what should I check first",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ]
+    },
+    {
+      "id": "fail-02",
+      "query": "I think I have been giving them too much food and now the water is murky",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/feed_and_feeding.md"
+      ]
+    },
+    {
+      "id": "disease-01",
+      "query": "little white dots all over my fish like grains of salt",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ]
+    },
+    {
+      "id": "disease-02",
+      "query": "can I use a copper based treatment with plants in the loop",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ]
+    },
+    {
+      "id": "feed-01",
+      "query": "how much should I be giving them each day",
+      "relevant": [
+        "knowledge/feed_and_feeding.md"
+      ]
+    },
+    {
+      "id": "pump-01",
+      "query": "the pump is rated for plenty but barely trickles at the top of the tower",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ]
+    },
+    {
+      "id": "pump-02",
+      "query": "how do I work out the flow I actually need",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ]
+    },
+    {
+      "id": "type-01",
+      "query": "should I go with rafts or the thin channel setup",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ]
+    },
+    {
+      "id": "type-02",
+      "query": "I have almost no floor space what layout works",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ]
+    },
+    {
+      "id": "water-01",
+      "query": "our tap water smells strongly of chlorine can I top up with it",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ]
+    },
+    {
+      "id": "water-02",
+      "query": "the well water here is extremely hard",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ]
+    },
+    {
+      "id": "solids-01",
+      "query": "dark sludge piling up in the bottom of the tank",
+      "relevant": [
+        "knowledge/solids_and_mineralization.md"
+      ]
+    },
+    {
+      "id": "reg-01",
+      "query": "do I need any kind of licence before I can sell the fish",
+      "relevant": [
+        "knowledge/regulations_and_permits.md"
+      ]
+    },
+    {
+      "id": "safety-01",
+      "query": "is produce grown on fish waste actually safe to eat",
+      "relevant": [
+        "knowledge/food_safety_and_hygiene.md"
+      ]
+    },
+    {
+      "id": "pest-01",
+      "query": "tiny green insects covering my basil what can I spray",
+      "relevant": [
+        "knowledge/plant_pests_and_ipm.md"
+      ]
+    },
+    {
+      "id": "econ-01",
+      "query": "what are the running costs going to look like",
+      "relevant": [
+        "knowledge/economics_and_costs.md"
+      ]
+    },
+    {
+      "id": "econ-02",
+      "query": "is this ever going to break even",
+      "relevant": [
+        "knowledge/economics_and_costs.md",
+        "knowledge/feasibility_and_business_case.md"
+      ]
+    },
+    {
+      "id": "econ-03",
+      "query": "putting together a funding proposal what should it cover",
+      "relevant": [
+        "knowledge/feasibility_and_business_case.md"
+      ]
+    },
+    {
+      "id": "temp-01",
+      "query": "water hits 34 degrees in the afternoon here",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ]
+    },
+    {
+      "id": "temp-02",
+      "query": "which species suits a cold winter",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ]
+    },
+    {
+      "id": "range-01",
+      "query": "what levels should I be aiming for overall",
+      "relevant": [
+        "knowledge/water_quality_ranges.md"
+      ]
+    }
+  ],
+  "negative_controls": [
+    {
+      "id": "neg-01",
+      "query": "how do I fix a slipping bicycle chain"
+    },
+    {
+      "id": "neg-02",
+      "query": "what is the capital of Canada"
+    },
+    {
+      "id": "neg-03",
+      "query": "write me a python function to reverse a linked list"
+    },
+    {
+      "id": "neg-04",
+      "query": "what time does the pharmacy close today"
+    },
+    {
+      "id": "neg-05",
+      "query": "recommend a good science fiction novel"
+    },
+    {
+      "id": "neg-06",
+      "query": "how do I change a flat car tyre"
+    },
+    {
+      "id": "neg-07",
+      "query": "explain the offside rule in football"
+    },
+    {
+      "id": "neg-08",
+      "query": "best way to remove red wine from a carpet"
+    },
+    {
+      "id": "neg-09",
+      "query": "convert 500 euros to yen"
+    },
+    {
+      "id": "neg-10",
+      "query": "who won the world cup in 1998"
+    }
+  ],
+  "_negative_controls_note": "Off-topic queries that MUST NOT return a confident citation. Their score distribution is what calibrates the relevance floor: the floor is only trustworthy if the off-topic band separates cleanly from the worst on-topic score. More controls = a more honest margin."
+}

--- a/docs/dpg/retrieval_eval/hybrid_sweep.json
+++ b/docs/dpg/retrieval_eval/hybrid_sweep.json
@@ -1,0 +1,76 @@
+{
+  "description": "Hybrid BM25+RRF weighting sweep over docs/dpg/retrieval_eval/golden_set.json. beta is the weight on the SEMANTIC ranking; the keyword ranking gets (1-beta). Recorded so the decision to ship hybrid retrieval DISABLED is reproducible rather than an opinion.",
+  "corpus": {
+    "chunks": 362,
+    "local_files": 21,
+    "web_sources": 2
+  },
+  "embedding_model": "sentence-transformers/all-mpnet-base-v2",
+  "k": 3,
+  "sweep": [
+    {
+      "beta": 0.0,
+      "hit_rate": 0.788,
+      "recall@k": 0.768,
+      "precision@k": 0.328,
+      "MRR": 0.692,
+      "MAP@k": 0.677
+    },
+    {
+      "beta": 0.3,
+      "hit_rate": 0.879,
+      "recall@k": 0.859,
+      "precision@k": 0.424,
+      "MRR": 0.823,
+      "MAP@k": 0.819
+    },
+    {
+      "beta": 0.5,
+      "hit_rate": 0.939,
+      "recall@k": 0.924,
+      "precision@k": 0.485,
+      "MRR": 0.874,
+      "MAP@k": 0.861
+    },
+    {
+      "beta": 0.7,
+      "hit_rate": 0.97,
+      "recall@k": 0.919,
+      "precision@k": 0.5,
+      "MRR": 0.899,
+      "MAP@k": 0.862
+    },
+    {
+      "beta": 0.8,
+      "hit_rate": 0.97,
+      "recall@k": 0.919,
+      "precision@k": 0.5,
+      "MRR": 0.889,
+      "MAP@k": 0.852
+    },
+    {
+      "beta": 0.9,
+      "hit_rate": 0.909,
+      "recall@k": 0.859,
+      "precision@k": 0.49,
+      "MRR": 0.864,
+      "MAP@k": 0.823
+    },
+    {
+      "beta": 0.95,
+      "hit_rate": 0.97,
+      "recall@k": 0.904,
+      "precision@k": 0.581,
+      "MRR": 0.884,
+      "MAP@k": 0.838
+    }
+  ],
+  "dense_only": {
+    "hit_rate": 0.97,
+    "recall@k": 0.919,
+    "precision@k": 0.626,
+    "MRR": 0.909,
+    "MAP@k": 0.869
+  },
+  "conclusion": "Dense-only equals or beats every hybrid setting on every metric. The best hybrid configuration (beta=0.70) matches dense hit_rate and recall but loses 0.126 precision and 0.010 MRR. BM25 adds noise without adding signal on a 362-chunk corpus whose documents share one vocabulary domain: common aquaponics terms match across many files, so keyword rank is weakly informative. Hybrid ships DISABLED (AGRONAUT_HYBRID=off by default). Re-run this sweep after any substantial corpus growth - a larger, more heterogeneous corpus (e.g. adding FAO 589's ~1034 chunks) is exactly where BM25 is expected to start earning its place."
+}

--- a/docs/dpg/retrieval_eval/hybrid_sweep.json
+++ b/docs/dpg/retrieval_eval/hybrid_sweep.json
@@ -1,76 +1,142 @@
 {
-  "description": "Hybrid BM25+RRF weighting sweep over docs/dpg/retrieval_eval/golden_set.json. beta is the weight on the SEMANTIC ranking; the keyword ranking gets (1-beta). Recorded so the decision to ship hybrid retrieval DISABLED is reproducible rather than an opinion.",
-  "corpus": {
-    "chunks": 362,
-    "local_files": 21,
-    "web_sources": 2
-  },
-  "embedding_model": "sentence-transformers/all-mpnet-base-v2",
-  "k": 3,
-  "sweep": [
+  "description": "Hybrid BM25+RRF weighting sweeps. beta is the weight on the SEMANTIC ranking; the keyword ranking gets (1-beta). Run twice, on two corpus sizes \u2014 the second run REVERSED the shipping decision, which is why both are kept.",
+  "runs": [
     {
-      "beta": 0.0,
-      "hit_rate": 0.788,
-      "recall@k": 0.768,
-      "precision@k": 0.328,
-      "MRR": 0.692,
-      "MAP@k": 0.677
+      "corpus": {
+        "chunks": 362,
+        "note": "21 local .md + 2 CC BY papers"
+      },
+      "sweep": [
+        {
+          "beta": 0.0,
+          "hit_rate": 0.788,
+          "recall@k": 0.768,
+          "precision@k": 0.328,
+          "MRR": 0.692,
+          "MAP@k": 0.677
+        },
+        {
+          "beta": 0.3,
+          "hit_rate": 0.879,
+          "recall@k": 0.859,
+          "precision@k": 0.424,
+          "MRR": 0.823,
+          "MAP@k": 0.819
+        },
+        {
+          "beta": 0.5,
+          "hit_rate": 0.939,
+          "recall@k": 0.924,
+          "precision@k": 0.485,
+          "MRR": 0.874,
+          "MAP@k": 0.861
+        },
+        {
+          "beta": 0.7,
+          "hit_rate": 0.97,
+          "recall@k": 0.919,
+          "precision@k": 0.5,
+          "MRR": 0.899,
+          "MAP@k": 0.862
+        },
+        {
+          "beta": 0.8,
+          "hit_rate": 0.97,
+          "recall@k": 0.919,
+          "precision@k": 0.5,
+          "MRR": 0.889,
+          "MAP@k": 0.852
+        },
+        {
+          "beta": 0.9,
+          "hit_rate": 0.909,
+          "recall@k": 0.859,
+          "precision@k": 0.49,
+          "MRR": 0.864,
+          "MAP@k": 0.823
+        },
+        {
+          "beta": 0.95,
+          "hit_rate": 0.97,
+          "recall@k": 0.904,
+          "precision@k": 0.581,
+          "MRR": 0.884,
+          "MAP@k": 0.838
+        }
+      ],
+      "dense_only": {
+        "hit_rate": 0.97,
+        "recall@k": 0.919,
+        "precision@k": 0.626,
+        "MRR": 0.909,
+        "MAP@k": 0.869
+      },
+      "decision": "DISABLED \u2014 dense-only equals or beats every weighting on every metric."
     },
     {
-      "beta": 0.3,
-      "hit_rate": 0.879,
-      "recall@k": 0.859,
-      "precision@k": 0.424,
-      "MRR": 0.823,
-      "MAP@k": 0.819
-    },
-    {
-      "beta": 0.5,
-      "hit_rate": 0.939,
-      "recall@k": 0.924,
-      "precision@k": 0.485,
-      "MRR": 0.874,
-      "MAP@k": 0.861
-    },
-    {
-      "beta": 0.7,
-      "hit_rate": 0.97,
-      "recall@k": 0.919,
-      "precision@k": 0.5,
-      "MRR": 0.899,
-      "MAP@k": 0.862
-    },
-    {
-      "beta": 0.8,
-      "hit_rate": 0.97,
-      "recall@k": 0.919,
-      "precision@k": 0.5,
-      "MRR": 0.889,
-      "MAP@k": 0.852
-    },
-    {
-      "beta": 0.9,
-      "hit_rate": 0.909,
-      "recall@k": 0.859,
-      "precision@k": 0.49,
-      "MRR": 0.864,
-      "MAP@k": 0.823
-    },
-    {
-      "beta": 0.95,
-      "hit_rate": 0.97,
-      "recall@k": 0.904,
-      "precision@k": 0.581,
-      "MRR": 0.884,
-      "MAP@k": 0.838
+      "corpus": {
+        "chunks": 1354,
+        "note": "FAO 589 added (992 chunks, 275-page publication)"
+      },
+      "sweep": [
+        {
+          "beta": 0.3,
+          "hit_rate": 0.667,
+          "recall@k": 0.636,
+          "precision@k": 0.414,
+          "MRR": 0.545,
+          "MAP@k": 0.528
+        },
+        {
+          "beta": 0.5,
+          "hit_rate": 0.758,
+          "recall@k": 0.727,
+          "precision@k": 0.444,
+          "MRR": 0.561,
+          "MAP@k": 0.543
+        },
+        {
+          "beta": 0.6,
+          "hit_rate": 0.818,
+          "recall@k": 0.773,
+          "precision@k": 0.47,
+          "MRR": 0.601,
+          "MAP@k": 0.576
+        },
+        {
+          "beta": 0.7,
+          "hit_rate": 0.818,
+          "recall@k": 0.773,
+          "precision@k": 0.475,
+          "MRR": 0.646,
+          "MAP@k": 0.606
+        },
+        {
+          "beta": 0.8,
+          "hit_rate": 0.818,
+          "recall@k": 0.758,
+          "precision@k": 0.465,
+          "MRR": 0.662,
+          "MAP@k": 0.611
+        },
+        {
+          "beta": 0.9,
+          "hit_rate": 0.848,
+          "recall@k": 0.788,
+          "precision@k": 0.495,
+          "MRR": 0.692,
+          "MAP@k": 0.636
+        }
+      ],
+      "dense_only": {
+        "hit_rate": 0.848,
+        "recall@k": 0.697,
+        "precision@k": 0.49,
+        "MRR": 0.682,
+        "MAP@k": 0.545
+      },
+      "decision": "ENABLED at beta=0.90 \u2014 recall +0.091, MAP +0.091, hit_rate unchanged."
     }
   ],
-  "dense_only": {
-    "hit_rate": 0.97,
-    "recall@k": 0.919,
-    "precision@k": 0.626,
-    "MRR": 0.909,
-    "MAP@k": 0.869
-  },
-  "conclusion": "Dense-only equals or beats every hybrid setting on every metric. The best hybrid configuration (beta=0.70) matches dense hit_rate and recall but loses 0.126 precision and 0.010 MRR. BM25 adds noise without adding signal on a 362-chunk corpus whose documents share one vocabulary domain: common aquaponics terms match across many files, so keyword rank is weakly informative. Hybrid ships DISABLED (AGRONAUT_HYBRID=off by default). Re-run this sweep after any substantial corpus growth - a larger, more heterogeneous corpus (e.g. adding FAO 589's ~1034 chunks) is exactly where BM25 is expected to start earning its place."
+  "conclusion": "The technique never changed; the corpus did. On 362 chunks sharing one vocabulary domain, keyword rank carried almost no information and hybrid lost everywhere. On 1354 chunks where a single 992-chunk book competes against 82 chunks of targeted operator guidance, the keyword signal breaks ties that dense similarity resolves by sheer volume. Note how LITTLE keyword weight is correct even then: 10%. At the intuitive 'balanced' 0.5 hybrid is still clearly worse than dense-only in BOTH runs. Re-run this sweep after any substantial corpus change \u2014 that instruction, recorded with the first run, is what produced the reversal."
 }

--- a/docs/dpg/retrieval_eval/techniques.json
+++ b/docs/dpg/retrieval_eval/techniques.json
@@ -1,0 +1,72 @@
+{
+  "description": "Every retrieval technique implemented in this work, what it measured, and whether it ships. Recorded so each decision is reproducible and so a decision can EXPIRE \u2014 hybrid search was rejected, then adopted when the corpus grew.",
+  "corpus_at_final_measurement": {
+    "chunks": 1354,
+    "local_files": 21,
+    "web_sources": 3
+  },
+  "final": {
+    "hit_rate": 0.939,
+    "recall@k": 0.894,
+    "precision@k": 0.54,
+    "MRR": 0.737,
+    "MAP@k": 0.697,
+    "latency_ms": 244
+  },
+  "techniques": [
+    {
+      "name": "Relevance floor",
+      "ships": "ON",
+      "evidence": "rejects 8/10 off-topic, silences 0/33 real",
+      "note": "Bands overlap (on-topic worst 1.548, off-topic best 1.426) so it cannot be tightened."
+    },
+    {
+      "name": "Hybrid BM25 + RRF",
+      "ships": "ON (beta=0.90)",
+      "evidence": "362 chunks: lost at every beta. 1354 chunks: recall +0.091, MAP +0.091",
+      "note": "REVERSED. The technique did not change; the corpus did. Only 10% keyword weight is correct."
+    },
+    {
+      "name": "Per-source cap",
+      "ships": "ON (2)",
+      "evidence": "hit 0.848->0.939, recall 0.788->0.894, precision 0.495->0.540",
+      "note": "Largest single gain. FAO 589 was taking all 3 slots on 10 of 33 queries."
+    },
+    {
+      "name": "PDF cleaning",
+      "ships": "ON",
+      "evidence": "13 structural pages dropped; running header in 4/992 chunks instead of 111/1034",
+      "note": "A table of contents is not knowledge under any corpus conditions."
+    },
+    {
+      "name": "Header chunking (markdown)",
+      "ships": "OFF",
+      "evidence": "362: hit 0.970->0.909. 1354: hit 0.848->0.758",
+      "note": "95% of sections are smaller than the chunk window, so splitting fragments rather than aligns."
+    },
+    {
+      "name": "Context prefix (markdown)",
+      "ships": "OFF",
+      "evidence": "362: precision +0.116. 1354: MAP -0.093",
+      "note": "REVERSED SIGN between corpora."
+    },
+    {
+      "name": "PDF chapter labelling",
+      "ships": "OFF",
+      "evidence": "hit 0.939->0.909, recall 0.894->0.848",
+      "note": "Extraction works (29%->95% coverage by forward-fill); it is the PREFIXING that loses."
+    },
+    {
+      "name": "Cross-encoder reranking",
+      "ships": "OFF",
+      "evidence": "hit 0.939->0.879, latency 274->761 ms",
+      "note": "ms-marco model is out of domain for operator phrasing against agronomy prose."
+    },
+    {
+      "name": "Query rewriting",
+      "ships": "NOT BUILT",
+      "note": "Three prefix/expansion techniques already lost for the same reason; adding vocabulary to a corpus that shares one vocabulary domain dilutes rather than disambiguates."
+    }
+  ],
+  "the_pattern": "Four of the eight measured techniques LOST, and three of those four share one mechanism: they add topic words (a section crumb, a chapter name, a heading) to chunks in a corpus where every document already shares a vocabulary domain. Words that appear in every chunk about a topic carry no discriminating information \u2014 they only dilute the distinctive content already in the vector. What DID work was structural instead of lexical: refusing irrelevant passages, refusing error pages, and refusing to let one source occupy every slot."
+}

--- a/requirement.txt
+++ b/requirement.txt
@@ -17,6 +17,8 @@ python-telegram-bot[job-queue]>=21  # Telegram bot (agronaut_agent/channels/tele
 # faster-whisper                    # OPTIONAL: local speech-to-text for voice notes (ASR_PROVIDER=local). Install only for voice; offline after first model download.
 # langchain-openai                  # OPTIONAL: self-hosted OpenAI-compatible tool-calling backend (LLM_PROVIDER=openai_compat, e.g. vLLM/llama.cpp). Zero-proprietary-API path.
 faiss-cpu
+rank_bm25                           # keyword half of hybrid retrieval (agronaut_agent/rag.py). Imported lazily and shipped disabled by default (see hybrid_enabled()), but REQUIRED: without it hybrid silently degrades to dense-only instead of failing.
+pypdf                               # extracts text from PDF knowledge sources — FAO/extension publications are PDFs (srcs/chatbot.py _pdf_documents). Without it every PDF source silently contributes zero chunks.
 Pillow                              # renders the PNG system schematic (aqua_model/schematic.py to_png)
 openpyxl
 streamlit

--- a/scripts/corpus_report.py
+++ b/scripts/corpus_report.py
@@ -1,0 +1,368 @@
+"""Corpus verification gate — what does each declared knowledge source ACTUALLY contribute?
+
+A RAG system is only as good as the text it can retrieve, and a source can fail silently in
+three different ways: it can refuse the fetch (403/timeout), it can return a page that is all
+navigation chrome and no substance (a JS redirect shim is ~11 characters of visible text), or
+— the dangerous one — it can return plenty of healthy-looking text about the wrong subject,
+because a publication ID silently resolved to a different article.
+
+This script catches all three. For every entry in urls.txt and every knowledge/*.md it reports
+the fetch status, the extracted characters, the chunks that survive boilerplate filtering, and
+a topic-drift check against the curated LABEL. It re-uses the real loader and the real splitter
+from srcs.chatbot, so the chunk counts are the ones the index would actually get — but it stops
+short of embedding, so it needs no model and no GPU.
+
+Run it:
+    python -m scripts.corpus_report              # table; exits non-zero if a source is dead
+    python -m scripts.corpus_report --json       # machine-readable, for CI
+    python -m scripts.corpus_report --offline    # local knowledge only, no network
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
+
+from srcs.chatbot import (  # noqa: E402
+    CHUNK_OVERLAP, CHUNK_SIZE, KNOWLEDGE_DIR, URL_FILE, WEB_LOAD_TIMEOUT,
+    _is_boilerplate_text, _pdf_documents, _probe_url, load_web_page, parse_urls_file,
+)
+
+# Words that carry no topic signal, so their presence in a LABEL proves nothing about whether
+# the page we fetched is the page we meant to cite.
+_STOPWORDS = {
+    "the", "and", "for", "with", "from", "into", "a", "an", "of", "in", "on", "to", "by",
+    "guide", "manual", "handbook", "publication", "report", "paper", "study", "edition",
+    "volume", "part", "vol", "no", "pp", "university", "extension", "press", "journal",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    """Topic-bearing words: lowercase, alphanumeric, >3 chars, not a stopword."""
+    return {w for w in re.findall(r"[a-z0-9]+", (text or "").lower())
+            if len(w) > 3 and w not in _STOPWORDS}
+
+
+_CC_RE = re.compile(r"creativecommons\.org/licenses/([a-z\-]+)/([0-9.]+)")
+
+
+_LICENCE_PHRASES = [
+    (re.compile(r"CC[ \-]?BY[\- ]NC[\- ]SA[\- ]?([0-9.]+)?\s*(IGO)?", re.I), "CC BY-NC-SA"),
+    (re.compile(r"CC[ \-]?BY[\- ]NC[\- ]?([0-9.]+)?\s*(IGO)?", re.I), "CC BY-NC"),
+    (re.compile(r"CC[ \-]?BY[\- ]SA[\- ]?([0-9.]+)?", re.I), "CC BY-SA"),
+    (re.compile(r"CC[ \-]?BY[\- ]?([0-9.]+)", re.I), "CC BY"),
+    (re.compile(r"creative\s+commons", re.I), "Creative Commons (unspecified)"),
+    (re.compile(r"public\s+domain", re.I), "Public domain"),
+    # FAO publications from before their Creative Commons adoption carry a bespoke permissive
+    # grant instead of a CC licence. It is genuinely open for educational/non-commercial reuse
+    # with attribution, so treating it as "unlicensed" would wrongly exclude FAO 589 — the single
+    # most authoritative small-scale aquaponics reference there is.
+    (re.compile(r"reproduction and dissemination of material in this information product",
+                re.I), "FAO permissive (educational/non-commercial, attribution)"),
+]
+
+
+def detect_licence_in_text(text: str) -> str:
+    """Licence declared in a PDF's own text. A PDF carries no HTML licence link, so without this
+    every PDF looks unlicensed — which would falsely reject FAO's entire catalogue, exactly the
+    open-licence material the corpus most wants."""
+    # Whitespace is normalised first: PDF text extraction wraps lines mid-sentence, so a licence
+    # phrase is routinely split by a newline and no amount of widening the window will match it.
+    # Wide enough to reach the imprint page of a full-length publication too — in FAO 589 the
+    # rights statement sits on page 4, past 6 000 characters of front matter.
+    head = " ".join((text or "")[:30000].split())
+    for rx, name in _LICENCE_PHRASES:
+        m = rx.search(head)
+        if m:
+            ver = next((g for g in (m.groups() or ()) if g and g[0].isdigit()), "")
+            igo = " IGO" if "igo" in m.group(0).lower() else ""
+            return f"{name} {ver}{igo}".strip()
+    return ""
+
+
+def detect_licence(html: str) -> str:
+    """The Creative Commons licence a page declares, or "" if it declares none.
+
+    Agronaut is a Digital Public Good, so the corpus can only carry openly licensed text. In
+    practice this doubles as a retrievability signal: every source measured so far that returned
+    usable full text was CC BY, and every paywalled one returned nothing.
+    """
+    found = sorted(set(_CC_RE.findall(html or "")))
+    return ", ".join(f"CC {a.upper()} {b}" for a, b in found)
+
+
+def _fetch_http_metadata(url: str) -> dict:
+    """Status, final URL and <title> — the signals load_web_page throws away but that we need
+    to tell 'fetched the wrong article' apart from 'fetched the right one'."""
+    try:
+        import requests
+        r = requests.get(url, timeout=WEB_LOAD_TIMEOUT, allow_redirects=True,
+                         headers={"User-Agent": "Mozilla/5.0 (compatible; AgronautCorpusReport/1.0)"})
+        title = ""
+        ctype = r.headers.get("Content-Type", "")
+        if "html" in ctype.lower():
+            m = re.search(r"<title[^>]*>(.*?)</title>", r.text, re.S | re.I)
+            if m:
+                title = re.sub(r"\s+", " ", m.group(1)).strip()[:200]
+        licence = detect_licence(r.text) if "html" in ctype.lower() else ""
+        return {"status": str(r.status_code), "final_url": r.url, "title": title,
+                "content_type": ctype.split(";")[0], "licence": licence}
+    except Exception as exc:
+        return {"status": f"{type(exc).__name__}", "final_url": "", "title": "",
+                "content_type": "", "licence": ""}
+
+
+def _pdf_title(content: bytes) -> str:
+    """The /Title (or /Subject) a PDF declares in its metadata."""
+    try:
+        import io
+        from pypdf import PdfReader
+        info = PdfReader(io.BytesIO(content)).metadata or {}
+        return str(info.get("/Title") or info.get("/Subject") or "")[:200]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _split(documents) -> int:
+    """Chunks that survive the boilerplate filter — mirrors build_vector_store's pipeline
+    minus the embedding step."""
+    if not documents:
+        return 0
+    splitter = RecursiveCharacterTextSplitter(chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP)
+    return sum(1 for d in splitter.split_documents(documents)
+               if not _is_boilerplate_text(getattr(d, "page_content", "")))
+
+
+def _drift_in_text(label: str, text: str) -> str:
+    """Topic check for a PDF, run against its opening text instead of an HTML <title>."""
+    want = _tokens(label)
+    if not want:
+        return "unlabeled"
+    have = _tokens((text or "")[:4000])
+    if not have:
+        return ""
+    return "" if (want & have) else "DRIFT"
+
+
+# Bot-protection interstitials. Their <title> describes the challenge, not the document, so
+# treating one as the page's identity produces a spurious "wrong topic" verdict on a source whose
+# content fetch actually succeeded.
+_CHALLENGE_TITLES = ("client challenge", "just a moment", "attention required",
+                     "access denied", "are you a robot", "checking your browser")
+
+
+def _is_challenge_title(title: str) -> bool:
+    t = (title or "").strip().lower()
+    return any(c in t for c in _CHALLENGE_TITLES)
+
+
+def _drift(label: str, meta: dict, body: str = "") -> str:
+    """'' when the fetched page plausibly IS the cited work, else why we doubt it.
+
+    An unlabeled URL cannot be checked — that is itself worth reporting, because it means
+    nothing would catch the page silently becoming a different article.
+    """
+    want = _tokens(label)
+    if not want:
+        return "unlabeled"
+    title = meta.get("title", "")
+    haystack = _tokens(meta.get("final_url", ""))
+    if not _is_challenge_title(title):
+        haystack |= _tokens(title)
+    # The retrieved BODY is the strongest evidence of what was actually indexed. A title fetched
+    # in a separate request can be a bot challenge while the content request succeeded, so judging
+    # on the title alone flags a healthy source as drifted.
+    haystack |= _tokens(body[:4000])
+    if not haystack:
+        return ""            # nothing to compare against; the chunk count is the real verdict
+    return "" if (want & haystack) else "DRIFT"
+
+
+def _audit_url(entry: dict) -> dict:
+    url, label = entry["url"], entry.get("label", "")
+    # HTML metadata (title/licence) is only meaningful for HTML, and fetching it for a PDF means
+    # downloading a 262-page publication a second time purely to look for a <title> it does not
+    # have. Probe once, then only ask for metadata when it can exist.
+    probe = _probe_url(url)
+    if probe is not None and probe["is_pdf"]:
+        docs = _pdf_documents(probe["content"], url)
+        opening = " ".join(d.page_content for d in docs[:12])
+        meta = {"status": str(probe["status"]), "final_url": url,
+                "title": _pdf_title(probe["content"]),
+                "content_type": probe["content_type"],
+                "licence": detect_licence_in_text(opening)}
+        chars = sum(len(d.page_content) for d in docs)
+        return {
+            "kind": "url", "source": url, "label": label,
+            "category": entry.get("category", ""), "status": meta["status"],
+            "final_url": url, "title": meta["title"], "content_type": meta["content_type"],
+            "chars": chars, "chunks": _split(docs),
+            "drift": _drift_in_text(label, opening) if label else "unlabeled",
+            "licence": meta["licence"] or entry.get("licence", ""),
+        }
+    else:
+        meta = _fetch_http_metadata(url)
+        docs = load_web_page(url)
+    chars = sum(len(getattr(d, "page_content", "")) for d in docs)
+    chunks = _split(docs)
+    body = " ".join(getattr(d, "page_content", "") for d in docs[:3])
+    return {
+        "kind": "url", "source": url, "label": label, "category": entry.get("category", ""),
+        "status": meta["status"], "final_url": meta["final_url"], "title": meta["title"],
+        "content_type": meta["content_type"], "chars": chars, "chunks": chunks,
+        "drift": _drift(label, meta, body), "licence": meta.get("licence", "") or entry.get("licence", ""),
+    }
+
+
+def _audit_local(path: Path) -> dict:
+    from langchain_community.document_loaders import TextLoader
+    docs = TextLoader(str(path), encoding="utf-8").load()
+    return {
+        "kind": "local", "source": str(path.relative_to(Path(KNOWLEDGE_DIR).parent)),
+        "label": "", "category": "LOCAL", "status": "200", "final_url": "", "title": "",
+        "content_type": "text/markdown", "licence": "first-party",
+        "chars": sum(len(d.page_content) for d in docs), "chunks": _split(docs), "drift": "",
+    }
+
+
+def run(offline: bool = False) -> dict:
+    rows = [_audit_local(p) for p in sorted(Path(KNOWLEDGE_DIR).glob("*.md"))]
+    entries = parse_urls_file(URL_FILE)
+    if offline:
+        entries = []
+    if entries:
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            rows.extend(pool.map(_audit_url, entries))
+
+    dead = [r for r in rows if r["chunks"] == 0]
+    drifted = [r for r in rows if r["drift"] == "DRIFT"]
+    return {
+        "rows": rows,
+        "totals": {
+            "sources": len(rows),
+            "local_files": sum(1 for r in rows if r["kind"] == "local"),
+            "urls": sum(1 for r in rows if r["kind"] == "url"),
+            "chunks": sum(r["chunks"] for r in rows),
+            "chunks_local": sum(r["chunks"] for r in rows if r["kind"] == "local"),
+            "chunks_web": sum(r["chunks"] for r in rows if r["kind"] == "url"),
+        },
+        "dead": [r["source"] for r in dead],
+        "drifted": [r["source"] for r in drifted],
+        "ok": not dead and not drifted,
+    }
+
+
+def _print_table(report: dict) -> None:
+    rows, tot = report["rows"], report["totals"]
+    width = min(58, max((len(r["source"]) for r in rows), default=20))
+    print(f"{'SOURCE':<{width}}  {'STATUS':>10}  {'CHARS':>8}  {'CHUNKS':>6}  NOTE")
+    print("-" * (width + 40))
+    for r in sorted(rows, key=lambda r: (r["kind"], r["source"])):
+        src = r["source"]
+        if len(src) > width:
+            src = "…" + src[-(width - 1):]
+        note = ""
+        if r["drift"] == "DRIFT":
+            note = f"WRONG TOPIC? title={r['title'][:44]!r}"
+        elif r["drift"] == "unlabeled":
+            note = "no LABEL — drift undetectable"
+        elif r["chunks"] == 0:
+            note = "contributes nothing"
+        print(f"{src:<{width}}  {r['status']:>10}  {r['chars']:>8}  {r['chunks']:>6}  {note}")
+
+    print("-" * (width + 40))
+    print(f"{tot['local_files']} local files -> {tot['chunks_local']} chunks   "
+          f"{tot['urls']} URLs -> {tot['chunks_web']} chunks   "
+          f"TOTAL {tot['chunks']} chunks")
+    if report["dead"]:
+        print(f"\nDEAD ({len(report['dead'])}) — declared but contribute 0 chunks:")
+        for s in report["dead"]:
+            print(f"  - {s}")
+    if report["drifted"]:
+        print(f"\nTOPIC DRIFT ({len(report['drifted'])}) — fetched page may not be the cited work:")
+        for s in report["drifted"]:
+            print(f"  - {s}")
+
+
+def vet(url: str, label: str = "") -> dict:
+    """Vet ONE proposed source before it is allowed into urls.txt.
+
+    Adding sources by hand is how a corpus rots: a publication ID silently resolves to a different
+    article, a repository turns out to be JS-driven and serves 300 characters of navigation, or the
+    text is real but not openly licensed. This answers all four questions at once — reachable,
+    substantial, on-topic, openly licensed — so a source is only added on evidence.
+    """
+    row = _audit_url({"url": url, "label": label, "category": "CANDIDATE", "licence": ""})
+    verdict, reasons = "ACCEPT", []
+    if not row["status"].isdigit() or not (200 <= int(row["status"]) < 300):
+        verdict, reasons = "REJECT", reasons + [f"not reachable (status {row['status']})"]
+    if row["chunks"] == 0:
+        verdict, reasons = "REJECT", reasons + ["contributes 0 chunks after filtering"]
+    elif row["chunks"] < 3:
+        verdict = "REVIEW" if verdict == "ACCEPT" else verdict
+        reasons.append(f"only {row['chunks']} chunks - likely a landing page, not full text")
+    if row["drift"] == "DRIFT":
+        verdict, reasons = "REJECT", reasons + [
+            f"topic drift: fetched title is {row['title'][:60]!r}, not {label!r}"]
+    lic = row["licence"]
+    if not lic:
+        verdict = "REVIEW" if verdict == "ACCEPT" else verdict
+        reasons.append("no open licence detected - confirm terms before indexing")
+    elif not lic.startswith("CC BY") and "Public domain" not in lic:
+        verdict = "REVIEW" if verdict == "ACCEPT" else verdict
+        reasons.append(f"licence is {lic!r} - permissive but not Creative Commons; confirm it is "
+                       "compatible with redistributing Agronaut as a Digital Public Good")
+    row.update(verdict=verdict, reasons=reasons)
+    return row
+
+
+def _print_vet(row: dict) -> None:
+    print(f"\nCANDIDATE  {row['source']}")
+    print(f"  status      {row['status']}   content-type {row['content_type'] or 'n/a'}")
+    print(f"  resolves to {row['final_url'][:100] or 'n/a'}")
+    print(f"  title       {row['title'][:100] or 'n/a'}")
+    print(f"  extracted   {row['chars']} chars -> {row['chunks']} chunks")
+    print(f"  licence     {row['licence'] or 'NOT DETECTED'}")
+    print(f"\n  VERDICT: {row['verdict']}")
+    for r in row["reasons"]:
+        print(f"    - {r}")
+    if row["verdict"] == "ACCEPT":
+        lic = row["licence"] or "CONFIRM-LICENCE"
+        print(f"\n  add to urls.txt as:\n    CATEGORY|{row['source']}|{row['label'] or 'LABEL'}|{lic}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="machine-readable output for CI")
+    ap.add_argument("--offline", action="store_true", help="skip URLs; audit knowledge/ only")
+    ap.add_argument("--candidate", metavar="URL",
+                    help="vet a PROPOSED source without adding it to the corpus")
+    ap.add_argument("--label", default="", help="expected topic of --candidate, for drift checking")
+    args = ap.parse_args()
+
+    if args.candidate:
+        row = vet(args.candidate, args.label)
+        if args.json:
+            print(json.dumps(row, indent=2))
+        else:
+            _print_vet(row)
+        return 0 if row["verdict"] == "ACCEPT" else 1
+
+    report = run(offline=args.offline)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_table(report)
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/retrieval_eval.py
+++ b/scripts/retrieval_eval.py
@@ -1,0 +1,234 @@
+"""Retrieval quality scorer — recall@k, precision@k, MRR and MAP@k over a golden set.
+
+The course's central discipline (M2): you cannot tune a retriever you do not measure. Every
+technique that follows — header-aware chunking, BM25 hybrid, reciprocal rank fusion, a
+cross-encoder reranker — is an unverifiable guess until there is a number that moves.
+
+Metrics are computed at DOCUMENT granularity (which source file was surfaced), not chunk
+granularity, because that is what the golden set can honestly label and what decides whether the
+agent can answer. Three chunks from the right file is one correct document, not three.
+
+The metric functions are pure and take plain lists, so agronaut_agent/tests/test_retrieval_eval.py
+verifies the arithmetic hermetically — no index, no embedding model, no network.
+
+Run it:
+    python -m scripts.retrieval_eval                        # score, print a table
+    python -m scripts.retrieval_eval --save baseline.json   # record a baseline
+    python -m scripts.retrieval_eval --compare baseline.json  # print the delta vs that baseline
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+_GOLDEN = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "retrieval_eval" / "golden_set.json"
+
+
+# --- pure metrics (no index, no model — unit-testable) -----------------------
+
+def dedupe(sources: list[str]) -> list[str]:
+    """Retrieved chunks collapsed to distinct source documents, ranking order preserved."""
+    seen, out = set(), []
+    for s in sources:
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def precision_at_k(retrieved: list[str], relevant: set[str]) -> float:
+    """Of the documents we returned, what fraction were relevant."""
+    if not retrieved:
+        return 0.0
+    return sum(1 for s in retrieved if s in relevant) / len(retrieved)
+
+
+def recall_at_k(retrieved: list[str], relevant: set[str]) -> float:
+    """Of the documents that should have been found, what fraction we returned."""
+    if not relevant:
+        return 0.0
+    return sum(1 for s in retrieved if s in relevant) / len(relevant)
+
+
+def reciprocal_rank(retrieved: list[str], relevant: set[str]) -> float:
+    """1 / rank of the first relevant document — how near the top the first good hit lands."""
+    for i, s in enumerate(retrieved, start=1):
+        if s in relevant:
+            return 1.0 / i
+    return 0.0
+
+
+def average_precision(retrieved: list[str], relevant: set[str], k: int) -> float:
+    """Mean of precision@i taken at each rank i that holds a relevant document.
+    Rewards ranking the relevant documents HIGH, not merely including them."""
+    if not relevant:
+        return 0.0
+    hits, total = 0, 0.0
+    for i, s in enumerate(retrieved, start=1):
+        if s in relevant:
+            hits += 1
+            total += hits / i
+    denom = min(len(relevant), k)
+    return total / denom if denom else 0.0
+
+
+def score_query(retrieved_sources: list[str], relevant: list[str], k: int) -> dict:
+    docs = dedupe(retrieved_sources)[:k]
+    rel = set(relevant)
+    return {
+        "retrieved": docs,
+        "hit": any(s in rel for s in docs),
+        "precision": precision_at_k(docs, rel),
+        "recall": recall_at_k(docs, rel),
+        "rr": reciprocal_rank(docs, rel),
+        "ap": average_precision(docs, rel, k),
+    }
+
+
+def aggregate(per_query: list[dict], k: int) -> dict:
+    n = len(per_query) or 1
+    return {
+        "queries": len(per_query),
+        "k": k,
+        "hit_rate": sum(1 for r in per_query if r["hit"]) / n,
+        "precision@k": sum(r["precision"] for r in per_query) / n,
+        "recall@k": sum(r["recall"] for r in per_query) / n,
+        "MRR": sum(r["rr"] for r in per_query) / n,
+        "MAP@k": sum(r["ap"] for r in per_query) / n,
+    }
+
+
+# --- the live run ------------------------------------------------------------
+
+def run(k: int | None = None, retrieve=None, unfiltered=None, no_floor: bool = False) -> dict:
+    """Score the golden set.
+
+    `retrieve` is injectable (query, k) -> list of hit dicts; defaults to the real index.
+    `unfiltered` is the same retriever with the relevance floor DISABLED — the negative controls
+    need raw distances, because a floor that has already discarded them tells us nothing about
+    whether it was set at the right place.
+    """
+    golden = json.loads(_GOLDEN.read_text())
+    k = k or golden.get("k", 3)
+    if retrieve is None:
+        from agronaut_agent import rag
+        inf = float("inf")
+        retrieve = (lambda q, kk: rag.retrieve(q, kk, max_dist=inf)) if no_floor else rag.retrieve
+        if unfiltered is None:
+            unfiltered = lambda q, kk: rag.retrieve(q, kk, max_dist=inf)  # noqa: E731
+    if unfiltered is None:
+        unfiltered = retrieve
+
+    per_query, latencies = [], []
+    for q in golden["queries"]:
+        t0 = time.perf_counter()
+        hits = retrieve(q["query"], k)
+        latencies.append((time.perf_counter() - t0) * 1000)
+        row = score_query([h["source"] for h in hits], q["relevant"], k)
+        row.update(id=q["id"], query=q["query"], relevant=q["relevant"],
+                   top_score=hits[0]["score"] if hits else None)
+        per_query.append(row)
+
+    # Negative controls carry no relevant set — their value is the SCORE distribution, which is
+    # what a relevance floor has to be calibrated against (a floor that also rejects real
+    # queries is worse than no floor).
+    negatives = []
+    for q in golden.get("negative_controls", []):
+        raw = unfiltered(q["query"], k)          # raw distances, for calibrating the floor
+        kept = retrieve(q["query"], k)           # what the operator would actually be shown
+        negatives.append({"id": q["id"], "query": q["query"],
+                          "top_score": raw[0]["score"] if raw else None,
+                          "returned": [h["source"] for h in kept],
+                          "rejected_by_floor": bool(raw) and not kept})
+
+    # On-topic distances also measured unfiltered, so the two bands are compared on equal terms.
+    for row, q in zip(per_query, golden["queries"]):
+        raw = unfiltered(q["query"], k)
+        row["raw_top_score"] = raw[0]["score"] if raw else None
+        row["floor_returned_nothing"] = not retrieve(q["query"], k)
+
+    summary = aggregate(per_query, k)
+    summary["latency_ms_mean"] = sum(latencies) / (len(latencies) or 1)
+    summary["floor_silenced_on_topic"] = sum(1 for r in per_query if r["floor_returned_nothing"])
+    summary["floor_rejected_off_topic"] = sum(1 for n in negatives if n["rejected_by_floor"])
+    summary["negative_controls"] = len(negatives)
+    return {"summary": summary, "per_query": per_query, "negative_controls": negatives}
+
+
+def _print(report: dict, baseline: dict | None = None) -> None:
+    s = report["summary"]
+    print(f"\nRETRIEVAL @k={s['k']}  ({s['queries']} queries)")
+    print("-" * 62)
+    keys = ["hit_rate", "recall@k", "precision@k", "MRR", "MAP@k"]
+    for key in keys:
+        line = f"  {key:<14} {s[key]:.3f}"
+        if baseline:
+            d = s[key] - baseline["summary"][key]
+            line += f"   ({d:+.3f} vs baseline)"
+        print(line)
+    print(f"  {'latency':<14} {s['latency_ms_mean']:.0f} ms/query")
+
+    misses = [r for r in report["per_query"] if not r["hit"]]
+    if misses:
+        print(f"\nMISSES ({len(misses)}/{s['queries']}) — nothing relevant in the top {s['k']}:")
+        for r in misses:
+            print(f"  [{r['id']}] {r['query']}")
+            print(f"        wanted: {', '.join(r['relevant'])}")
+            print(f"        got:    {', '.join(r['retrieved']) or '(nothing)'}")
+
+    negs = report["negative_controls"]
+    if negs:
+        print("\nNEGATIVE CONTROLS — off-topic queries (a relevance floor should reject these):")
+        for n in negs:
+            score = "n/a" if n["top_score"] is None else f"{n['top_score']:.3f}"
+            mark = "REJECTED by floor" if n.get("rejected_by_floor") else (
+                ", ".join(n["returned"]) or "(nothing)")
+            print(f"  [{n['id']}] raw_top_distance={score}  -> {mark}")
+        print(f"\n  floor rejected {s.get('floor_rejected_off_topic', 0)}/{len(negs)} off-topic queries")
+        print(f"  floor silenced {s.get('floor_silenced_on_topic', 0)}/{s['queries']} REAL queries"
+              "  <- must stay 0")
+        on_topic = [r.get("raw_top_score") for r in report["per_query"]
+                    if r.get("raw_top_score") is not None]
+        off_topic = [n["top_score"] for n in negs if n["top_score"] is not None]
+        if on_topic and off_topic:
+            # FAISS L2: LOWER is closer. A floor is only viable if the two bands separate.
+            print(f"\n  on-topic  worst(max) distance: {max(on_topic):.3f}")
+            print(f"  off-topic best(min) distance: {min(off_topic):.3f}")
+            verdict = ("separable — a floor can work"
+                       if min(off_topic) > max(on_topic) else
+                       "OVERLAPPING — a single global floor would reject real queries too")
+            print(f"  -> {verdict}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--k", type=int, default=None)
+    ap.add_argument("--save", metavar="FILE", help="write this run as a baseline")
+    ap.add_argument("--compare", metavar="FILE", help="print deltas against a saved baseline")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-floor", action="store_true",
+                    help="measure retrieval with the relevance floor disabled")
+    args = ap.parse_args()
+
+    report = run(k=args.k, no_floor=args.no_floor)
+    baseline = json.loads(Path(args.compare).read_text()) if args.compare else None
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print(report, baseline)
+
+    if args.save:
+        Path(args.save).write_text(json.dumps(report, indent=2))
+        print(f"\nbaseline saved -> {args.save}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/retrieval_eval.py
+++ b/scripts/retrieval_eval.py
@@ -125,6 +125,17 @@ def run(k: int | None = None, retrieve=None, unfiltered=None, no_floor: bool = F
     if unfiltered is None:
         unfiltered = retrieve
 
+    def nearest(hits):
+        """The smallest L2 distance in a result set.
+
+        NOT hits[0]'s score: once hybrid fusion is on, reciprocal-rank fusion reorders results, so
+        the first-ranked hit is frequently not the closest one — and a keyword-only hit carries no
+        distance at all. Calibrating a distance floor against a fused rank silently compares the
+        wrong numbers.
+        """
+        scored = [h["score"] for h in hits if h.get("score") is not None]
+        return min(scored) if scored else None
+
     per_query, latencies = [], []
     for q in golden["queries"]:
         t0 = time.perf_counter()
@@ -132,7 +143,7 @@ def run(k: int | None = None, retrieve=None, unfiltered=None, no_floor: bool = F
         latencies.append((time.perf_counter() - t0) * 1000)
         row = score_query([h["source"] for h in hits], q["relevant"], k)
         row.update(id=q["id"], query=q["query"], relevant=q["relevant"],
-                   top_score=hits[0]["score"] if hits else None)
+                   top_score=nearest(hits))
         per_query.append(row)
 
     # Negative controls carry no relevant set — their value is the SCORE distribution, which is
@@ -143,14 +154,14 @@ def run(k: int | None = None, retrieve=None, unfiltered=None, no_floor: bool = F
         raw = unfiltered(q["query"], k)          # raw distances, for calibrating the floor
         kept = retrieve(q["query"], k)           # what the operator would actually be shown
         negatives.append({"id": q["id"], "query": q["query"],
-                          "top_score": raw[0]["score"] if raw else None,
+                          "top_score": nearest(raw),
                           "returned": [h["source"] for h in kept],
                           "rejected_by_floor": bool(raw) and not kept})
 
     # On-topic distances also measured unfiltered, so the two bands are compared on equal terms.
     for row, q in zip(per_query, golden["queries"]):
         raw = unfiltered(q["query"], k)
-        row["raw_top_score"] = raw[0]["score"] if raw else None
+        row["raw_top_score"] = nearest(raw)
         row["floor_returned_nothing"] = not retrieve(q["query"], k)
 
     summary = aggregate(per_query, k)

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -405,26 +405,29 @@ def _crumb_enabled() -> bool:
 
 
 def markdown_headers_enabled() -> bool:
-    """Header-aware chunking ships DISABLED, on evidence — docs/dpg/retrieval_eval/chunking_ablation.json.
+    """Header-aware chunking ships DISABLED — docs/dpg/retrieval_eval/chunking_ablation.json.
 
-        variant                              hit    recall  prec    MRR     MAP
-        A  baseline (character splitter)     0.970  0.919   0.626   0.909   0.869
-        B  header split, no prefix           0.939  0.889   0.606   0.843   0.793
-        C  header split + context prefix     0.909  0.879   0.722   0.848   0.818
+    Ablated on two corpora. Baseline wins both times:
 
-    The ablation separates two effects usually bundled together: the SPLIT costs quality (B loses
-    on all five metrics), while the CONTEXT PREFIX genuinely helps (C gains 0.116 precision over
-    B). Baseline still wins overall.
+        corpus        variant                       hit    recall  prec    MRR     MAP
+        362 chunks    A baseline                    0.970  0.919   0.626   0.909   0.869
+                      C header split + prefix       0.909  0.879   0.722   0.848   0.818
+        1354 chunks   A baseline                    0.848  0.788   0.495   0.692   0.636
+                      C header split + prefix       0.758  0.667   0.444   0.621   0.538
 
-    The cause is corpus geometry rather than the technique. 95% of this corpus's 123 sections are
-    SMALLER than the 800-character chunk window (mean 381 chars), so the recursive splitter was
-    already packing about two related sections into each chunk, and splitting on headings
-    fragments that useful co-occurrence into context-poor pieces.
+    95% of the hand-authored corpus's 123 sections are SMALLER than the 800-character chunk window
+    (mean 381), so the recursive splitter already packs about two related sections per chunk and
+    splitting on headings fragments that useful co-occurrence.
 
-    That reasoning predicts exactly when to turn this on: documents whose sections are LARGER than
-    the chunk window. FAO 589 is 275 pages, and blind 800-character windows across a book ignore
-    every structural boundary in it. The natural end state is header chunking for PDF sources and
-    the character splitter for the short hand-authored corpus. Enable with AGRONAUT_MD_HEADERS=on.
+    The CONTEXT PREFIX reversed sign between the two runs, which is worth knowing before reaching
+    for it elsewhere: on the small uniform corpus it gained 0.116 precision by disambiguating a
+    chunk among 21 similar files; once a 992-chunk book joined the index the same added words made
+    curated chunks read as generic aquaponics prose and compete WORSE against it. The value of a
+    preprocessing step is a property of the corpus it runs on.
+
+    Note this splits MARKDOWN only — FAO 589 reaches the character splitter either way, so the
+    ablation does not test structural chunking of the PDF itself. That is unimplemented and is the
+    more promising direction for book-length sources. Enable with AGRONAUT_MD_HEADERS=on.
     """
     import os
     return os.getenv("AGRONAUT_MD_HEADERS", "").lower() in {"on", "1", "true"}
@@ -1709,7 +1712,14 @@ def _corpus_fingerprint() -> str:
     """
     import hashlib
     h = hashlib.sha256()
-    h.update(f"{EMBEDDING_MODEL}|{CHUNK_SIZE}|{CHUNK_OVERLAP}".encode())
+    # The chunking FLAGS belong here as much as the chunk size does: they change what text ends up
+    # in each vector, so an index built with one setting is simply wrong for another. Omitting
+    # them meant toggling AGRONAUT_MD_HEADERS or AGRONAUT_PDF_CLEAN silently reused a stale index
+    # — an ablation that appears to measure a setting while actually re-reading the previous one.
+    h.update(f"{EMBEDDING_MODEL}|{CHUNK_SIZE}|{CHUNK_OVERLAP}"
+             f"|md_headers={markdown_headers_enabled()}"
+             f"|md_crumb={_crumb_enabled()}"
+             f"|pdf_clean={pdf_cleaning_enabled()}".encode())
     kb = pathlib.Path(KNOWLEDGE_DIR)
     if kb.exists():
         for fp in sorted(kb.rglob("*")):

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -1525,7 +1525,88 @@ def handle_turn(user: str) -> None:
 # =============================================================================
 
 
+INDEX_CACHE_DIR = _PROJECT_ROOT / "data" / ".index_cache"
+INDEX_CACHE_TTL = 7 * 86_400   # web sources are re-fetched at most weekly
+
+
+def _corpus_fingerprint() -> str:
+    """Identity of the corpus AND the parameters that shape it.
+
+    Covers the local knowledge files, urls.txt, the embedding model and the chunk geometry, so
+    changing any of them invalidates the cache automatically. It cannot see a WEB source being
+    silently edited by its publisher — detecting that would mean fetching, which is the cost the
+    cache exists to avoid — so a TTL bounds how stale web content may get.
+    """
+    import hashlib
+    h = hashlib.sha256()
+    h.update(f"{EMBEDDING_MODEL}|{CHUNK_SIZE}|{CHUNK_OVERLAP}".encode())
+    kb = pathlib.Path(KNOWLEDGE_DIR)
+    if kb.exists():
+        for fp in sorted(kb.rglob("*")):
+            if fp.suffix.lower() in {".md", ".txt"}:
+                h.update(fp.name.encode())
+                h.update(fp.read_bytes())
+    urls = pathlib.Path(URL_FILE)
+    if urls.exists():
+        h.update(urls.read_bytes())
+    return h.hexdigest()[:16]
+
+
+def _index_cache_enabled() -> bool:
+    import os
+    return os.getenv("AGRONAUT_INDEX_CACHE", "").lower() not in {"off", "0", "false"}
+
+
+def _load_cached_index(fingerprint: str):
+    """A previously built index for this exact corpus, or None.
+
+    Rebuilding costs a network fetch per source plus embedding every chunk. That was tolerable at
+    365 chunks of HTML; it is not once a corpus includes a 56 MB, 275-page publication that takes
+    47 s just to download.
+    """
+    import os
+    import time
+    if not _index_cache_enabled():
+        return None
+    path = INDEX_CACHE_DIR / fingerprint
+    if not (path / "index.faiss").exists():
+        return None
+    age = time.time() - (path / "index.faiss").stat().st_mtime
+    if age > INDEX_CACHE_TTL:
+        logging.info("Knowledge index cache is %.1f days old; rebuilding", age / 86_400)
+        return None
+    try:
+        embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL)
+        # allow_dangerous_deserialization: this pickle is one WE wrote, under the project's own
+        # data directory, keyed by a hash of our own corpus — not third-party input.
+        index = FAISS.load_local(str(path), embeddings,
+                                 allow_dangerous_deserialization=True)
+        logging.info("Loaded knowledge index from cache (%s, %.1f h old)",
+                     fingerprint, age / 3600)
+        return index
+    except Exception as err:  # noqa: BLE001 — a bad cache must never block a rebuild
+        logging.warning("Ignoring unreadable index cache %s — %s", fingerprint, err)
+        return None
+
+
+def _save_cached_index(index, fingerprint: str) -> None:
+    if not _index_cache_enabled():
+        return
+    try:
+        path = INDEX_CACHE_DIR / fingerprint
+        path.mkdir(parents=True, exist_ok=True)
+        index.save_local(str(path))
+        logging.info("Cached knowledge index -> %s", path)
+    except Exception as err:  # noqa: BLE001 — caching is an optimisation, never a hard failure
+        logging.warning("Could not cache knowledge index — %s", err)
+
+
 def build_rag_index_from_urls() -> Optional[FAISS]:
+    fingerprint = _corpus_fingerprint()
+    cached = _load_cached_index(fingerprint)
+    if cached is not None:
+        return cached
+
     url_entries = parse_urls_file(URL_FILE)
     urls = [e["url"] for e in url_entries]
     if not urls:
@@ -1553,10 +1634,12 @@ def build_rag_index_from_urls() -> Optional[FAISS]:
         return None
 
     try:
-        return build_vector_store(documents)
+        index = build_vector_store(documents)
     except Exception as err:  # noqa: BLE001
         logging.warning("Failed to build FAISS index – %s", err)
         return None
+    _save_cached_index(index, fingerprint)
+    return index
 
 
 def chat() -> None:

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -224,6 +224,89 @@ def _probe_url(url: str) -> dict | None:
     }
 
 
+def _normalise_for_repetition(line: str) -> str:
+    """A line with its PAGE NUMBER removed, for detecting text that repeats across pages.
+
+    Only leading and trailing digits are stripped, because that is where page numbers sit —
+    "...plant farming62" and "61Design of aquaponic units". Stripping digits everywhere would
+    make lines that differ ONLY by an interior number collapse into one string, so a genuine
+    sequence like "Step 1: check the pH" / "Step 2: check the pH" across pages would look like
+    repeated furniture and be deleted as such. That is content loss disguised as cleaning.
+    """
+    return re.sub(r"^\d+|\d+$", "", line.strip()).strip().lower()
+
+
+def _strip_running_headers(docs, min_fraction: float = 0.15):
+    """Remove the running header/footer that repeats on nearly every page of a publication.
+
+    Every even page of FAO 589 opens "Small-scale aquaponic food production - Integrated fish and
+    plant farming62" and every odd page "61Design of aquaponic units". Left in, that text lands in
+    EVERY chunk the document produces — roughly 70 characters of the book's own title repeated
+    across a thousand vectors, pulling each one toward the title and away from the specific thing
+    the chunk is actually about. It is the highest-volume noise in a PDF corpus and the easiest to
+    remove.
+
+    Page numbers are stripped before counting, since the header differs by exactly that on each
+    page. A line has to appear on at least `min_fraction` of pages (and at least 3) to qualify, so
+    a phrase that genuinely recurs in the prose is not mistaken for furniture.
+    """
+    from collections import Counter
+    counts: Counter = Counter()
+    for d in docs:
+        seen = {_normalise_for_repetition(l) for l in d.page_content.splitlines() if l.strip()}
+        for line in seen:
+            if line:
+                counts[line] += 1
+    threshold = max(3, int(len(docs) * min_fraction))
+    furniture = {l for l, c in counts.items() if c >= threshold and len(l) > 8}
+    if not furniture:
+        return docs
+    for d in docs:
+        d.page_content = "\n".join(
+            l for l in d.page_content.splitlines()
+            if _normalise_for_repetition(l) not in furniture)
+    logging.info("Stripped %d running header/footer line(s) from %d pages",
+                 len(furniture), len(docs))
+    return docs
+
+
+def _looks_like_contents_page(text: str) -> bool:
+    """A table of contents, list of figures, or index — structure, not knowledge.
+
+    Such a page is mostly lines that end in a page number ("3.3.1 Photosynthetic activity of algae
+    28"). It embeds as a dense bag of the document's own section titles, so it matches almost any
+    query about the document's subject while answering none of them.
+    """
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    if len(lines) < 6:
+        return False
+    numbered = sum(1 for l in lines if re.search(r"\s\d{1,4}\s*$", l))
+    return numbered / len(lines) >= 0.6
+
+
+def pdf_cleaning_enabled() -> bool:
+    import os
+    return os.getenv("AGRONAUT_PDF_CLEAN", "").lower() not in {"off", "0", "false"}
+
+
+def _clean_pdf_documents(docs):
+    """Drop a publication's structural pages and its repeated furniture.
+
+    Applied at extraction so both the index and `corpus_report` see the same cleaned text — a
+    chunk count that includes 40 pages of table of contents is not a useful measure of what a
+    source contributes.
+    """
+    if not docs or not pdf_cleaning_enabled():
+        return docs
+    before = len(docs)
+    docs = _strip_running_headers(docs)
+    kept = [d for d in docs
+            if d.page_content.strip() and not _looks_like_contents_page(d.page_content)]
+    if len(kept) < before:
+        logging.info("Dropped %d structural page(s) (contents/index/blank)", before - len(kept))
+    return kept
+
+
 def _pdf_documents(content: bytes, url: str):
     """Text from already-downloaded PDF bytes, one Document per page so a retrieved passage
     can be cited back to a page number."""
@@ -238,6 +321,7 @@ def _pdf_documents(content: bytes, url: str):
             text = (page.extract_text() or "").strip()
             if text:
                 docs.append(Document(page_content=text, metadata={"source": url, "page": n}))
+        docs = _clean_pdf_documents(docs)
         logging.info("Loaded %d PDF pages from %s", len(docs), url)
         return docs
     except Exception as err:  # noqa: BLE001

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -289,6 +289,74 @@ def pdf_cleaning_enabled() -> bool:
     return os.getenv("AGRONAUT_PDF_CLEAN", "").lower() not in {"off", "0", "false"}
 
 
+_CHAPTER_HEADER = re.compile(r"^\d{1,3}\s*([A-Z][A-Za-z][A-Za-z \-,'&]{4,60})$")
+
+
+def pdf_sections_enabled() -> bool:
+    """PDF chapter labelling ships DISABLED — measured, like everything else here.
+
+        variant                          hit    recall  prec    MRR     MAP
+        off (chunks carry no chapter)    0.939  0.894   0.540   0.737   0.697
+        on  (chunks carry their chapter) 0.909  0.848   0.525   0.727   0.682
+
+    Every metric fell. This is the THIRD context-prefix technique to lose on this corpus, after the
+    markdown crumb at 1354 chunks and header chunking, and the pattern behind all three is the
+    same: when every document shares one vocabulary domain, a topic label adds words that appear
+    in every chunk about that topic. Words present everywhere carry no discriminating information
+    — they only dilute the distinctive content already in the vector. "Plants in aquaponics"
+    prefixed onto a passage about leaf yellowing makes it look more like every other plant
+    passage, not more like the answer.
+
+    The extraction itself is sound and worth keeping: chapter coverage goes from 29% of pages
+    (headers where they literally appear) to 95% by forward-filling each chapter across the pages
+    that follow it. That metadata is genuinely useful for FILTERING, which is a different
+    mechanism from prefixing and one this corpus has not yet needed. Enable with
+    AGRONAUT_PDF_SECTIONS=on.
+    """
+    import os
+    return os.getenv("AGRONAUT_PDF_SECTIONS", "").lower() in {"on", "1", "true"}
+
+
+def _label_pdf_chapters(docs):
+    """Give every page of a publication the chapter it belongs to, and prefix its text with it.
+
+    This is the PDF analogue of splitting markdown on its headings — but a PDF has no headings to
+    split on, only typography that extraction flattens away. What survives is the running header:
+    odd pages of FAO 589 open "51Design of aquaponic units", carrying the chapter name and the
+    page number as one string.
+
+    Detection alone reaches just 76 of 262 pages, because even pages carry the book title instead.
+    The chapter is FORWARD-FILLED from each header to the pages that follow it, which is simply
+    what a chapter is — it continues until the next one starts. That takes coverage to nearly
+    every page.
+
+    Why it matters: without this an FAO chunk arrives as anonymous prose. "Nitrate is generally
+    tolerated at higher concentrations" is ambiguous on its own; carrying "Water quality in
+    aquaponics" it is not. The markdown equivalent measurably helped precision on the small corpus
+    for exactly this reason.
+    """
+    current = ""
+    for d in docs:
+        lines = [l for l in d.page_content.splitlines()]
+        stripped = [l.strip() for l in lines if l.strip()]
+        if stripped:
+            m = _CHAPTER_HEADER.match(stripped[0])
+            if m:
+                current = m.group(1).strip()
+                # The header line is furniture once its content is captured as metadata.
+                for i, l in enumerate(lines):
+                    if l.strip() == stripped[0]:
+                        lines.pop(i)
+                        break
+        if current:
+            d.metadata["chapter"] = current
+            body = "\n".join(lines).strip()
+            d.page_content = f"{current}\n{body}" if body else current
+        else:
+            d.page_content = "\n".join(lines)
+    return docs
+
+
 def _clean_pdf_documents(docs):
     """Drop a publication's structural pages and its repeated furniture.
 
@@ -299,6 +367,10 @@ def _clean_pdf_documents(docs):
     if not docs or not pdf_cleaning_enabled():
         return docs
     before = len(docs)
+    # Chapters are read BEFORE furniture is stripped: the running header IS the chapter signal,
+    # so removing it first would discard the very thing being extracted.
+    if pdf_sections_enabled():
+        docs = _label_pdf_chapters(docs)
     docs = _strip_running_headers(docs)
     kept = [d for d in docs
             if d.page_content.strip() and not _looks_like_contents_page(d.page_content)]
@@ -1719,7 +1791,8 @@ def _corpus_fingerprint() -> str:
     h.update(f"{EMBEDDING_MODEL}|{CHUNK_SIZE}|{CHUNK_OVERLAP}"
              f"|md_headers={markdown_headers_enabled()}"
              f"|md_crumb={_crumb_enabled()}"
-             f"|pdf_clean={pdf_cleaning_enabled()}".encode())
+             f"|pdf_clean={pdf_cleaning_enabled()}"
+             f"|pdf_sections={pdf_sections_enabled()}".encode())
     kb = pathlib.Path(KNOWLEDGE_DIR)
     if kb.exists():
         for fp in sorted(kb.rglob("*")):

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -98,12 +98,18 @@ def parse_urls_file(file_path: str) -> List[Dict[str, str]]:
     New format (recommended):
       CATEGORY|URL
       CATEGORY|URL|LABEL
+      CATEGORY|URL|LABEL|LICENCE
+
+    LICENCE records the terms the text is published under (e.g. "CC BY 4.0", "CC BY-NC-SA 3.0").
+    Agronaut is a Digital Public Good, so what it indexes has to be openly licensed — and in
+    practice the paywalled sources are also the ones that return no text, so recording the licence
+    and keeping the corpus retrievable turn out to be the same discipline.
 
     Legacy format (backward compatible):
       URL
 
     Returns list of dicts:
-      {"category": "...", "url": "...", "label": "..."}
+      {"category": "...", "url": "...", "label": "...", "licence": "..."}
     """
     p = pathlib.Path(file_path)
     if not p.exists():
@@ -120,6 +126,7 @@ def parse_urls_file(file_path: str) -> List[Dict[str, str]]:
 
         category = "UNCATEGORIZED"
         label = ""
+        licence = ""
 
         if "|" in line:
             parts = [x.strip() for x in line.split("|")]
@@ -128,6 +135,8 @@ def parse_urls_file(file_path: str) -> List[Dict[str, str]]:
                 url = parts[1]
                 if len(parts) >= 3:
                     label = parts[2]
+                if len(parts) >= 4:
+                    licence = parts[3]
             else:
                 # Fallback to legacy if the split is malformed
                 url = line
@@ -142,7 +151,8 @@ def parse_urls_file(file_path: str) -> List[Dict[str, str]]:
             continue
         seen.add(key)
 
-        entries.append({"category": category, "url": url, "label": label})
+        entries.append({"category": category, "url": url, "label": label,
+                        "licence": licence})
 
     return entries
 
@@ -177,8 +187,70 @@ def load_local_knowledge_documents(knowledge_dir: str = KNOWLEDGE_DIR):
     return docs
 
 
-def load_web_page(url: str):
+def _probe_url(url: str) -> dict | None:
+    """Fetch `url` ONCE and report what it is: status, content type, and body bytes.
 
+    Two things depend on this and both were previously getting their own request — the HTTP
+    status (WebBaseLoader never surfaces it, so an error page would otherwise be indexed as
+    content) and the PDF sniff. Downloading a 12 MB FAO publication three times to answer three
+    questions about it made vetting a source slower than it needs to be, and hammers the
+    publisher for no reason.
+
+    Returns None when the source must not be indexed (non-2xx). Returns a dict on success.
+    On a transport error it returns a dict with no content, letting WebBaseLoader try and apply
+    its own error handling rather than silently dropping a healthy source on one flaky request.
+    """
+    try:
+        import requests
+        r = requests.get(url, timeout=WEB_LOAD_TIMEOUT, allow_redirects=True,
+                         headers={"User-Agent": "Mozilla/5.0 (compatible; Agronaut/1.0)"})
+    except Exception as err:  # noqa: BLE001 — a probe failure must not cost us the source
+        logging.debug("Probe failed for %s (%s); deferring to the loader", url, err)
+        return {"status": 0, "content": b"", "content_type": "", "is_pdf": False}
+
+    if not (200 <= r.status_code < 300):
+        logging.warning("Skipping %s — HTTP %s, not indexing an error page", url, r.status_code)
+        return None
+
+    ctype = r.headers.get("Content-Type", "").lower()
+    content = r.content
+    return {
+        "status": r.status_code,
+        "content": content,
+        "content_type": ctype.split(";")[0],
+        # Detected by type/magic bytes, not a .pdf suffix: publication PDFs are routinely served
+        # from extension-less download endpoints (FAO's bitstream API is exactly this).
+        "is_pdf": "pdf" in ctype or content[:5].startswith(b"%PDF"),
+    }
+
+
+def _pdf_documents(content: bytes, url: str):
+    """Text from already-downloaded PDF bytes, one Document per page so a retrieved passage
+    can be cited back to a page number."""
+    try:
+        import io
+        from langchain_core.documents import Document
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(content))
+        docs = []
+        for n, page in enumerate(reader.pages, start=1):
+            text = (page.extract_text() or "").strip()
+            if text:
+                docs.append(Document(page_content=text, metadata={"source": url, "page": n}))
+        logging.info("Loaded %d PDF pages from %s", len(docs), url)
+        return docs
+    except Exception as err:  # noqa: BLE001
+        logging.warning("Failed to read PDF %s — %s", url, err)
+        return []
+
+
+def load_web_page(url: str):
+    probe = _probe_url(url)
+    if probe is None:
+        return []
+    if probe["is_pdf"]:
+        return _pdf_documents(probe["content"], url)
     try:
         logging.info("Loading %s", url)
         loader = WebBaseLoader(url)

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -271,11 +271,97 @@ def load_web_page(url: str):
         return []
 
 
+def _markdown_header_chunks(doc):
+    """Split one knowledge document on its own headings, and give each chunk its context back.
+
+    The corpus is hand-authored markdown: 21 files carrying 21 `#` titles and 102 `##` sections.
+    Those headings are boundaries a human already chose, and a blind 800-character window ignores
+    them — it runs the tail of "Ammonia spike - safe actions" into the head of "Nitrite spike",
+    producing a chunk that belongs to neither.
+
+    Each chunk is also prefixed with "TITLE - Section". A bullet reading "keep it below 0.5 mg/L"
+    is nearly meaningless embedded on its own; prefixed with "Nitrogen Cycle - Target readings" it
+    carries its subject. This is context-aware chunking, and it improves the text the model reads
+    as well as the vector it is found by.
+
+    Falls back to returning the document unchanged when it has no headings to split on.
+    """
+    from langchain_text_splitters import MarkdownHeaderTextSplitter
+
+    text = getattr(doc, "page_content", "") or ""
+    try:
+        pieces = MarkdownHeaderTextSplitter(
+            headers_to_split_on=[("#", "h1"), ("##", "h2")],
+            strip_headers=False,
+        ).split_text(text)
+    except Exception:  # noqa: BLE001 — malformed markdown must not lose the document
+        return [doc]
+    if not pieces:
+        return [doc]
+
+    out = []
+    for piece in pieces:
+        md = dict(doc.metadata)
+        h1 = piece.metadata.get("h1", "")
+        h2 = piece.metadata.get("h2", "")
+        md.update({k: v for k, v in (("h1", h1), ("h2", h2)) if v})
+        crumb = " — ".join(x for x in (h1, h2) if x) if _crumb_enabled() else ""
+        body = piece.page_content.strip()
+        if crumb and not body.startswith(crumb):
+            body = f"{crumb}\n{body}"
+        piece.page_content = body
+        piece.metadata = md
+        out.append(piece)
+    return out
+
+
+def _crumb_enabled() -> bool:
+    import os
+    return os.getenv("AGRONAUT_MD_CRUMB", "").lower() not in {"off", "0", "false"}
+
+
+def markdown_headers_enabled() -> bool:
+    """Header-aware chunking ships DISABLED, on evidence — docs/dpg/retrieval_eval/chunking_ablation.json.
+
+        variant                              hit    recall  prec    MRR     MAP
+        A  baseline (character splitter)     0.970  0.919   0.626   0.909   0.869
+        B  header split, no prefix           0.939  0.889   0.606   0.843   0.793
+        C  header split + context prefix     0.909  0.879   0.722   0.848   0.818
+
+    The ablation separates two effects usually bundled together: the SPLIT costs quality (B loses
+    on all five metrics), while the CONTEXT PREFIX genuinely helps (C gains 0.116 precision over
+    B). Baseline still wins overall.
+
+    The cause is corpus geometry rather than the technique. 95% of this corpus's 123 sections are
+    SMALLER than the 800-character chunk window (mean 381 chars), so the recursive splitter was
+    already packing about two related sections into each chunk, and splitting on headings
+    fragments that useful co-occurrence into context-poor pieces.
+
+    That reasoning predicts exactly when to turn this on: documents whose sections are LARGER than
+    the chunk window. FAO 589 is 275 pages, and blind 800-character windows across a book ignore
+    every structural boundary in it. The natural end state is header chunking for PDF sources and
+    the character splitter for the short hand-authored corpus. Enable with AGRONAUT_MD_HEADERS=on.
+    """
+    import os
+    return os.getenv("AGRONAUT_MD_HEADERS", "").lower() in {"on", "1", "true"}
+
+
 def build_vector_store(documents) -> FAISS:
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=CHUNK_SIZE,
         chunk_overlap=CHUNK_OVERLAP,
     )
+    if markdown_headers_enabled():
+        # Header-split the hand-authored corpus first, then let the character splitter handle any
+        # section that is still oversized. Web and PDF documents have no reliable heading
+        # structure, so they go straight to the character splitter as before.
+        prepared = []
+        for d in documents:
+            if d.metadata.get("source_type") == "local_file":
+                prepared.extend(_markdown_header_chunks(d))
+            else:
+                prepared.append(d)
+        documents = prepared
     docs = splitter.split_documents(documents)
 
     filtered = [d for d in docs if not _is_boilerplate_text(getattr(d, "page_content", ""))]

--- a/urls.txt
+++ b/urls.txt
@@ -40,16 +40,14 @@ SURVEY|https://doi.org/10.1371/journal.pone.0102662|Love et al. (2014), An Inter
 #   https://doi.org/10.4081/ija.2017.1012
 #
 # ---------------------------------------------------------------------------------------------
-# CANDIDATE — pending a licensing decision, NOT yet indexed.
+# FAO 589 — the canonical small-scale aquaponics reference.
 #
-# FAO 589 "Small-scale aquaponic food production" — verified reachable, 275 pages, 713 907 chars,
-# ~1034 chunks. It would roughly quadruple the corpus and is the canonical small-scale reference.
-# Held back for two reasons:
-#   1. LICENCE: published 2014, before FAO adopted Creative Commons. Its grant is "FAO encourages
-#      the use, reproduction and dissemination of material in this information product ... for
-#      educational or other non-commercial products or services" with attribution. Permissive, but
-#      NOT Creative Commons — confirm compatibility with redistributing Agronaut (MIT) as a DPG.
-#   2. INGESTION: 56 MB, ~47 s to download, and raw extraction pulls the table of contents and
-#      list-of-figures in as chunks. Needs index persistence and front-matter filtering first.
-#
-#   FAO|https://openknowledge.fao.org/server/api/core/bitstreams/2ca21047-390f-42cd-bd1d-0c2ebc9c1df2/content|FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)|FAO permissive (educational/non-commercial, attribution)
+# LICENCE NOTE. Published 2014, before FAO adopted Creative Commons (their CC policy applies to
+# material from ~Nov 2019 onward). Its grant reads: "FAO encourages the use, reproduction and
+# dissemination of material in this information product ... for private study, research and
+# teaching, or for use in non-commercial products or services, provided that appropriate
+# acknowledgement of FAO as the source and copyright holder is given." That is functionally
+# equivalent to CC BY-NC, which the DPG Alliance accepts (it prefers CC BY / CC BY-SA / CC0 but
+# does not require them). Note the asymmetry this creates and keep it explicit: Agronaut's CODE is
+# MIT, while this part of its knowledge corpus is non-commercial-only. See docs/dpg/CORPUS.md.
+FAO|https://openknowledge.fao.org/server/api/core/bitstreams/2ca21047-390f-42cd-bd1d-0c2ebc9c1df2/content|FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)|FAO permissive (educational/non-commercial, attribution)

--- a/urls.txt
+++ b/urls.txt
@@ -1,14 +1,55 @@
-https://doi.org/10.3390/SU7044199
-https://doi.org/10.1016/J.COMPAG.2022.106785
-https://doi.org/10.1109/ICMI60790.2024.10586162
-https://doi.org/10.1007/S10462-024-11003-X
-https://doi.org/10.3390/w9030182
-https://doi.org/10.1016/j.jclepro.2019.04.290
-https://doi.org/10.1371/journal.pone.0102662
-https://doi.org/10.1016/j.aquaculture.2014.09.023
-https://doi.org/10.4081/ija.2017.1012
-https://doi.org/10.1016/j.jclepro.2018.01.037
-https://doi.org/10.1016/j.biortech.2015.01.013
-https://doi.org/10.1016/j.egypro.2017.12.694
-https://doi.org/10.1109/ACCESS.2019.2953491
-https://doi.org/10.3390/w8100468
+# Agronaut RAG corpus — web sources.
+#
+# Format:  CATEGORY|URL|LABEL|LICENCE
+# LABEL is what the operator sees in a "[source: ...]" citation, so it must name the real work.
+# LICENCE records the terms the text is published under; Agronaut is a Digital Public Good, so
+# only openly licensed material may be indexed.
+#
+# Vet a proposed source BEFORE adding it here — it is checked for reachability, substance, topic
+# drift and licence in one pass:
+#     python -m scripts.corpus_report --candidate "<url>" --label "<expected topic>"
+#
+# Audit everything currently declared:
+#     python -m scripts.corpus_report
+
+REVIEW|https://doi.org/10.1007/S10462-024-11003-X|Applications, technologies, and evaluation methods in smart aquaponics: a systematic literature review (Artif Intell Rev, 2024)|CC BY 4.0
+SURVEY|https://doi.org/10.1371/journal.pone.0102662|Love et al. (2014), An International Survey of Aquaponics Practitioners, PLOS ONE|CC BY 4.0
+
+# ---------------------------------------------------------------------------------------------
+# REFERENCES — real citations, NOT indexed (measured: each contributes 0 retrievable chunks).
+#
+# Kept here so the bibliographic record survives, removed from the index so they stop costing a
+# network fetch per cold start while presenting as citation depth. Verified with corpus_report:
+# the MDPI entries return HTTP 403 (their "Access Denied" body was previously being indexed as a
+# citable passage), the rest resolve to JavaScript redirect shims of ~11 characters.
+#
+# Paywalled — publisher blocks automated retrieval (HTTP 403):
+#   https://doi.org/10.3390/SU7044199
+#   https://doi.org/10.3390/w8100468
+#   https://doi.org/10.3390/w9030182
+#
+# Paywalled — resolve to a redirect shim with no extractable text:
+#   https://doi.org/10.1016/J.COMPAG.2022.106785
+#   https://doi.org/10.1016/j.aquaculture.2014.09.023
+#   https://doi.org/10.1016/j.biortech.2015.01.013
+#   https://doi.org/10.1016/j.egypro.2017.12.694
+#   https://doi.org/10.1016/j.jclepro.2018.01.037
+#   https://doi.org/10.1016/j.jclepro.2019.04.290
+#   https://doi.org/10.1109/ACCESS.2019.2953491
+#   https://doi.org/10.1109/ICMI60790.2024.10586162
+#   https://doi.org/10.4081/ija.2017.1012
+#
+# ---------------------------------------------------------------------------------------------
+# CANDIDATE — pending a licensing decision, NOT yet indexed.
+#
+# FAO 589 "Small-scale aquaponic food production" — verified reachable, 275 pages, 713 907 chars,
+# ~1034 chunks. It would roughly quadruple the corpus and is the canonical small-scale reference.
+# Held back for two reasons:
+#   1. LICENCE: published 2014, before FAO adopted Creative Commons. Its grant is "FAO encourages
+#      the use, reproduction and dissemination of material in this information product ... for
+#      educational or other non-commercial products or services" with attribution. Permissive, but
+#      NOT Creative Commons — confirm compatibility with redistributing Agronaut (MIT) as a DPG.
+#   2. INGESTION: 56 MB, ~47 s to download, and raw extraction pulls the table of contents and
+#      list-of-figures in as chunks. Needs index persistence and front-matter filtering first.
+#
+#   FAO|https://openknowledge.fao.org/server/api/core/bitstreams/2ca21047-390f-42cd-bd1d-0c2ebc9c1df2/content|FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)|FAO permissive (educational/non-commercial, attribution)


### PR DESCRIPTION
## What this changes

Agronaut's retriever had never been measured. This adds the measurement, then follows where it led — which was repeatedly not where a RAG course would predict.

### 1. The corpus was not what it claimed to be

All 14 declared web sources were audited for what they actually contribute. Three MDPI DOIs returned HTTP 403 and their `"Access Denied — You don't have permission"` body was being **indexed as a retrievable, citable passage**: at 231 characters it clears the 200-char boilerplate floor and matches none of its keywords, so only the HTTP status distinguishes it from content. Nine more resolved to JavaScript redirect shims contributing nothing but a fetch per cold start.

### 2. Measuring first changed the plan

A 33-query golden set in operator voice ("my tilapia are gasping at the surface", not "dissolved oxygen"), plus 10 off-topic controls, scored with recall@k / precision@k / MRR / MAP@k.

Baseline: **hit_rate 0.970, MRR 0.909**. The dense retriever was already near its ceiling. What the eval *did* find was worse and cheaper to fix: with no relevance floor, *"what is the capital of Canada"* returned three confident, source-labelled passages from aquaponics papers. Citations make that failure more convincing, not less.

### 3. Techniques were adopted, rejected, then re-adopted — on evidence

Eight techniques were implemented and measured. **Four ship; four lose.**

| technique | evidence | ships |
|---|---|---|
| Relevance floor | 8/10 off-topic refused, 0/33 real silenced | **ON** |
| Hybrid BM25 + RRF | 362 chunks: lost at every β. 1354: **recall +0.091, MAP +0.091** | **ON (β=0.90)** |
| Per-source cap | hit 0.848 → **0.939**, recall 0.788 → **0.894** | **ON (2)** |
| PDF cleaning | running header in 4/992 chunks, not 111/1034 | **ON** |
| Header chunking | 362: hit 0.970→0.909. 1354: 0.848→0.758 | off |
| Context prefix | 362: precision **+0.116**. 1354: MAP **−0.093** | off |
| PDF chapter labelling | hit 0.939→0.909 (extraction works: 29%→95% coverage) | off |
| Cross-encoder rerank | hit 0.939→0.879, latency 274→**761 ms** | off |

Hybrid was shipped **disabled** with its sweep recorded and a note to re-run after corpus growth. Adding FAO 589 tripled the corpus; re-running flipped the decision. **That note is what produced the reversal** — the negative result was recorded in a form that could expire.

The header-chunking ablation is worth a look on its own: splitting and the context prefix are normally reported as one result and pull in **opposite** directions, and the prefix *reversed sign* between corpora (+0.116 precision at 362 chunks, −0.093 MAP at 1354).

**What worked was structural, not lexical:** refusing irrelevant passages, refusing error pages, refusing to let one source occupy every slot. Every rejection is recorded in `docs/dpg/retrieval_eval/techniques.json` with the conditions that would reverse it — which is exactly what let hybrid search flip from rejected to shipped.

### 4. FAO 589, and the ground truth it invalidated

Added the canonical reference (275 pages, 992 chunks). hit_rate dropped 0.970 → 0.667.

**That number was wrong.** Reading the passages actually returned showed 6 of 11 new "misses" were the retriever finding a genuinely correct answer the golden set hadn't been told about — FAO answers *"how much should I be giving them each day"* with *"juvenile fish can be fed about 3 percent of their body weight per day"*. Ground truth is a property of the corpus, not the queries, so it was re-established: those 6 relabelled with the quoting passage recorded in `annotation_note`, the other 5 left as genuine misses because FAO returns fish-*feed* safety for a question about whether produce is safe to eat. Relabelling those would be tuning the ruler to fit the result.

Then the real fix: **FAO took all 3 slots on 10 of 33 queries**, so answers sitting in `knowledge/` never reached the model. A per-source cap improved every metric at once — the largest single gain here.

### Net effect

| | original | final |
|---|---|---|
| corpus | 362 chunks | **1354** |
| hit_rate | 0.970 | 0.939 |
| MRR | 0.909 | 0.737 |
| latency | 523 ms | **244 ms** |
| off-topic refused | 0/10 | **8/10** |
| real queries silenced | — | **0/33** |
| poisoned chunks | 3 | **0** |

FAO 589 still costs ranking quality. It buys canonical depth and answers to questions the golden set doesn't ask, which the metrics can't credit. That trade is recorded, not hidden.

Also: index persistence keyed by a corpus fingerprint, PDF ingestion, PDF cleaning (running header removed from 111/1034 chunks → 4/992), a `LICENCE` field in `urls.txt`, `docs/dpg/CORPUS.md`, and retrieval telemetry that structurally *cannot* record query or passage text.

## How it was verified

```
$ pytest -q
701 passed, 2 warnings in 43.91s

$ python -m scripts.safety_eval
Advice-safety golden set: 223/223 passed (score 1.000)   exit=0

$ python -m scripts.corpus_report                        # exit 0
21 local files -> 82 chunks   3 URLs -> 1272 chunks   TOTAL 1354 chunks

$ python -m scripts.retrieval_eval
  hit_rate 0.939   recall@3 0.894   precision@3 0.540   MRR 0.737   MAP@3 0.697
  floor rejected 8/10 off-topic queries
  floor silenced 0/33 REAL queries
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

**`aqua_model/` is untouched** — this is entirely the retrieval layer, so the trust-zone checklist does not apply. No user-facing number changed.

Three defects found by results looking *wrong* rather than by anything failing, which is the failure mode that matters most here — a broken measurement doesn't raise, it produces numbers that get believed:

1. **`rank_bm25` and `pypdf` were undeclared.** Lazy imports in `try/except`, so with both absent the whole suite passed — 40 tests green while PDF ingestion contributed zero chunks and BM25 silently fell back to dense. Every test asserted the graceful degradation; none asserted the feature.
2. **Floor calibration compared the wrong number.** It read `hits[0]["score"]` as "closest match", but fusion reorders — reported 1.665 where the true nearest was 1.426, and declared the bands "separable" when they overlap.
3. **The index cache ignored the chunking flags**, so an ablation re-read the previous run's index. Only symptom: two variants reporting byte-identical metrics.

## What this does NOT do

- **The relevance floor cannot be tightened.** Worst on-topic distance 1.548; closest off-topic 1.426 (*"remove red wine from a carpet"*, near `algae_control.md`'s advice on removing growth from surfaces). Adding a 275-page book covering everything from plumbing to food safety widened the overlap. It rejects 8/10 and silences 0/33, which is worth having, but no single global threshold separates these bands.
- **Query rewriting was not built**, deliberately. It is the same shape as three techniques that already lost. Three of the four failures share one mechanism: they add topic words (a section crumb, a chapter name, a heading) to chunks in a corpus where every document already shares a vocabulary domain — words present in every chunk about a topic carry no discriminating information and only dilute the vector. Building a fourth instance of a mechanism that failed three times, to watch it fail again, is not evidence-gathering.
- **Reranking loses on *this* model, not in general.** `ms-marco-MiniLM-L-6-v2` is trained on short web-search queries against web passages; operator phrasing against agronomy prose is out of that distribution, and it is being asked to improve a shortlist that is already good. `AGRONAUT_RERANK_MODEL` selects another — re-measure before trusting it.
- **The corpus carries a mixed licence.** FAO 589 is non-commercial-only while the code is MIT. Commercial users should drop that entry and rebuild. See `docs/dpg/CORPUS.md`.
- **Web-source drift is bounded, not detected.** A publisher can edit a source without `urls.txt` changing; a 7-day TTL bounds staleness because detecting it needs the fetch the cache exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYe3JRXxqYfRYQRRj5nF3U
