### PR TITLE
fix(qc): make "reliable" a verdict a sensor channel has to earn

### DIFF
--- a/aqua_model/coefficients.py
+++ b/aqua_model/coefficients.py
@@ -53,6 +53,20 @@ SAFETY_FACTOR = Coefficient(
     note="Headroom for losses, peaks, clogging, and coefficient uncertainty.",
 )
 
+# How far above saturation a dissolved-oxygen reading may sit before it is a broken probe rather
+# than a bloom. Photosynthesis genuinely supersaturates a densely planted system during the day —
+# 110-130% of saturation is routinely reported, and short excursions higher do occur. Sustained
+# multiples are not physical: public aquaponics data has been observed at 4.3x saturation while
+# flagged "reliable", which is a dead probe, not a planted tank.
+DO_SUPERSATURATION_TOLERANCE = Coefficient(
+    name="do_supersaturation_tolerance",
+    value=1.5, low=1.3, high=2.0, unit="dimensionless", source="LIT",
+    note="Multiple of Benson-Krause saturation above which a DO reading is treated as "
+         "instrument failure. Generous by design: rejecting a real afternoon oxygen peak is "
+         "worse than admitting a mildly wrong one, because the peak is real information.",
+)
+
+
 # Nitrogen chemistry — well established.
 N_FRACTION_OF_PROTEIN = Coefficient(
     name="n_fraction_of_protein",

--- a/aqua_model/datasets.py
+++ b/aqua_model/datasets.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pandas as pd
 
 from .logging_schema import SCHEMA_VERSION
+from . import sensor_qc
 
 _PKG_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _PKG_DIR.parent
@@ -89,23 +90,86 @@ def _saturation(s: pd.Series) -> tuple[float, float]:
     return at_floor, at_ceiling
 
 
-def empirical_envelope(df: pd.DataFrame | None = None) -> dict:
-    """Per-channel distribution (p5/p50/p95, range) with an honest trust flag.
+# Channels for which a physical-plausibility test exists. Anything not here is reported
+# `unassessed` rather than `reliable`, so an unchecked channel is visibly unchecked.
+_ASSESSED = {
+    "water_temp_c", "ph", "dissolved_oxygen_mg_l", "ammonia_mg_l",
+    "nitrite_mg_l", "nitrate_mg_l", "turbidity_ntu", "fish_length_cm", "fish_weight_g",
+}
 
-    Channels pinned at a sensor rail are marked low-trust so nobody mistakes a saturated
-    reading for a calibrated one.
+# Pairs that must be independent instruments. Nitrification runs ammonia -> nitrite -> nitrate in
+# sequence with a lag, so near-perfect correlation means one probe wired to two fields.
+_INDEPENDENT_PAIRS = [("ammonia_mg_l", "nitrite_mg_l"), ("nitrite_mg_l", "nitrate_mg_l")]
+
+_SENTINEL_THRESHOLD = 0.02      # 2% dead-sensor readings is already a broken channel
+_IMPLAUSIBLE_THRESHOLD = 0.02
+
+
+def _trust_verdict(col: str, s: pd.Series, temps: pd.Series | None) -> tuple[str, dict]:
+    """Judge one channel. Returns (verdict, evidence).
+
+    `reliable` is a conclusion reached by passing every applicable test — never a fallback for
+    "no test ran". A channel with no test defined reports `unassessed`, because silently promoting
+    the unchecked to trustworthy is how a dissolved-oxygen channel at 4.3x saturation ended up
+    calibrating coefficients.
+    """
+    evidence: dict = {}
+    at_floor, at_ceiling = _saturation(s)
+    evidence["frac_at_floor"] = round(at_floor, 3)
+    evidence["frac_at_ceiling"] = round(at_ceiling, 3)
+
+    sent_frac, sent_meaning = sensor_qc.sentinel_fraction(s.tolist())
+    if sent_frac > _SENTINEL_THRESHOLD:
+        evidence["sentinel"] = sent_meaning
+        evidence["frac_sentinel"] = round(sent_frac, 3)
+        return "low (dead-sensor sentinel)", evidence
+
+    if at_floor > _SATURATION_THRESHOLD or at_ceiling > _SATURATION_THRESHOLD:
+        return "low (sensor saturation)", evidence
+
+    if col not in _ASSESSED:
+        return "unassessed", evidence
+
+    bad = sum(1 for v in s if sensor_qc.implausible_value(col, float(v)) is not None)
+    if col == "dissolved_oxygen_mg_l" and temps is not None and not temps.empty:
+        t_med = float(temps.median())
+        if -2.0 <= t_med <= 60.0:
+            evidence["do_saturation_at_median_temp"] = round(
+                sensor_qc.do_saturation_mg_l(t_med), 2)
+            bad = max(bad, sum(1 for v in s if sensor_qc.implausible_do(float(v), t_med)))
+    frac_bad = bad / len(s) if len(s) else 0.0
+    evidence["frac_implausible"] = round(frac_bad, 3)
+    if frac_bad > _IMPLAUSIBLE_THRESHOLD:
+        return "low (physically implausible)", evidence
+    return "reliable", evidence
+
+
+def empirical_envelope(df: pd.DataFrame | None = None) -> dict:
+    """Per-channel distribution (p5/p50/p95, range) with an honest trust verdict.
+
+    Every channel is judged against every test that applies to it: rail saturation, dead-sensor
+    sentinels, physical impossibility, and — across channels — instrument independence. A channel
+    only earns `reliable` by passing them all.
     """
     if df is None:
         df = load_all()
+    temps = (pd.to_numeric(df["water_temp_c"], errors="coerce").dropna()
+             if "water_temp_c" in df.columns else None)
+    # Judge every channel we know how to judge that is actually present — not only the columns
+    # the IoTPond CSVs happen to have. Adopting a second dataset (or ingesting an operator's own
+    # log, which carries nitrite where IoTPond does not) must not silently skip its extra channels.
+    known = list(dict.fromkeys(
+        list(NUMERIC_CHANNELS)
+        + sorted(_ASSESSED)
+        + [c for pair in _INDEPENDENT_PAIRS for c in pair]))
     out: dict = {}
-    for col in NUMERIC_CHANNELS:
+    for col in known:
         if col not in df.columns:
             continue
         s = pd.to_numeric(df[col], errors="coerce").dropna()
         if s.empty:
             continue
-        at_floor, at_ceiling = _saturation(s)
-        saturated = at_floor > _SATURATION_THRESHOLD or at_ceiling > _SATURATION_THRESHOLD
+        verdict, evidence = _trust_verdict(col, s, temps)
         out[col] = {
             "n": int(s.size),
             "min": round(float(s.min()), 3),
@@ -113,10 +177,21 @@ def empirical_envelope(df: pd.DataFrame | None = None) -> dict:
             "p50": round(float(s.median()), 3),
             "p95": round(float(s.quantile(0.95)), 3),
             "max": round(float(s.max()), 3),
-            "frac_at_floor": round(at_floor, 3),
-            "frac_at_ceiling": round(at_ceiling, 3),
-            "trust": "low (sensor saturation)" if saturated else "reliable",
+            **evidence,
+            "trust": verdict,
         }
+
+    # Cross-channel: a pair that should be two instruments and behaves like one.
+    for a, b in _INDEPENDENT_PAIRS:
+        if a in out and b in out and a in df.columns and b in df.columns:
+            sa = pd.to_numeric(df[a], errors="coerce")
+            sb = pd.to_numeric(df[b], errors="coerce")
+            ok, r = sensor_qc.channels_are_independent(sa.tolist(), sb.tolist())
+            if not ok:
+                for ch in (a, b):
+                    out[ch]["trust"] = "low (not an independent instrument)"
+                    out[ch]["correlated_with"] = {"channel": b if ch == a else a,
+                                                  "r": round(float(r), 4)}
     return out
 
 

--- a/aqua_model/sensor_qc.py
+++ b/aqua_model/sensor_qc.py
@@ -1,0 +1,144 @@
+"""Physical plausibility checks for sensor channels.
+
+A sensor can fail in more ways than one, and each failure mode needs its own test. The envelope
+builder originally tested exactly one — a channel pinned at its rail — and labelled everything else
+`reliable`. That made "reliable" the answer for every failure nobody had written a check for, and
+dissolved oxygen went out at 4.3x saturation wearing it.
+
+Three checks live here, each earned from real data in `data/raw/`:
+
+* **Physical ceilings.** Dissolved oxygen cannot meaningfully exceed saturation, which is a
+  function of temperature. pH is bounded by its own scale. Concentrations cannot be negative.
+* **Dead-sensor sentinels.** A DS18B20 with no probe attached reports exactly -127 degrees C. That
+  is a stable, in-band-looking number that no range check catches, and live aquaponics channels
+  are full of it.
+* **Channel independence.** Two channels that are supposed to measure different things and instead
+  correlate at r > 0.99 are one instrument written to two fields. Measured on public aquaponics
+  data, an `Ammonia`/`Nitrite` pair came back at r = 0.9994 — nitrite that was never nitrite.
+
+Pure functions over plain numbers: no I/O, no network, no pandas requirement in the core maths, so
+this stays inside the trust zone and is testable without a dataset.
+"""
+
+from __future__ import annotations
+
+import math
+
+from .coefficients import DO_SUPERSATURATION_TOLERANCE
+
+# Values a dead or unread sensor reports. These are the dangerous ones: stable, precise-looking,
+# and comfortably inside any range wide enough to admit genuine extremes.
+SENTINELS: dict[float, str] = {
+    -127.0: "DS18B20 temperature probe: no sensor connected",
+    -999.0: "generic no-data marker",
+    -9999.0: "generic no-data marker",
+    85.0: "DS18B20 power-on reset value (only suspicious in bulk)",
+    65535.0: "unsigned 16-bit overflow / unread ADC",
+    -32768.0: "signed 16-bit underflow / unread ADC",
+}
+
+# Channels where a negative reading is physically meaningless.
+_NON_NEGATIVE = {
+    "dissolved_oxygen_mg_l", "ammonia_mg_l", "nitrite_mg_l", "nitrate_mg_l",
+    "turbidity_ntu", "ec_us_cm", "tds_mg_l", "fish_length_cm", "fish_weight_g",
+    "water_level_l", "alkalinity_mg_l",
+}
+
+_PH_MIN, _PH_MAX = 0.0, 14.0
+
+
+def do_saturation_mg_l(temp_c: float, elevation_m: float = 0.0) -> float:
+    """Dissolved-oxygen saturation in fresh water, mg/L (Benson & Krause).
+
+    The standard closed-form fit used by USGS and APHA; no lookup table required. Pressure is
+    corrected for elevation with the barometric approximation, because a highland site genuinely
+    saturates lower and would otherwise look supersaturated.
+    """
+    if not math.isfinite(temp_c) or not (-2.0 <= temp_c <= 60.0):
+        raise ValueError(f"temperature {temp_c} out of range for a saturation calculation")
+    tk = temp_c + 273.15
+    ln_c = (-139.34411
+            + 1.575701e5 / tk
+            - 6.642308e7 / tk ** 2
+            + 1.243800e10 / tk ** 3
+            - 8.621949e11 / tk ** 4)
+    c = math.exp(ln_c)
+    if elevation_m:
+        c *= math.exp(-elevation_m / 8434.0)     # barometric scale height, metres
+    return c
+
+
+def implausible_do(do_mg_l: float, temp_c: float, elevation_m: float = 0.0) -> bool:
+    """True when a DO reading exceeds what water at this temperature can physically hold.
+
+    A tolerance above 1.0 is deliberate: photosynthesis genuinely supersaturates a planted system
+    for part of the day. Sustained multiples of saturation are a broken probe, not a bloom.
+    """
+    if do_mg_l < 0:
+        return True
+    return do_mg_l > DO_SUPERSATURATION_TOLERANCE.value * do_saturation_mg_l(temp_c, elevation_m)
+
+
+def is_sentinel(value: float, tol: float = 1e-6) -> str | None:
+    """The dead-sensor meaning of `value`, or None if it is not a known sentinel."""
+    for s, meaning in SENTINELS.items():
+        if abs(value - s) <= tol:
+            return meaning
+    return None
+
+
+def implausible_value(channel: str, value: float) -> str | None:
+    """Why `value` is impossible for `channel`, or None if it is physically admissible.
+
+    Channel-agnostic checks only — anything needing a second channel (DO against temperature)
+    has its own function, because a per-value check cannot see the rest of the row.
+    """
+    if not math.isfinite(value):
+        return "not a finite number"
+    if channel == "ph" and not (_PH_MIN <= value <= _PH_MAX):
+        return f"pH {value} outside the 0-14 scale"
+    if channel in _NON_NEGATIVE and value < 0:
+        return f"negative {channel}"
+    return None
+
+
+def sentinel_fraction(values) -> tuple[float, str]:
+    """Fraction of readings that are dead-sensor sentinels, and what the commonest one means."""
+    vals = [v for v in values if isinstance(v, (int, float)) and math.isfinite(v)]
+    if not vals:
+        return 0.0, ""
+    counts: dict[str, int] = {}
+    for v in vals:
+        meaning = is_sentinel(float(v))
+        if meaning:
+            counts[meaning] = counts.get(meaning, 0) + 1
+    if not counts:
+        return 0.0, ""
+    worst = max(counts, key=counts.get)
+    return sum(counts.values()) / len(vals), worst
+
+
+def channels_are_independent(a, b, threshold: float = 0.99) -> tuple[bool, float]:
+    """Whether two channels look like separate instruments, plus their correlation.
+
+    Ammonia and nitrite are sequential stages of nitrification with a lag between them; they
+    cannot track each other almost perfectly in a living system. When they do, one probe is being
+    written to two fields — which is how a corpus acquires a nitrite column that never measured
+    nitrite.
+    """
+    pairs = [(float(x), float(y)) for x, y in zip(a, b)
+             if isinstance(x, (int, float)) and isinstance(y, (int, float))
+             and math.isfinite(x) and math.isfinite(y)]
+    n = len(pairs)
+    if n < 30:
+        return True, float("nan")           # too little overlap to accuse anyone
+    xs = [p[0] for p in pairs]
+    ys = [p[1] for p in pairs]
+    mx, my = sum(xs) / n, sum(ys) / n
+    sxy = sum((x - mx) * (y - my) for x, y in pairs)
+    sxx = sum((x - mx) ** 2 for x in xs)
+    syy = sum((y - my) ** 2 for y in ys)
+    if sxx <= 0 or syy <= 0:
+        return True, float("nan")           # a constant channel has no correlation to speak of
+    r = sxy / math.sqrt(sxx * syy)
+    return abs(r) < threshold, r

--- a/aqua_model/tests/test_datasets.py
+++ b/aqua_model/tests/test_datasets.py
@@ -73,3 +73,71 @@ def test_loader_uses_canonical_schema_names():
     df = D.load_all()
     assert {"water_temp_c", "ph", "ammonia_mg_l", "nitrate_mg_l", "pond"} <= set(df.columns)
     assert df["pond"].nunique() == 4
+
+
+# --- trust is a verdict, not a fallback --------------------------------------
+
+def test_dissolved_oxygen_is_no_longer_flagged_reliable():
+    """The bug this fixes. The shipped envelope marked DO `reliable` while its p95 sat at 4.3x
+    oxygen saturation, making it eligible to calibrate coefficients against."""
+    from aqua_model import datasets
+    env = datasets.load_artifact()["channels"]
+    assert env["dissolved_oxygen_mg_l"]["trust"] == "low (physically implausible)"
+    assert env["dissolved_oxygen_mg_l"]["do_saturation_at_median_temp"] < 10
+
+
+def test_saturated_channels_still_caught():
+    """The check that already existed must not regress: turbidity and ammonia sit on their rails."""
+    from aqua_model import datasets
+    env = datasets.load_artifact()["channels"]
+    assert env["turbidity_ntu"]["trust"].startswith("low")
+    assert env["ammonia_mg_l"]["trust"].startswith("low")
+
+
+def test_clean_channels_still_earn_reliable():
+    """The verdict has to stay usable — over-flagging would be its own failure."""
+    from aqua_model import datasets
+    env = datasets.load_artifact()["channels"]
+    assert env["water_temp_c"]["trust"] == "reliable"
+    assert env["ph"]["trust"] == "reliable"
+
+
+def test_unknown_channel_reports_unassessed_not_reliable():
+    """The heart of the bug: `reliable` used to be the else-branch, so any channel nobody wrote a
+    check for was silently promoted. An unchecked channel must say so."""
+    import pandas as pd
+    from aqua_model import datasets
+    # Varied values on purpose: a fixture with few distinct values trips the saturation check
+    # first and never reaches the question being asked.
+    s = pd.Series([i * 0.37 for i in range(200)])
+    verdict, _ = datasets._trust_verdict("a_channel_with_no_check", s, None)
+    assert verdict == "unassessed"
+
+
+def test_dead_sensor_sentinels_outrank_other_verdicts():
+    """A channel whose median is -127 is a disconnected probe, and that is the useful thing to
+    report — not that it happens to also look saturated."""
+    import pandas as pd
+    from aqua_model import datasets
+    s = pd.Series([-127.0] * 60 + [24.0] * 40)
+    verdict, evidence = datasets._trust_verdict("water_temp_c", s, None)
+    assert verdict == "low (dead-sensor sentinel)"
+    assert "DS18B20" in evidence["sentinel"]
+
+
+def test_non_independent_channels_are_demoted():
+    """Two channels that are one instrument must both lose their `reliable` verdict, even though
+    each looks fine measured alone."""
+    import pandas as pd
+    from aqua_model import datasets
+    n = 400
+    a = [0.11 + i * 0.001 for i in range(n)]
+    df = pd.DataFrame({
+        "water_temp_c": [24.5] * n,
+        "ammonia_mg_l": a,
+        "nitrite_mg_l": [x + 0.0001 for x in a],
+    })
+    env = datasets.empirical_envelope(df)
+    assert env["ammonia_mg_l"]["trust"] == "low (not an independent instrument)"
+    assert env["nitrite_mg_l"]["trust"] == "low (not an independent instrument)"
+    assert env["ammonia_mg_l"]["correlated_with"]["r"] > 0.99

--- a/aqua_model/tests/test_sensor_qc.py
+++ b/aqua_model/tests/test_sensor_qc.py
@@ -1,0 +1,154 @@
+"""Physical plausibility checks on sensor channels.
+
+Every case here is drawn from real data. The dissolved-oxygen numbers are the ones that shipped in
+`data/empirical_envelope.json` flagged `reliable` while sitting at 4.3x saturation; the -127 is
+what a DS18B20 with no probe attached reports, observed as the MEDIAN of a live public aquaponics
+channel; the 0.9994 correlation is a real `Ammonia`/`Nitrite` pair, verified against the
+instrument's own API rather than a CSV export.
+"""
+
+import math
+
+import pytest
+
+from aqua_model import sensor_qc as qc
+from aqua_model.coefficients import DO_SUPERSATURATION_TOLERANCE
+
+
+# --- oxygen saturation -------------------------------------------------------
+
+@pytest.mark.parametrize("temp_c,expected", [
+    (0.0, 14.62), (10.0, 11.29), (20.0, 9.09), (25.0, 8.24), (30.0, 7.56),
+])
+def test_saturation_matches_published_values(temp_c, expected):
+    """Benson & Krause against the standard table. Within 1% or the equation is mistyped."""
+    got = qc.do_saturation_mg_l(temp_c)
+    assert abs(got - expected) / expected < 0.01, f"{temp_c}C: {got:.2f} vs {expected}"
+
+
+def test_saturation_falls_with_temperature():
+    temps = [5, 15, 25, 35]
+    vals = [qc.do_saturation_mg_l(t) for t in temps]
+    assert vals == sorted(vals, reverse=True)
+
+
+def test_saturation_falls_with_elevation():
+    """A highland site genuinely holds less oxygen; without this it looks supersaturated."""
+    assert qc.do_saturation_mg_l(20, elevation_m=2500) < qc.do_saturation_mg_l(20, elevation_m=0)
+
+
+def test_saturation_rejects_absurd_temperature():
+    with pytest.raises(ValueError):
+        qc.do_saturation_mg_l(500)
+
+
+# --- the bug this module exists for ------------------------------------------
+
+def test_the_shipped_impossible_reading_is_caught():
+    """The exact value that shipped as `reliable`: p95 of 35.55 mg/L at a median 24.5 C, which is
+    4.3x saturation."""
+    assert qc.implausible_do(35.55, 24.5)
+    assert qc.implausible_do(41.12, 24.5)          # the recorded max, 4.9x
+
+
+def test_a_real_afternoon_oxygen_peak_is_not_caught():
+    """Photosynthesis genuinely supersaturates a planted bed. Rejecting that would discard real
+    information, which is why the tolerance is deliberately generous."""
+    sat = qc.do_saturation_mg_l(24.5)
+    assert not qc.implausible_do(sat * 1.25, 24.5)
+    assert not qc.implausible_do(sat * 0.75, 24.5)
+
+
+def test_negative_oxygen_is_impossible():
+    assert qc.implausible_do(-1.5, 24.5)
+
+
+def test_tolerance_is_the_documented_coefficient():
+    """The threshold is a sourced coefficient, not a literal buried in a comparison."""
+    sat = qc.do_saturation_mg_l(20.0)
+    tol = DO_SUPERSATURATION_TOLERANCE.value
+    assert not qc.implausible_do(sat * (tol - 0.05), 20.0)
+    assert qc.implausible_do(sat * (tol + 0.05), 20.0)
+
+
+# --- dead-sensor sentinels ---------------------------------------------------
+
+def test_ds18b20_disconnected_code_is_recognised():
+    """-127 is stable, precise and inside any range wide enough for real extremes. It was the
+    MEDIAN temperature of a live public channel."""
+    assert "DS18B20" in qc.is_sentinel(-127.0)
+
+
+@pytest.mark.parametrize("val", [-999.0, -9999.0, 65535.0, -32768.0])
+def test_other_sentinels_are_recognised(val):
+    assert qc.is_sentinel(val) is not None
+
+
+def test_ordinary_readings_are_not_sentinels():
+    for v in (24.5, 7.2, 0.0, 8.34, -1.0):
+        assert qc.is_sentinel(v) is None
+
+
+def test_sentinel_fraction_reports_the_commonest_cause():
+    vals = [-127.0] * 30 + [24.0] * 70
+    frac, meaning = qc.sentinel_fraction(vals)
+    assert frac == pytest.approx(0.30)
+    assert "DS18B20" in meaning
+
+
+def test_sentinel_fraction_on_clean_data():
+    frac, meaning = qc.sentinel_fraction([24.0, 24.5, 25.0])
+    assert frac == 0.0 and meaning == ""
+
+
+# --- per-value plausibility --------------------------------------------------
+
+def test_ph_outside_its_own_scale():
+    assert qc.implausible_value("ph", 15.78) is not None   # observed in a real dataset
+    assert qc.implausible_value("ph", -0.5) is not None
+    assert qc.implausible_value("ph", 7.2) is None
+
+
+def test_negative_concentrations():
+    assert qc.implausible_value("dissolved_oxygen_mg_l", -1.51) is not None  # real, from a
+    assert qc.implausible_value("nitrite_mg_l", -3.0) is not None            # normalised dataset
+    assert qc.implausible_value("ammonia_mg_l", 0.0) is None
+
+
+def test_nan_and_inf_are_rejected():
+    assert qc.implausible_value("tds_mg_l", float("nan")) is not None
+    assert qc.implausible_value("tds_mg_l", float("inf")) is not None
+
+
+def test_unknown_channel_is_not_judged():
+    """No test defined means no verdict — not a pass."""
+    assert qc.implausible_value("some_new_channel", -5.0) is None
+
+
+# --- channel independence ----------------------------------------------------
+
+def test_one_probe_written_to_two_fields_is_caught():
+    """The real case: an Ammonia/Nitrite pair at r = 0.9994, confirmed against the instrument API."""
+    a = [0.11 + i * 0.001 for i in range(500)]
+    b = [x + 0.0001 for x in a]
+    ok, r = qc.channels_are_independent(a, b)
+    assert not ok and r > 0.99
+
+
+def test_genuinely_different_channels_pass():
+    """Ammonia falling while nitrite rises — the actual signature of nitrification."""
+    a = [10.0 - i * 0.02 for i in range(500)]
+    b = [0.1 + (i % 37) * 0.05 for i in range(500)]
+    ok, _ = qc.channels_are_independent(a, b)
+    assert ok
+
+
+def test_too_little_overlap_makes_no_accusation():
+    ok, r = qc.channels_are_independent([1, 2, 3], [1, 2, 3])
+    assert ok and math.isnan(r)
+
+
+def test_constant_channel_is_not_accused():
+    """A flat channel has no correlation to speak of; saturation detection is its job, not this."""
+    ok, r = qc.channels_are_independent([5.0] * 200, list(range(200)))
+    assert ok and math.isnan(r)

--- a/data/empirical_envelope.json
+++ b/data/empirical_envelope.json
@@ -18,6 +18,7 @@
       "max": 27.812,
       "frac_at_floor": 0.0,
       "frac_at_ceiling": 0.0,
+      "frac_implausible": 0.0,
       "trust": "reliable"
     },
     "turbidity_ntu": {
@@ -40,7 +41,9 @@
       "max": 41.118,
       "frac_at_floor": 0.0,
       "frac_at_ceiling": 0.0,
-      "trust": "reliable"
+      "do_saturation_at_median_temp": 8.34,
+      "frac_implausible": 0.217,
+      "trust": "low (physically implausible)"
     },
     "ph": {
       "n": 232745,
@@ -51,6 +54,7 @@
       "max": 11.44,
       "frac_at_floor": 0.148,
       "frac_at_ceiling": 0.0,
+      "frac_implausible": 0.0,
       "trust": "reliable"
     },
     "ammonia_mg_l": {
@@ -73,6 +77,7 @@
       "max": 2000.0,
       "frac_at_floor": 0.0,
       "frac_at_ceiling": 0.005,
+      "frac_implausible": 0.0,
       "trust": "reliable"
     },
     "fish_length_cm": {
@@ -84,6 +89,7 @@
       "max": 35.39,
       "frac_at_floor": 0.006,
       "frac_at_ceiling": 0.001,
+      "frac_implausible": 0.0,
       "trust": "reliable"
     },
     "fish_weight_g": {
@@ -95,6 +101,7 @@
       "max": 394.66,
       "frac_at_floor": 0.006,
       "frac_at_ceiling": 0.001,
+      "frac_implausible": 0.0,
       "trust": "reliable"
     }
   }


### PR DESCRIPTION
Closes #86.

## What this changes

`empirical_envelope()` decided trust with one line:

```python
"trust": "low (sensor saturation)" if saturated else "reliable",
```

`reliable` was the **else-branch**. The rule tested one failure mode — a channel pinned at its rail — so anything failing a *different* way inherited "reliable" by omission rather than by assessment.

Dissolved oxygen failed a different way. Its p95 of **35.55 mg/L is 4.3× oxygen saturation** at the recorded median temperature of 24.5 °C (8.34 mg/L, Benson & Krause); the max of 41.12 is 4.9×. That channel shipped as trustworthy and was eligible to calibrate coefficients against — in the layer whose entire job is bounding the model against reality.

## Three checks, each earned from real data

**Physical ceilings.** Oxygen saturation as a closed-form function of temperature, with an elevation correction so a highland site doesn't read as supersaturated. The tolerance is a sourced coefficient (`DO_SUPERSATURATION_TOLERANCE`, 1.5×) and deliberately generous — photosynthesis genuinely supersaturates a planted bed in the afternoon, and rejecting a real oxygen peak discards real information. 4.3× is a dead probe, not a bloom.

**Dead-sensor sentinels.** A DS18B20 with no probe attached reports exactly `-127 °C`. Surveying live public aquaponics channels for #87, **-127 was the *median* temperature of one of them.** It is stable, precise, and sits comfortably inside any range wide enough to admit real extremes — no range check catches it. Also covers `-999`, `65535`, `-32768`.

**Channel independence.** Nitrification runs ammonia → nitrite → nitrate *in sequence, with a lag*; two such channels cannot track each other almost perfectly in a living system. A public dataset advertising both came back at **r = 0.9994** — verified against the instrument's own API, not just its CSV export, so the duplication is in the wiring rather than the download. One probe, two fields, a nitrite column that never measured nitrite.

## The actual fix

The verdict is now the worst finding across every applicable check, and **a channel with no applicable check reports `unassessed`, not `reliable`.**

That distinction is the point. The specific bug was one missing test; the *shape* of the bug was a default that promoted the unchecked to trustworthy. Worth grepping for elsewhere — any check that returns "fine" when it finds nothing will report "fine" for everything it was never taught to look for.

## Also

Generalises the envelope builder to judge **any known channel present in the frame**, not only the columns the IoTPond CSVs happen to have. `nitrite_mg_l` is in `logging_schema.py` and absent from IoTPond, so an operator's own log would have had its most safety-critical channel silently skipped.

## Result

```
data/empirical_envelope.json

  water_temp_c             reliable
  turbidity_ntu            low (sensor saturation)
  dissolved_oxygen_mg_l    low (physically implausible)   <- was `reliable`
  ph                       reliable
  ammonia_mg_l             low (sensor saturation)
  nitrate_mg_l             reliable
  fish_length_cm           reliable
  fish_weight_g            reliable
```

DO now carries the saturation figure that justifies its verdict. Temperature, pH, nitrate and the fish channels still earn `reliable`, so the flag stays useful rather than becoming uniformly pessimistic.

## How it was verified

```
$ pytest -q
760 passed

$ python -m scripts.safety_eval
Advice-safety golden set: 373/373 passed (score 1.000)
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

### Trust-zone checklist

- [x] No new import of an LLM, network, or UI library inside `aqua_model/` — `sensor_qc.py` imports only `math` and one coefficient
- [x] Any new number lives in `coefficients.py` with a value, range, unit, and **source** — `DO_SUPERSATURATION_TOLERANCE`
- [x] Any new user-facing result states what it does **not** model — `unassessed` is exactly that statement
- [x] Model-proposed values still reach the core only through a validation gate
- [ ] A probe was added to `docs/dpg/safety_eval/golden_set.json` — not applicable; this changes the *reality layer*, not the advice surface, and its 28 unit tests cover the guarantee directly

## What this does NOT do

- **It does not judge agronomic sanity, only physical possibility.** Nitrate at p50 = 511 mg/L is far above any aquaponics target and still passes, because it is not *impossible*. That's a different check and deliberately out of scope.
- **The sentinel list is not exhaustive.** It covers the ones actually observed plus the common ADC failures. New hardware will bring new ones — the list is a named constant so adding to it is a data change.
- **Independence is only checked for the nitrogen pairs.** Other channel pairs could be duplicated too; those pairs are where it matters most and where a real case was found.
- **It does not fix the underlying data.** IoTPond's DO is still unusable — it is now *labelled* unusable, which is the difference between a corpus you can reason about and one you cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYe3JRXxqYfRYQRRj5nF3U
