### PR TITLE
feat(scenario): fork the twin to ask "what if" before doing it to live fish

### DIFF
--- a/aqua_model/scenario.py
+++ b/aqua_model/scenario.py
@@ -1,0 +1,243 @@
+"""Ask the twin "what if" before doing it to live fish.
+
+The twin (`twin.py`) rolls one system forward. This forks it: take the state a system is in now,
+apply a change, and run both branches side by side. The output is not a number but a COMPARISON —
+what the change does to the path, relative to leaving things alone.
+
+That framing is deliberate. An absolute prediction ("nitrite will reach 2.3 mg/L") claims accuracy
+the twin has not earned: it has never been validated against a real system, because no public
+dataset pairs feeding records with independently-measured nitrogen (#87). A relative statement
+("this triples your nitrite peak and delays recovery by nine days") survives being wrong about the
+absolute level, because the same unmodelled error sits in both branches and largely cancels.
+
+Every trajectory carries an uncertainty band swept over `TwinParams` — the parameters the stepped
+model adds and nobody has fitted. The band is what is genuinely unknown, not decoration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+from .species import FishSpecies
+from .twin import (
+    NOT_MODELLED, PARAMS_FAST, PARAMS_SLOW, PARAMS_TYPICAL, StepResult, TwinParams, TwinState,
+    simulate,
+)
+
+# Concentrations at which a curated source says an operator should act. First-party, from
+# knowledge/nitrogen_cycle_and_cycling.md.
+#
+# The ammonia figure is TOTAL ammonia nitrogen and is a CONSERVATIVE PROXY, not a toxicity
+# calculation: what actually harms fish is the un-ionised NH3 fraction, which rises sharply with pH
+# and temperature and which this model explicitly does not compute (see twin.NOT_MODELLED). At high
+# pH the real danger begins below this number. Treat a crossing as "look at this", never as a
+# safety certificate.
+THRESHOLDS_MG_L = {
+    "tan_mg_l": 0.5,
+    "no2_mg_l": 0.5,
+    "no3_mg_l": 150.0,
+}
+THRESHOLD_SOURCE = "knowledge/nitrogen_cycle_and_cycling.md"
+
+# Below this a peak is indistinguishable from zero, and a RATIO against it is arithmetic noise —
+# 0.012 -> 8.12 mg/L is a real and serious change, but calling it "678x higher" is meaningless
+# precision. Under this floor the absolute change is reported instead.
+_MATERIAL_MG_L = 0.05
+
+
+@dataclass(frozen=True)
+class Intervention:
+    """A change an operator is considering. `None` means "leave this as it is"."""
+
+    name: str
+    feed_g_per_day: float | None = None
+    temperature_c: float | None = None
+    add_fish_kg: float | None = None
+    plant_uptake_capacity_g_day: float | None = None
+    volume_l: float | None = None
+
+    def apply_to_state(self, state: TwinState) -> TwinState:
+        if self.add_fish_kg is None and self.volume_l is None:
+            return state
+        return replace(
+            state,
+            fish_biomass_kg=state.fish_biomass_kg + (self.add_fish_kg or 0.0),
+            volume_l=self.volume_l if self.volume_l is not None else state.volume_l,
+        )
+
+
+@dataclass(frozen=True)
+class ChannelOutcome:
+    """What one water-quality channel does over a run."""
+
+    channel: str
+    peak: float
+    peak_day: float
+    final: float
+    days_above_threshold: float
+    threshold: float
+    peak_low: float          # uncertainty band, swept over TwinParams
+    peak_high: float
+
+    @property
+    def crosses_threshold(self) -> bool:
+        return self.peak > self.threshold
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    name: str
+    outcomes: dict[str, ChannelOutcome]
+    trajectory: list[StepResult]
+    warnings: tuple[str, ...]
+    not_modelled: tuple[str, ...] = NOT_MODELLED
+
+
+def _series(traj: list[StepResult], channel: str) -> list[tuple[float, float]]:
+    return [(r.state.day, getattr(r.state, channel)) for r in traj]
+
+
+def _outcome(channel: str, bands: dict[str, list[list[StepResult]]], dt_days: float) -> ChannelOutcome:
+    mid = bands["typical"][0]
+    pts = _series(mid, channel)
+    peak_day, peak = max(((d, v) for d, v in pts), key=lambda p: p[1])
+    thr = THRESHOLDS_MG_L[channel]
+    above = sum(dt_days for _d, v in pts if v > thr)
+    peaks = []
+    for runs in bands.values():
+        for run in runs:
+            peaks.append(max(getattr(r.state, channel) for r in run))
+    return ChannelOutcome(
+        channel=channel, peak=peak, peak_day=peak_day, final=pts[-1][1],
+        days_above_threshold=above, threshold=thr,
+        peak_low=min(peaks), peak_high=max(peaks),
+    )
+
+
+def run_scenario(
+    state: TwinState,
+    species: FishSpecies,
+    intervention: Intervention,
+    *,
+    days: int,
+    feed_g_per_day: float,
+    temperature_c: float,
+    dt_days: float = 1.0,
+    plant_uptake_capacity_g_day: float | None = None,
+) -> ScenarioResult:
+    """Fork the twin, apply an intervention, and run it forward with an uncertainty band.
+
+    Forking is safe by construction: `TwinState` is frozen, so a branch cannot reach back and
+    modify the system it came from. That property is why the twin's state was made immutable
+    before there was anything to fork.
+    """
+    start = intervention.apply_to_state(state)
+    feed = intervention.feed_g_per_day if intervention.feed_g_per_day is not None else feed_g_per_day
+    temp = intervention.temperature_c if intervention.temperature_c is not None else temperature_c
+    cap = (intervention.plant_uptake_capacity_g_day
+           if intervention.plant_uptake_capacity_g_day is not None
+           else plant_uptake_capacity_g_day)
+
+    bands: dict[str, list[list[StepResult]]] = {}
+    for label, params in (("typical", PARAMS_TYPICAL), ("fast", PARAMS_FAST), ("slow", PARAMS_SLOW)):
+        bands[label] = [simulate(start, species, days=days, feed_g_per_day=feed,
+                                 temperature_c=temp, dt_days=dt_days,
+                                 plant_uptake_capacity_g_day=cap, params=params)]
+
+    traj = bands["typical"][0]
+    warnings = tuple(dict.fromkeys(w for r in traj for w in r.warnings))
+    outcomes = {ch: _outcome(ch, bands, dt_days) for ch in THRESHOLDS_MG_L}
+    return ScenarioResult(name=intervention.name, outcomes=outcomes,
+                          trajectory=traj, warnings=warnings)
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """What an intervention changes, stated relative to leaving things alone."""
+
+    baseline: ScenarioResult
+    scenario: ScenarioResult
+    verdict: str
+    findings: tuple[str, ...]
+
+    def worsens(self) -> bool:
+        return any(
+            self.scenario.outcomes[ch].peak > self.baseline.outcomes[ch].peak * 1.1
+            for ch in self.scenario.outcomes
+        )
+
+
+def compare(baseline: ScenarioResult, scenario: ScenarioResult) -> Comparison:
+    """Contrast two runs and say, in plain terms, what changed.
+
+    Reported as ratios and day-offsets rather than absolute levels. The twin is unvalidated, so a
+    shared systematic error mostly cancels between two branches of the same model — which makes
+    "three times worse" far more defensible than "2.3 mg/L".
+    """
+    findings: list[str] = []
+    worse = False
+    for ch, after in scenario.outcomes.items():
+        before = baseline.outcomes[ch]
+        label = {"tan_mg_l": "ammonia", "no2_mg_l": "nitrite", "no3_mg_l": "nitrate"}[ch]
+        if before.peak >= _MATERIAL_MG_L:
+            ratio = after.peak / before.peak
+            if ratio >= 1.1:
+                worse = True
+                findings.append(
+                    f"{label} peak {ratio:.1f}x higher ({before.peak:.2f} -> {after.peak:.2f} mg/L, "
+                    f"plausible range {after.peak_low:.2f}-{after.peak_high:.2f})")
+            elif ratio <= 0.9:
+                findings.append(f"{label} peak {1 / ratio:.1f}x lower")
+        elif after.peak >= _MATERIAL_MG_L:
+            # Baseline was effectively zero: a ratio here would be noise, so state the level.
+            worse = True
+            findings.append(
+                f"{label} rises to {after.peak:.2f} mg/L (plausible range "
+                f"{after.peak_low:.2f}-{after.peak_high:.2f}) from a baseline that stayed near zero")
+
+        if after.crosses_threshold and not before.crosses_threshold:
+            worse = True
+            findings.append(
+                f"{label} crosses {after.threshold} mg/L for {after.days_above_threshold:.0f} days "
+                f"— the baseline never does ({THRESHOLD_SOURCE})")
+        elif after.crosses_threshold and after.days_above_threshold > before.days_above_threshold:
+            findings.append(
+                f"{label} spends {after.days_above_threshold - before.days_above_threshold:.0f} "
+                f"more days above {after.threshold} mg/L")
+
+    # An intervention that suppresses feeding improves every nitrogen channel, because less feed
+    # means less nitrogen. Reporting that as "improves water quality" is how a nitrogen-only model
+    # recommends starving fish or chilling them out of their thermal range. The model cannot see
+    # welfare, so where it has evidence that feeding was suppressed it must say what it is looking
+    # at rather than deliver a verdict it has no standing to give.
+    suppressed = any("optimum" in w for w in scenario.warnings)
+    if not findings:
+        verdict = "No material change to water quality over this horizon."
+    elif worse:
+        verdict = "This makes water quality worse before it settles — stage it or add capacity first."
+    elif suppressed:
+        verdict = ("Nitrogen levels fall, but only because the fish are outside their temperature "
+                   "optimum and eating less. That is suppressed feeding, not a healthier system — "
+                   "this model sees nitrogen only, and cannot speak to fish welfare or growth.")
+    else:
+        verdict = "This improves water quality over this horizon."
+    return Comparison(baseline=baseline, scenario=scenario, verdict=verdict,
+                      findings=tuple(findings))
+
+
+def format_comparison(cmp: Comparison) -> str:
+    """Operator-facing text. States its own limits, because a projection reads as a promise."""
+    lines = [f"{cmp.scenario.name} vs {cmp.baseline.name}", "", cmp.verdict]
+    if cmp.findings:
+        lines.append("")
+        lines += [f"  - {f}" for f in cmp.findings]
+    if cmp.scenario.warnings:
+        lines.append("")
+        lines += [f"  ! {w}" for w in cmp.scenario.warnings]
+    lines += [
+        "",
+        "This is a projection from an unvalidated model: it has not been checked against a real",
+        "system, so treat the SHAPE of the change as the useful part, not the absolute numbers.",
+        "NOT modelled: " + "; ".join(cmp.scenario.not_modelled[:3]) + ".",
+    ]
+    return "\n".join(lines)

--- a/aqua_model/tests/test_scenario.py
+++ b/aqua_model/tests/test_scenario.py
@@ -1,0 +1,192 @@
+"""Forking the twin to ask "what if" — and the honesty constraints on answering.
+
+The engine reports COMPARISONS, not predictions. The twin has never been validated against a real
+system (#87: no public dataset pairs feed with independently-measured nitrogen), so an absolute
+number claims accuracy it has not earned. A relative statement survives being wrong about the
+absolute level, because the same unmodelled error sits in both branches.
+
+Several tests here exist because the obvious implementation gives dangerous advice.
+"""
+
+import pytest
+
+from aqua_model.crops import CROPS
+from aqua_model.scenario import (
+    THRESHOLDS_MG_L, THRESHOLD_SOURCE, Intervention, compare, format_comparison, run_scenario,
+)
+from aqua_model.species import SPECIES
+from aqua_model.twin import NOT_MODELLED, TwinState, mature_biofilter, simulate
+
+SP = SPECIES["tilapia"]
+CROP = CROPS["lettuce"]
+FEED = 200.0
+TEMP = 27.0
+
+
+def _settled():
+    aob, nob = mature_biofilter(SP, FEED)
+    st = TwinState(volume_l=2000, aob_capacity_g_day=aob, nob_capacity_g_day=nob)
+    return simulate(st, SP, days=60, feed_g_per_day=FEED, temperature_c=TEMP)[-1].state
+
+
+def _common():
+    return dict(days=45, feed_g_per_day=FEED, temperature_c=TEMP,
+                plant_uptake_capacity_g_day=CROP.n_uptake_g_per_m2_day * 10)
+
+
+def _baseline(state):
+    return run_scenario(state, SP, Intervention("leave it alone"), **_common())
+
+
+# --- fork safety -------------------------------------------------------------
+
+def test_a_fork_cannot_modify_the_system_it_forked_from():
+    """The property the whole engine rests on. `TwinState` was made frozen before there was
+    anything to fork precisely so this could not go wrong later."""
+    state = _settled()
+    before = (state.tan_mg_l, state.no2_mg_l, state.no3_mg_l, state.day)
+    run_scenario(state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common())
+    assert (state.tan_mg_l, state.no2_mg_l, state.no3_mg_l, state.day) == before
+
+
+def test_two_scenarios_from_one_state_do_not_interfere():
+    state = _settled()
+    a = run_scenario(state, SP, Intervention("a", feed_g_per_day=FEED * 3), **_common())
+    b = run_scenario(state, SP, Intervention("b"), **_common())
+    assert a.outcomes["no2_mg_l"].peak > b.outcomes["no2_mg_l"].peak
+
+
+# --- the answers have to be right --------------------------------------------
+
+def test_tripling_feed_is_reported_as_worse():
+    state = _settled()
+    cmp = compare(_baseline(state), run_scenario(
+        state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common()))
+    assert cmp.worsens()
+    assert "worse" in cmp.verdict.lower()
+    assert any("nitrite" in f for f in cmp.findings)
+
+
+def test_threshold_crossings_name_their_source():
+    """A number that tells an operator to act must say where it came from — the same rule the
+    sizing surface already follows."""
+    state = _settled()
+    cmp = compare(_baseline(state), run_scenario(
+        state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common()))
+    crossings = [f for f in cmp.findings if "crosses" in f]
+    assert crossings
+    assert all(THRESHOLD_SOURCE in f for f in crossings)
+
+
+def test_doing_nothing_reports_no_material_change():
+    state = _settled()
+    cmp = compare(_baseline(state), _baseline(state))
+    assert not cmp.worsens()
+    assert "no material change" in cmp.verdict.lower()
+
+
+# --- where the obvious implementation gives dangerous advice ------------------
+
+def test_a_cold_snap_is_not_reported_as_an_improvement():
+    """The important one. Chilling tilapia to 18 C lowers every nitrogen channel, because the fish
+    stop eating. A nitrogen-only model reads that as cleaner water and would effectively recommend
+    chilling fish out of their thermal range. The verdict must name what it is actually seeing."""
+    state = _settled()
+    cmp = compare(_baseline(state), run_scenario(
+        state, SP, Intervention("cold snap", temperature_c=18.0), **_common()))
+    v = cmp.verdict.lower()
+    assert "improves water quality" not in v
+    assert "eating less" in v or "suppressed feeding" in v
+    assert "welfare" in v or "nitrogen only" in v
+
+
+def test_a_near_zero_baseline_does_not_produce_a_meaningless_ratio():
+    """Dividing by a baseline of 0.012 mg/L yields "678x higher" — arithmetically true, useless as
+    information, and it buries the real finding. Below the materiality floor, state the level."""
+    state = _settled()
+    cmp = compare(_baseline(state), run_scenario(
+        state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common()))
+    ammonia = [f for f in cmp.findings if f.startswith("ammonia") and "x higher" in f]
+    assert not ammonia, f"reported a ratio against a near-zero baseline: {ammonia}"
+    assert any("rises to" in f and "ammonia" in f for f in cmp.findings)
+
+
+# --- uncertainty is swept, not invented --------------------------------------
+
+def test_the_band_brackets_the_typical_run():
+    """The band comes from sweeping TwinParams — the parameters the stepped model adds and nobody
+    has fitted. It has to actually contain the central estimate."""
+    state = _settled()
+    res = run_scenario(state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common())
+    for out in res.outcomes.values():
+        assert out.peak_low <= out.peak <= out.peak_high
+
+
+def test_the_band_has_real_width_when_it_matters():
+    """A band that collapses to the point estimate is decoration. Under a transient the
+    nitrifier doubling times genuinely matter, so it should open up."""
+    state = _settled()
+    res = run_scenario(state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common())
+    no2 = res.outcomes["no2_mg_l"]
+    assert no2.peak_high > no2.peak_low * 1.2
+
+
+# --- honesty surface ---------------------------------------------------------
+
+def test_the_output_states_it_is_unvalidated():
+    state = _settled()
+    text = format_comparison(compare(_baseline(state), run_scenario(
+        state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common())))
+    assert "unvalidated" in text.lower()
+    assert "not modelled" in text.lower()
+
+
+def test_limits_travel_with_the_result():
+    state = _settled()
+    res = _baseline(state)
+    assert res.not_modelled == NOT_MODELLED
+    assert any("un-ionised" in n for n in res.not_modelled)
+
+
+def test_ammonia_threshold_is_documented_as_a_proxy():
+    """TAN is not what harms fish — un-ionised NH3 is, and its fraction is pH and temperature
+    dependent and unmodelled here. The constant must not read as a toxicity limit."""
+    import pathlib
+    # Comment markers stripped, then whitespace normalised: the note wraps across lines, so both
+    # the newline AND the leading "#" of the continuation land in the middle of the phrase. An
+    # exact-substring match would fail for reasons that have nothing to do with the documentation.
+    raw = (pathlib.Path(__file__).resolve().parents[1] / "scenario.py").read_text()
+    src = " ".join(line.lstrip().lstrip("#").strip() for line in raw.splitlines())
+    src = " ".join(src.split())
+    assert "CONSERVATIVE PROXY" in src
+    assert "un-ionised NH3 fraction" in src
+    assert "never as a safety certificate" in src
+
+
+# --- interventions -----------------------------------------------------------
+
+def test_stocking_more_fish_carries_into_the_run():
+    state = _settled()
+    res = run_scenario(state, SP, Intervention("stock 5 kg", add_fish_kg=5.0), **_common())
+    assert res.trajectory[0].state.fish_biomass_kg >= 5.0
+
+
+def test_a_smaller_bed_pushes_nitrate_up():
+    state = _settled()
+    big = run_scenario(state, SP, Intervention("as-is"), **_common())
+    small = run_scenario(state, SP, Intervention(
+        "shrink the bed", plant_uptake_capacity_g_day=CROP.n_uptake_g_per_m2_day * 1), **_common())
+    assert small.outcomes["no3_mg_l"].peak > big.outcomes["no3_mg_l"].peak
+
+
+def test_is_deterministic():
+    state = _settled()
+    a = run_scenario(state, SP, Intervention("x", feed_g_per_day=FEED * 2), **_common())
+    b = run_scenario(state, SP, Intervention("x", feed_g_per_day=FEED * 2), **_common())
+    assert a.outcomes["no2_mg_l"].peak == b.outcomes["no2_mg_l"].peak
+
+
+def test_thresholds_cover_every_reported_channel():
+    state = _settled()
+    res = _baseline(state)
+    assert set(res.outcomes) == set(THRESHOLDS_MG_L)

--- a/aqua_model/twin.py
+++ b/aqua_model/twin.py
@@ -85,6 +85,39 @@ _K_DENITRIFICATION = _N_REMOVAL_PER_DAY * DENITRIFICATION_FRACTION / _SINK_RATIO
 
 
 @dataclass(frozen=True)
+class TwinParams:
+    """The twin's own uncertain parameters, gathered so they can be varied deliberately.
+
+    These are NOT sizing coefficients — those live in `coefficients.py` with their sources and the
+    twin reuses them unchanged, which is what makes it converge to the steady-state model. These
+    are the parameters the STEPPED model adds, and they are literature-typical rather than fitted
+    to any real system. Naming them here does two things: it stops them being magic numbers buried
+    in the step function, and it lets the scenario engine sweep them to produce an uncertainty band
+    that reflects what is genuinely not known, instead of a band invented for the plot.
+    """
+
+    aob_doubling_days: float = 1.0
+    nob_doubling_days: float = 1.5
+    n_removal_per_day: float = 0.10
+
+    def k_plant(self) -> float:
+        return self.n_removal_per_day * C.PLANT_N_UPTAKE_FRACTION.value / _SINK_RATIO_TOTAL
+
+    def k_exchange(self) -> float:
+        return self.n_removal_per_day * WATER_EXCHANGE_FRACTION / _SINK_RATIO_TOTAL
+
+    def k_denitrification(self) -> float:
+        return self.n_removal_per_day * DENITRIFICATION_FRACTION / _SINK_RATIO_TOTAL
+
+
+# Plausible spread on each, for uncertainty bands. Nitrifier doubling times vary with temperature,
+# pH and media; nitrate turnover varies with exchange rate and crop demand.
+PARAMS_FAST = TwinParams(aob_doubling_days=0.7, nob_doubling_days=1.0, n_removal_per_day=0.15)
+PARAMS_TYPICAL = TwinParams()
+PARAMS_SLOW = TwinParams(aob_doubling_days=1.5, nob_doubling_days=2.5, n_removal_per_day=0.06)
+
+
+@dataclass(frozen=True)
 class TwinState:
     """Everything the nitrogen twin carries forward. Concentrations are mg/L as N."""
 
@@ -157,6 +190,7 @@ def step(
     temperature_c: float,
     dt_days: float = 1.0,
     plant_uptake_capacity_g_day: float | None = None,
+    params: TwinParams | None = None,
 ) -> StepResult:
     """Advance the twin by `dt_days`.
 
@@ -170,6 +204,7 @@ def step(
     outlasts it. That lag is the classic new-system nitrite spike, and it falls out of the rates
     rather than being scripted.
     """
+    params = params or PARAMS_TYPICAL
     if dt_days <= 0:
         raise ValueError("dt_days must be positive")
     if state.volume_l <= 0:
@@ -214,7 +249,7 @@ def step(
     # after another lets the first sink shrink the pool the next one sees, which biases the split
     # toward whichever happens to be evaluated first (~3% toward plants, in practice).
     pool = no3_g
-    plant_demand = pool * _K_PLANT * dt_days
+    plant_demand = pool * params.k_plant() * dt_days
     if plant_uptake_capacity_g_day is not None:
         capped = min(plant_demand, plant_uptake_capacity_g_day * dt_days)
         if capped < plant_demand - 1e-9:
@@ -222,8 +257,8 @@ def step(
                 "plant uptake is capacity-limited — nitrate will accumulate until the crop, "
                 "water exchange or bed area changes")
         plant_demand = capped
-    exch_demand = pool * _K_EXCHANGE * dt_days
-    denit_demand = pool * _K_DENITRIFICATION * dt_days
+    exch_demand = pool * params.k_exchange() * dt_days
+    denit_demand = pool * params.k_denitrification() * dt_days
 
     total_demand = plant_demand + exch_demand + denit_demand
     if total_demand > pool > 0:                 # a long step cannot remove more than exists
@@ -235,8 +270,8 @@ def step(
     no3_g = max(0.0, pool - (n_plant + n_exchange + n_denit))
 
     # --- nitrifier populations respond to the load they just saw ---
-    aob_next = _grow(aob_cap, tan_demand_g_day, _AOB_DOUBLING_DAYS, dt_days)
-    nob_next = _grow(nob_cap, no2_demand_g_day, _NOB_DOUBLING_DAYS, dt_days)
+    aob_next = _grow(aob_cap, tan_demand_g_day, params.aob_doubling_days, dt_days)
+    nob_next = _grow(nob_cap, no2_demand_g_day, params.nob_doubling_days, dt_days)
 
     growth_kg = (effective_feed / species.fcr / 1000.0) if species.fcr > 0 else 0.0
 
@@ -280,6 +315,7 @@ def simulate(
     temperature_c: float,
     dt_days: float = 1.0,
     plant_uptake_capacity_g_day: float | None = None,
+    params: TwinParams | None = None,
 ) -> list[StepResult]:
     """Roll the twin forward and return every step, so the PATH is inspectable — not just where
     it ended up. The whole point is the transient."""
@@ -288,7 +324,8 @@ def simulate(
     cur = state
     for _ in range(steps):
         r = step(cur, species, feed_g_per_day=feed_g_per_day, temperature_c=temperature_c,
-                 dt_days=dt_days, plant_uptake_capacity_g_day=plant_uptake_capacity_g_day)
+                 dt_days=dt_days, plant_uptake_capacity_g_day=plant_uptake_capacity_g_day,
+                 params=params)
         out.append(r)
         cur = r.state
     return out


### PR DESCRIPTION
Phase 4 of #85 — the scenario engine.

## What it does

`twin.py` rolls one system forward. This forks it: take the state a system is in now, apply a change, run both branches, report the difference.

```
TRIPLE THE FEED
  This makes water quality worse before it settles — stage it or add capacity first.
   - ammonia rises to 8.12 mg/L (plausible range 7.09-10.37) from a baseline near zero
   - ammonia crosses 0.5 mg/L for 4 days — the baseline never does
     (knowledge/nitrogen_cycle_and_cycling.md)
   - nitrite peak 31.0x higher (0.22 -> 6.77 mg/L, plausible range 4.08-14.38)
   - nitrite crosses 0.5 mg/L for 7 days — the baseline never does
   - nitrate peak 3.2x higher (21.18 -> 67.18 mg/L)
```

Forking is safe by construction: `TwinState` is frozen — a property added in #89 before there was anything to fork, and now the thing the engine rests on.

## Comparison, not prediction — deliberately

An absolute number ("nitrite will reach 2.3 mg/L") claims accuracy the twin has not earned. It has never been validated against a real system, because no public dataset pairs feeding records with independently-measured nitrogen (#87).

A **relative** statement survives being wrong about the absolute level, because the same unmodelled error sits in both branches and largely cancels. So the engine reports ratios, day-offsets and threshold crossings — never a bare forecast.

Uncertainty bands are swept over `TwinParams`: the nitrifier doubling times and nitrate turnover rate the *stepped* model adds and nobody has fitted. Those were magic numbers inside the step function; gathering them makes the band reflect **what is genuinely unknown** rather than a spread invented for the plot. Sizing coefficients are *not* varied — the twin reuses them unchanged, which is what makes it converge to `nitrogen_check`.

## Two results the obvious implementation gets wrong

Both were caught by writing the test first, and both would have shipped as confident advice.

**A cold snap was reported as "improves water quality".** Chilling tilapia to 18 °C lowers every nitrogen channel — *because the fish stop eating*. A nitrogen-only model reads starvation as cleaner water, and would effectively have recommended chilling fish out of their thermal range to fix an ammonia problem. The verdict now says what it is actually looking at:

> *Nitrogen levels fall, but only because the fish are outside their temperature optimum and eating less. That is suppressed feeding, not a healthier system — this model sees nitrogen only, and cannot speak to fish welfare or growth.*

The model's blind spot **is** the finding, so it has to be said out loud rather than papered over.

**"ammonia peak 678.6x higher".** Arithmetically true against a settled baseline of 0.012 mg/L, and useless — the precision is noise and it buries the real result. Below a materiality floor the absolute level is reported instead.

## The ammonia threshold is a proxy, and says so

Crossings cite `knowledge/nitrogen_cycle_and_cycling.md`. The ammonia figure is **total** ammonia nitrogen and is documented as a **CONSERVATIVE PROXY, not a toxicity calculation** — what harms fish is the un-ionised NH₃ fraction, whose share rises sharply with pH and temperature and which this model explicitly does not compute. **At high pH the real danger begins below the number quoted.** A crossing means "look at this", never "you are safe".

## How it was verified

```
$ pytest -q
796 passed

$ python -m scripts.safety_eval
Advice-safety golden set: 373/373 passed (score 1.000)
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

### Trust-zone checklist

- [x] No new import of an LLM, network, or UI library — imports `dataclasses` and the model's own modules
- [x] Any new number lives in `coefficients.py` with value, range, unit, **source** — the thresholds are not model coefficients; they are curated operator guidance and cite their file, and the proxy caveat is asserted by a test
- [x] Any new user-facing result states what it does **not** model — `NOT_MODELLED` travels with every result, and the output declares itself unvalidated
- [x] Model-proposed values still reach the core only through a validation gate
- [ ] A probe in `docs/dpg/safety_eval/golden_set.json` — not yet: nothing here reaches an operator until this is wired to an agent tool. That wiring is the right moment for a probe, and the 16 unit tests cover the guarantees now.

## What this does NOT do

- **It is not wired to the agent or the UI.** Deliberate. The honesty gate in #85 says an unvalidated twin may not present forward predictions to an operator, and exposing this as a tool would do exactly that. It ships as a library the next phase can use once there is a validation story.
- **It cannot rank interventions by welfare, cost, or yield** — only by nitrogen. The cold-snap case is the worked example of why that matters, and why the verdict refuses to give advice it has no standing to give.
- **Absolute levels should not be quoted to operators.** The band widths (nitrite 4.08–14.38 on a 6.77 central estimate) are the honest picture of how little is pinned down.
- **No sensor assimilation.** Scenarios start from a state you supply; correcting that state against live readings is phase 3, which remains blocked on a held-out dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYe3JRXxqYfRYQRRj5nF3U
