### PR TITLE
feat(intake+costing): both front doors onto the twin, and designs priced with researched regional prices

### DIFF
--- a/agronaut_agent/profile.py
+++ b/agronaut_agent/profile.py
@@ -16,6 +16,10 @@ PROFILE_KEYS: tuple[str, ...] = (
     "water_budget_lpd",
     "ph",
     "tank_volume_l",         # actual tank on a running system (input, not computed)
+    "fish_count",            # head currently stocked (running system)
+    "fish_avg_weight_g",     # mean weight of the stocked fish (running system)
+    "system_type",           # raft | nft | media_bed | vertical_tower
+    "climate_site",          # fetched climate slug for the twin (e.g. ouagadougou_2025)
     "dissolved_oxygen_mgl",
     "ammonia_mgl",
     "water_source",
@@ -52,6 +56,10 @@ _LABELS: dict[str, str] = {
     "crop": "crop",
     "grow_area_m2": "grow area",
     "tank_volume_l": "tank (L)",
+    "fish_count": "fish (head)",
+    "fish_avg_weight_g": "avg fish weight (g)",
+    "system_type": "growing method",
+    "climate_site": "climate site",
     "temperature_c": "temp (°C)",
     "ph": "pH",
     "dissolved_oxygen_mgl": "DO (mg/L)",
@@ -65,8 +73,9 @@ _LABELS: dict[str, str] = {
 }
 
 # Default display order: system spec first, then water params, then goal.
-_SYSTEM_ORDER = ("system_stage", "location", "fish_species", "crop", "grow_area_m2",
-                 "tank_volume_l", "water_budget_lpd", "water_source")
+_SYSTEM_ORDER = ("system_stage", "location", "fish_species", "crop", "system_type",
+                 "grow_area_m2", "tank_volume_l", "fish_count", "fish_avg_weight_g",
+                 "water_budget_lpd", "water_source", "climate_site")
 _WATER_ORDER = ("temperature_c", "ph", "dissolved_oxygen_mgl", "ammonia_mgl")
 _GOAL_ORDER = ("goal", "goal_detail", "objective", "experience_level")
 
@@ -97,9 +106,13 @@ _TOOL_PROFILE_ARGS: dict[str, tuple[str, ...]] = {
                              "water_budget_lpd"),
     "optimize_fish_crop_ratio": ("grow_area_m2", "temperature_c", "water_budget_lpd",
                                  "objective"),
+    "simulate_season": ("fish_species", "crop", "grow_area_m2", "system_type"),
+    "design_system_3d": ("fish_species", "crop", "grow_area_m2", "temperature_c",
+                         "water_budget_lpd", "system_type"),
 }
 # Substrings that mark a tool result as a non-success — never persist args from these.
-_TOOL_FAILURE_MARKERS = ("VALIDATION_FAILED", "TOOL_ERROR", "Unknown objective", "Unknown tool")
+_TOOL_FAILURE_MARKERS = ("VALIDATION_FAILED", "TOOL_ERROR", "Unknown objective", "Unknown tool",
+                         "Unknown species", "No climate file")
 
 
 def profile_updates_from_tool(name: str, args: dict, result: str) -> dict:

--- a/agronaut_agent/profile.py
+++ b/agronaut_agent/profile.py
@@ -109,10 +109,13 @@ _TOOL_PROFILE_ARGS: dict[str, tuple[str, ...]] = {
     "simulate_season": ("fish_species", "crop", "grow_area_m2", "system_type"),
     "design_system_3d": ("fish_species", "crop", "grow_area_m2", "temperature_c",
                          "water_budget_lpd", "system_type"),
+    "estimate_system_cost": ("fish_species", "crop", "grow_area_m2", "temperature_c",
+                             "water_budget_lpd", "system_type"),
 }
 # Substrings that mark a tool result as a non-success — never persist args from these.
 _TOOL_FAILURE_MARKERS = ("VALIDATION_FAILED", "TOOL_ERROR", "Unknown objective", "Unknown tool",
-                         "Unknown species", "No climate file")
+                         "Unknown species", "No climate file", "Unknown region",
+                         "No price book")
 
 
 def profile_updates_from_tool(name: str, args: dict, result: str) -> dict:

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -14,7 +14,7 @@ def test_tool_registry():
     assert "optimize_fish_crop_ratio" in names
     assert "search_knowledge_base" in names
     assert "remember_about_user" in names
-    assert len(AGRONAUT_TOOLS) == 20
+    assert len(AGRONAUT_TOOLS) == 21
 
 
 def test_size_valid_carries_numbers_and_sources():
@@ -166,7 +166,7 @@ def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "update_profile" in names
-    assert len(AGRONAUT_TOOLS) == 20
+    assert len(AGRONAUT_TOOLS) == 21
 
 
 def test_update_profile_writes_canonical_drops_unknown():
@@ -197,7 +197,7 @@ def test_registry_includes_schedule_followup():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "schedule_followup" in names
-    assert len(AGRONAUT_TOOLS) == 20
+    assert len(AGRONAUT_TOOLS) == 21
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
@@ -241,7 +241,7 @@ def test_registry_includes_community_tools():
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "nominate_shared_insight" in names
     assert "search_community_knowledge" in names
-    assert len(AGRONAUT_TOOLS) == 20
+    assert len(AGRONAUT_TOOLS) == 21
 
 
 def test_nominate_writes_pending_and_rejects_blank():
@@ -292,7 +292,7 @@ def test_registry_includes_record_measurement():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "record_measurement" in names
-    assert len(AGRONAUT_TOOLS) == 20
+    assert len(AGRONAUT_TOOLS) == 21
 
 
 def test_record_measurement_maps_metric_to_qualified_key():
@@ -455,7 +455,8 @@ def test_simulate_season_teaches_when_the_site_is_missing():
     """A missing climate file must return the fetch command, not a stack trace."""
     from agronaut_agent.tools import simulate_season
     text = simulate_season.func(fish_species="tilapia", crop="basil",
-                                grow_area_m2=10.0, site="atlantis")
+                                grow_area_m2=10.0, site="atlantis",
+                                water_budget_lpd=300.0)
     assert "fetch_climate.py" in text
     assert "atlantis" in text
 
@@ -467,3 +468,58 @@ def test_what_if_nitrogen_reports_relative_not_absolute():
                                  change="double feed", new_feed_g_per_day=300.0)
     assert "x higher" in text or "x lower" in text or "No material change" in text
     assert "unvalidated" in text
+
+
+def test_simulate_season_design_mode_stocks_the_designed_system():
+    """Path 1 of the intake procedure: the agreed design flows into the twin without
+    anyone retyping numbers — the summary label carries the design's own fish count."""
+    from agronaut_agent.tools import simulate_season
+    text = simulate_season.func(fish_species="tilapia", crop="basil", grow_area_m2=24.0,
+                                site="taichung_2025", water_budget_lpd=500.0,
+                                system_type="raft", days=60)
+    assert "designed:" in text and "fish" in text
+    assert "Season projection" in text
+
+
+def test_simulate_season_without_a_system_teaches_instead_of_guessing():
+    from agronaut_agent.tools import simulate_season
+    text = simulate_season.func(fish_species="tilapia", crop="basil",
+                                grow_area_m2=10.0, site="taichung_2025")
+    assert "water_budget_lpd" in text
+
+
+def test_simulate_my_system_asks_for_what_the_mirror_is_missing():
+    """Path 2: an incomplete profile returns the exact list to collect, not a guess."""
+    from agronaut_agent.store import _Db, MemoryStore
+    from agronaut_agent import runtime
+    from agronaut_agent.tools import simulate_my_system
+
+    mem = MemoryStore(_Db(":memory:"))
+    runtime.set_current(mem, "cli:t")
+    try:
+        mem.set_facts("cli:t", {"fish_species": "tilapia", "crop": "lettuce"},
+                      source="user_stated")
+        text = simulate_my_system.func()
+    finally:
+        runtime.clear_current()
+    assert "tank_volume_l" in text and "fish_count" in text and "climate_site" in text
+    assert "update_profile" in text
+
+
+def test_simulate_my_system_mirrors_a_complete_profile():
+    from agronaut_agent.store import _Db, MemoryStore
+    from agronaut_agent import runtime
+    from agronaut_agent.tools import simulate_my_system
+
+    mem = MemoryStore(_Db(":memory:"))
+    runtime.set_current(mem, "cli:t")
+    try:
+        mem.set_facts("cli:t", {
+            "fish_species": "tilapia", "crop": "basil", "grow_area_m2": 15,
+            "tank_volume_l": 2000, "fish_count": 60, "fish_avg_weight_g": 200,
+            "climate_site": "taichung_2025"}, source="user_stated")
+        text = simulate_my_system.func(days=60)
+    finally:
+        runtime.clear_current()
+    assert "your system" in text
+    assert "Season projection" in text

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -14,7 +14,7 @@ def test_tool_registry():
     assert "optimize_fish_crop_ratio" in names
     assert "search_knowledge_base" in names
     assert "remember_about_user" in names
-    assert len(AGRONAUT_TOOLS) == 21
+    assert len(AGRONAUT_TOOLS) == 22
 
 
 def test_size_valid_carries_numbers_and_sources():
@@ -166,7 +166,7 @@ def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "update_profile" in names
-    assert len(AGRONAUT_TOOLS) == 21
+    assert len(AGRONAUT_TOOLS) == 22
 
 
 def test_update_profile_writes_canonical_drops_unknown():
@@ -197,7 +197,7 @@ def test_registry_includes_schedule_followup():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "schedule_followup" in names
-    assert len(AGRONAUT_TOOLS) == 21
+    assert len(AGRONAUT_TOOLS) == 22
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
@@ -241,7 +241,7 @@ def test_registry_includes_community_tools():
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "nominate_shared_insight" in names
     assert "search_community_knowledge" in names
-    assert len(AGRONAUT_TOOLS) == 21
+    assert len(AGRONAUT_TOOLS) == 22
 
 
 def test_nominate_writes_pending_and_rejects_blank():
@@ -292,7 +292,7 @@ def test_registry_includes_record_measurement():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "record_measurement" in names
-    assert len(AGRONAUT_TOOLS) == 21
+    assert len(AGRONAUT_TOOLS) == 22
 
 
 def test_record_measurement_maps_metric_to_qualified_key():
@@ -523,3 +523,11 @@ def test_simulate_my_system_mirrors_a_complete_profile():
         runtime.clear_current()
     assert "your system" in text
     assert "Season projection" in text
+
+
+def test_estimate_system_cost_degrades_without_a_price_book_or_region():
+    from agronaut_agent.tools import estimate_system_cost
+    text = estimate_system_cost.func(fish_species="tilapia", crop="basil",
+                                     grow_area_m2=24.0, temperature_c=27.0,
+                                     water_budget_lpd=500.0, region="list")
+    assert "price book" in text.lower() or "region" in text.lower()

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -862,6 +862,60 @@ def design_system_3d(
             f"simulate a season at their site next (simulate_season).")
 
 
+@tool
+def estimate_system_cost(
+    fish_species: str,
+    crop: str,
+    grow_area_m2: float,
+    temperature_c: float,
+    water_budget_lpd: float,
+    region: str,
+    system_type: str = "raft",
+    greenhouse: str = "poly",
+) -> str:
+    """ESTIMATE what the designed system costs to BUILD (capex) and RUN (opex/year), from
+    researched regional prices with sources and dates. Quantities are taken off the same
+    deterministic design + layout the 3D view draws, so the estimate prices the system the
+    user saw. Output is RANGES, names any component the region's book cannot price (the
+    total excludes it, loudly), and lists what is not included (land, labour, delivery).
+
+    Use whenever a design conversation reaches budget: "what will it cost", "can I afford
+    this", "cost in my country". region: a key from the price book — call with an unknown
+    region (e.g. 'list') to get the available regions. greenhouse: 'poly' or 'shade'
+    (prices the envelope the user will actually build)."""
+    import json
+    from pathlib import Path
+
+    from aqua_model.costing import estimate_cost, format_estimate
+    from aqua_model.layout import plan_layout
+
+    book_path = Path(__file__).resolve().parent.parent / "data" / "price_book.json"
+    if not book_path.exists():
+        return ("No price book on disk yet (data/price_book.json). Tell the user cost "
+                "estimation is being set up and they should ask again soon.")
+    book = json.loads(book_path.read_text())
+    regions = sorted(book.get("regions", {}))
+    region_key = str(region).strip().lower()
+    if region_key not in book.get("regions", {}):
+        return ("Unknown region: choose one of " + ", ".join(regions) +
+                ". Pick the closest to the user's location and SAY which you used — "
+                "prices vary hugely between regions.")
+    try:
+        design = validate_design_input(fish_species, crop, grow_area_m2, temperature_c,
+                                       water_budget_lpd, None, system_type)
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    out = size_system(design)
+    layout = plan_layout(out, crop_label=crop, species_label=fish_species)
+    est = estimate_cost(out, layout, book, region_key,
+                        species_key=str(fish_species).strip().lower(),
+                        greenhouse_mode=str(greenhouse).strip().lower())
+    header = ("" if out.feasible
+              else f"NOTE: this design is infeasible ({out.binding_constraint}) — "
+                   "the estimate prices it anyway, but fix the design first.\n\n")
+    return header + format_estimate(est)
+
+
 AGRONAUT_TOOLS = [
     size_aquaponics_system,
     size_mixed_bed_aquaponics,
@@ -874,6 +928,7 @@ AGRONAUT_TOOLS = [
     render_system_schematic,
     simulate_season,
     simulate_my_system,
+    estimate_system_cost,
     what_if_nitrogen,
     design_system_3d,
     search_knowledge_base,

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -418,9 +418,11 @@ def update_profile(updates: dict) -> str:
     have learned, e.g. {"goal": "optimize", "objective": "protein", "grow_area_m2": 10,
     "tank_volume_l": 1000, "dissolved_oxygen_mgl": 5.5}. Canonical keys: system_stage,
     fish_species, crop, grow_area_m2, temperature_c, water_budget_lpd, ph, tank_volume_l,
-    dissolved_oxygen_mgl, ammonia_mgl, water_source, location, goal, goal_detail,
-    objective, experience_level. Unknown keys are ignored. Call this whenever the user
-    reveals a durable fact — do not wait for the end of the conversation."""
+    fish_count, fish_avg_weight_g, system_type, climate_site, dissolved_oxygen_mgl,
+    ammonia_mgl, water_source, location, goal, goal_detail, objective, experience_level.
+    Unknown keys are ignored. Call this whenever the user reveals a durable fact — do not
+    wait for the end of the conversation. For a user with a RUNNING system, fish_count,
+    fish_avg_weight_g, tank_volume_l and climate_site are what simulate_my_system needs."""
     cur = runtime.get_current()
     if cur is None:
         return "Profile unavailable right now."
@@ -576,66 +578,186 @@ def _climate_days(site: str):
     return from_records(payload["days"]), payload.get("site", {})
 
 
+def _greenhouse_from(mode: str, heat_setpoint_c: float | None):
+    from aqua_model.climate import GreenhouseParams as _GH
+
+    mode = str(mode).strip().lower()
+    if mode == "shade":
+        return _GH(shade_to_ambient=True), "shade"
+    if mode == "heated" or heat_setpoint_c is not None:
+        return _GH(heat_setpoint_c=float(heat_setpoint_c or 26.0)), "heated"
+    return _GH(), "poly"
+
+
+def _run_season(*, species_key: str, crop_key: str, grow_area_m2: float, site: str,
+                init, days: int, greenhouse: str, heat_setpoint_c: float | None,
+                label_extra: str = "") -> str:
+    from aqua_model.production import ProductionParams as _PP, format_summary, simulate_production
+    from aqua_model.crops import get_crop
+    from aqua_model.species import get_species
+
+    weather, _meta = _climate_days(site)
+    gh, mode = _greenhouse_from(greenhouse, heat_setpoint_c)
+    n_days = max(1, min(int(days), len(weather)))
+    run = simulate_production(
+        init(weather[0].t_mean_c) if callable(init) else init,
+        weather[:n_days], get_species(species_key), species_key, get_crop(crop_key),
+        float(grow_area_m2), params=_PP(greenhouse=gh))
+    label = f"{site} · {mode}" + (f" @{gh.heat_setpoint_c:.0f}C" if gh.heat_setpoint_c else "")
+    return format_summary(run, site_label=label + label_extra)
+
+
 @tool
 def simulate_season(
     fish_species: str,
     crop: str,
     grow_area_m2: float,
     site: str,
-    fish_count: int = 80,
-    start_weight_g: float = 50.0,
-    volume_l: float = 3000.0,
+    fish_count: int | None = None,
+    start_weight_g: float = 20.0,
+    volume_l: float | None = None,
+    water_budget_lpd: float | None = None,
+    system_type: str = "raft",
     days: int = 365,
     greenhouse: str = "poly",
     heat_setpoint_c: float | None = None,
+    biofilter_cycled: bool | None = None,
 ) -> str:
     """SIMULATE a season of this system at a real site — the digital twin. Returns projected
     fish harvest (kg), crop harvest (kg), feed use and realized FCR, water-temperature range,
     nitrogen peaks, and WHICH factor limited the crop (light / temperature / nitrogen), with
     honest warnings (lethal-temperature days, suppressed feeding) and what is NOT modelled.
 
-    Use for any "how much will it produce", "will it work in <place>/<season>", "what if I
-    add a heater / use shade instead" question. Run it twice with one change to compare
-    scenarios — the relative difference is the trustworthy part.
+    TWO WAYS TO SET THE SYSTEM — prefer the first after a design conversation:
+    1. FROM THE AGREED DESIGN (leave fish_count and volume_l unset, give water_budget_lpd
+       and system_type): the tool sizes the design itself with the same deterministic
+       calculator and stocks it with the design's own fish count and volume — no retyping
+       numbers between tools, so the twin simulates exactly the system that was designed.
+    2. EXPLICIT (give fish_count and volume_l directly), for ad-hoc questions. For a
+       system the user already runs, prefer simulate_my_system, which reads their profile.
 
-    site: a fetched climate slug (e.g. 'ouagadougou_2025', 'taichung_2025'). If missing, the
-        error tells you the fetch command to give the user.
-    greenhouse: 'poly' (plastic tunnel, +3C and 70% light), 'shade' (shade net / outdoors,
-        ambient temperature and full light), or 'heated' (poly + water heater; set
-        heat_setpoint_c, e.g. 26).
-    days: how many days of the climate file to run (starts at its first day)."""
-    from aqua_model.climate import GreenhouseParams as _GH
-    from aqua_model.crops import get_crop
-    from aqua_model.production import (
-        ProductionParams as _PP, format_summary, simulate_production, start_state,
-    )
+    Run twice with one change to compare scenarios — the relative difference is the
+    trustworthy part.
+
+    site: a fetched climate slug (e.g. 'ouagadougou_2025'). If missing, the error tells
+        you the fetch command to give the user.
+    greenhouse: 'poly' (+3C, 70% light), 'shade' (ambient, full light — the realistic hot-
+        climate option), or 'heated' (poly + water heater at heat_setpoint_c, e.g. 26).
+    start_weight_g: stocking weight (default 20 g fingerlings).
+    biofilter_cycled: leave unset for the honest default — a designed NEW build starts
+        uncycled (the cycling transient, nitrite spike included, is part of a first
+        season), an explicit run assumes an established, cycled system."""
+    from aqua_model.production import start_state, start_state_from_design
     from aqua_model.species import get_species
 
+    species_key = str(fish_species).strip().lower()
+    crop_key = str(crop).strip().lower()
     try:
-        species = get_species(str(fish_species).strip().lower())
-        crop_obj = get_crop(str(crop).strip().lower())
+        species = get_species(species_key)
+        from aqua_model.crops import get_crop
+        get_crop(crop_key)
     except KeyError as err:
         return f"Unknown species or crop: {err}. Call list_supported_species_and_crops."
+
+    designed_note = ""
+    if fish_count is None or volume_l is None:
+        # Design mode: size the system the user agreed to, then stock it.
+        if water_budget_lpd is None:
+            return ("Give either (fish_count and volume_l) for an explicit run, or "
+                    "water_budget_lpd (+ system_type) so I can size the agreed design first.")
+        try:
+            design = validate_design_input(species_key, crop_key, float(grow_area_m2),
+                                           26.0, float(water_budget_lpd), None,
+                                           str(system_type).strip().lower())
+        except ValidationError as err:
+            return serialize.serialize_validation_error(err.errors)
+        out = size_system(design)
+        if not out.feasible:
+            return (f"The design is infeasible ({out.binding_constraint}) — fix the design "
+                    "before simulating it.")
+
+        cycled = False if biofilter_cycled is None else bool(biofilter_cycled)
+
+        def init(t0: float):
+            return start_state_from_design(out, species, water_temp_c=t0,
+                                           start_weight_g=float(start_weight_g),
+                                           cycled=cycled)
+        designed_note = (f" · designed: {out.fish_count} fish, "
+                         f"{out.system_volume_l:,.0f} L")
+    else:
+        cycled = True if biofilter_cycled is None else bool(biofilter_cycled)
+
+        def init(t0: float):
+            return start_state(volume_l=float(volume_l), fish_count=int(fish_count),
+                               start_weight_g=float(start_weight_g), water_temp_c=t0,
+                               species=species, cycled=cycled)
     try:
-        weather, site_meta = _climate_days(site)
+        return _run_season(species_key=species_key, crop_key=crop_key,
+                           grow_area_m2=float(grow_area_m2), site=site, init=init,
+                           days=days, greenhouse=greenhouse,
+                           heat_setpoint_c=heat_setpoint_c, label_extra=designed_note)
     except FileNotFoundError as err:
         return str(err)
-    mode = str(greenhouse).strip().lower()
-    if mode == "shade":
-        gh = _GH(shade_to_ambient=True)
-    elif mode == "heated" or heat_setpoint_c is not None:
-        gh = _GH(heat_setpoint_c=float(heat_setpoint_c or 26.0))
-    else:
-        gh = _GH()
-    n_days = max(1, min(int(days), len(weather)))
-    init = start_state(volume_l=float(volume_l), fish_count=int(fish_count),
-                       start_weight_g=float(start_weight_g),
-                       water_temp_c=weather[0].t_mean_c, species=species)
-    run = simulate_production(
-        init, weather[:n_days], species, str(fish_species).strip().lower(), crop_obj,
-        float(grow_area_m2), params=_PP(greenhouse=gh))
-    label = f"{site} · {mode}" + (f" @{gh.heat_setpoint_c:.0f}C" if gh.heat_setpoint_c else "")
-    return format_summary(run, site_label=label)
+
+
+@tool
+def simulate_my_system(
+    site: str | None = None,
+    days: int = 365,
+    greenhouse: str = "poly",
+    heat_setpoint_c: float | None = None,
+) -> str:
+    """SIMULATE the season ahead for the system THIS USER ALREADY RUNS, from their saved
+    profile — the digital-twin mirror of their real farm. Use whenever a user with an
+    existing system asks "what will MY system do", "should I add a heater", "is my winter
+    going to be a problem". Before calling, make sure the profile holds their real setup
+    (update_profile with: fish_species, crop, grow_area_m2, tank_volume_l, fish_count,
+    fish_avg_weight_g, and climate_site once their weather is fetched). If anything
+    essential is missing this returns the exact list to ask the user for — ask, save with
+    update_profile, then call again. The biofilter is assumed cycled (it is a running
+    system). Compare scenarios by calling twice with a different greenhouse mode."""
+    from aqua_model.production import start_state
+    from aqua_model.species import get_species
+
+    cur = runtime.get_current()
+    if cur is None:
+        return "Profile unavailable right now — use simulate_season with explicit numbers."
+    mem, user_id = cur
+    facts = mem.get_facts(user_id) or {}
+
+    needed = ("fish_species", "crop", "grow_area_m2", "tank_volume_l", "fish_count",
+              "fish_avg_weight_g")
+    missing = [k for k in needed if not str(facts.get(k, "")).strip()]
+    site = _clean_optional(site) or str(facts.get("climate_site", "")).strip()
+    if not site:
+        missing.append("climate_site (fetch their weather first: "
+                       "python scripts/fetch_climate.py --lat <LAT> --lon <LON> --name <site>)")
+    if missing:
+        return ("To mirror their system I still need: " + ", ".join(missing) +
+                ". Ask the user, save with update_profile, then call this again.")
+
+    species_key = str(facts["fish_species"]).strip().lower()
+    try:
+        species = get_species(species_key)
+    except KeyError:
+        return f"Unknown species in profile: {facts['fish_species']!r} — correct it first."
+
+    def init(t0: float):
+        return start_state(volume_l=float(facts["tank_volume_l"]),
+                           fish_count=int(float(facts["fish_count"])),
+                           start_weight_g=float(facts["fish_avg_weight_g"]),
+                           water_temp_c=t0, species=species, cycled=True)
+    try:
+        return _run_season(species_key=species_key,
+                           crop_key=str(facts["crop"]).strip().lower(),
+                           grow_area_m2=float(facts["grow_area_m2"]), site=site,
+                           init=init, days=days, greenhouse=greenhouse,
+                           heat_setpoint_c=heat_setpoint_c,
+                           label_extra=" · your system")
+    except FileNotFoundError as err:
+        return str(err)
+    except (KeyError, ValueError) as err:
+        return f"Profile value unusable: {err} — correct it with update_profile."
 
 
 @tool
@@ -751,6 +873,7 @@ AGRONAUT_TOOLS = [
     render_pilot_proposal,
     render_system_schematic,
     simulate_season,
+    simulate_my_system,
     what_if_nitrogen,
     design_system_3d,
     search_knowledge_base,

--- a/aqua_model/costing.py
+++ b/aqua_model/costing.py
@@ -1,0 +1,250 @@
+"""Cost estimation: the sized design, priced with researched regional prices.
+
+A design conversation ends with "what will this cost me?", and the honest answer has three
+parts this module keeps separate:
+
+    the QUANTITY TAKEOFF   — what to buy and how much, derived from the design and layout
+                             (deterministic, auditable, no prices involved);
+    the PRICE BOOK         — researched regional prices with source and date, loaded from
+                             `data/price_book.json` by the CALLER (this module never reads
+                             a file — trust-zone rules);
+    the ESTIMATE           — takeoff x prices, as RANGES, because a price book is research,
+                             not a quote.
+
+Every line carries its unit price's source; missing prices appear as explicit UNPRICED
+lines instead of silently shrinking the total — an estimate that omits the greenhouse
+because nobody priced greenhouses is worse than no estimate. Totals therefore state both
+the priced subtotal and what is missing from it.
+
+The price book's numbers are seeds in the same sense as every coefficient here: researched,
+cited, dated, and meant to be replaced by local quotes. The output says so.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from .layout import Layout
+from .system_types import get_system_type
+from .types import DesignOutput
+
+NOT_INCLUDED = (
+    "land, site preparation and foundations",
+    "labour (a labour_day price may exist in the book, but build hours vary too much to guess)",
+    "delivery and transport",
+    "permits and water rights",
+    "backup power (a battery or generator is strongly advised for NFT and high stocking)",
+    "plumbing sundries beyond the fitting allowance (valves, unions, bulkheads vary by build)",
+)
+
+# Fitting allowance on straight pipe: elbows, tees and glue typically add ~30% to a run.
+_PIPE_FITTING_FACTOR = 1.3
+# Air stones scale with tanks and beds (FAO 589: one per 2-4 m2 of raft canal).
+_RAFT_M2_PER_AIRSTONE = 3.0
+
+
+@dataclass(frozen=True)
+class TakeoffLine:
+    """One thing to buy: a quantity with a unit, before any price is attached."""
+
+    key: str          # canonical price-book key, e.g. "tank_1000l"
+    label: str
+    qty: float
+    unit: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class CostLine:
+    takeoff: TakeoffLine
+    unit_price: float | None = None      # None => unpriced in this region's book
+    low: float | None = None
+    high: float | None = None
+    source: str = ""
+
+    def subtotal(self) -> tuple[float, float, float] | None:
+        if self.unit_price is None:
+            return None
+        lo = self.low if self.low is not None else self.unit_price
+        hi = self.high if self.high is not None else self.unit_price
+        q = self.takeoff.qty
+        return (q * lo, q * self.unit_price, q * hi)
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    region: str
+    currency: str
+    as_of: str
+    capex: tuple[CostLine, ...]
+    opex_per_year: tuple[CostLine, ...]
+    unpriced: tuple[str, ...]            # labels the book could not price
+    not_included: tuple[str, ...] = NOT_INCLUDED
+
+    def _total(self, lines: tuple[CostLine, ...]) -> tuple[float, float, float]:
+        lo = mid = hi = 0.0
+        for line in lines:
+            s = line.subtotal()
+            if s:
+                lo, mid, hi = lo + s[0], mid + s[1], hi + s[2]
+        return lo, mid, hi
+
+    def capex_total(self) -> tuple[float, float, float]:
+        return self._total(self.capex)
+
+    def opex_total(self) -> tuple[float, float, float]:
+        return self._total(self.opex_per_year)
+
+
+def takeoff(out: DesignOutput, layout: Layout, *, species_key: str = "tilapia",
+            greenhouse_mode: str = "poly") -> list[TakeoffLine]:
+    """What the design needs bought, in price-book units. Quantities come from the same
+    numbers the 3D layout draws, so the estimate prices the system the user saw."""
+    system = get_system_type(out.system_type)
+    lines: list[TakeoffLine] = []
+
+    tanks = layout.by_role("fish_tank")
+    tank_units = sum(max(0.25, (math.pi * (t.d / 2) ** 2 * t.h) ) for t in tanks)
+    lines.append(TakeoffLine("tank_1000l", "fish/rearing tanks", round(tank_units, 1),
+                             "x 1000 L equivalent", f"{len(tanks)} tank(s) + sump/clarifier below"))
+    # clarifier + sump volumes also hold water and cost roughly like tanks per litre
+    aux = layout.by_role("clarifier") + layout.by_role("biofilter") + layout.by_role("sump")
+    aux_m3 = 0.0
+    for c in aux:
+        aux_m3 += (math.pi * (c.d / 2) ** 2 * c.h) if c.kind == "cyl" else c.w * c.l * c.h
+    if aux_m3:
+        lines.append(TakeoffLine("tank_1000l", "filtration vessels (clarifier/biofilter/sump)",
+                                 round(aux_m3, 1), "x 1000 L equivalent"))
+
+    if system.key == "raft":
+        lines.append(TakeoffLine("raft_foam_m2", "raft boards", round(out.grow_area_m2, 1), "m²"))
+        lines.append(TakeoffLine("liner_m2", "canal liner",
+                                 round(out.grow_area_m2 * 1.4, 1), "m²",
+                                 "bed floor + walls allowance"))
+    elif system.key == "media_bed":
+        media_m3 = out.grow_area_m2 * system.water_depth_m * 1.5
+        lines.append(TakeoffLine("gravel_m3", "grow-bed media (gravel/LECA)",
+                                 round(media_m3, 1), "m³", "bed volume x 1.5 settling"))
+        lines.append(TakeoffLine("liner_m2", "bed liner", round(out.grow_area_m2 * 1.6, 1), "m²"))
+    elif system.key == "nft":
+        channel_m = out.grow_area_m2 / 0.15   # one 0.15 m-wide planted strip per channel run
+        lines.append(TakeoffLine("nft_channel_m", "NFT channels", round(channel_m, 1), "m"))
+    elif system.key == "vertical_tower":
+        towers = max(1, round(out.grow_area_m2 / (system.footprint_ratio * 0.4 * 0.4) / 6))
+        lines.append(TakeoffLine("vertical_tower_unit", "grow towers", towers, "towers",
+                                 "media-filled vertical units incl. drip line"))
+
+    if not system.provides_biofiltration and out.biofilter_media_m2:
+        lines.append(TakeoffLine("biofilter_media_m3", "biofilter media",
+                                 round(out.biofilter_media_m2 / 200.0 / 0.6, 2), "m³",
+                                 "at ~200 m²/m³ specific surface, 60% packing"))
+
+    lines.append(TakeoffLine("pump_small", "water pump",
+                             max(1, len(tanks) // 3 + 1), "unit",
+                             f"≥{out.pump_turnover_lph:.0f} L/h at ~{out.pump_head_m:.1f} m head"))
+    n_stones = len(tanks) + max(1, round(out.grow_area_m2 / _RAFT_M2_PER_AIRSTONE)) \
+        if system.key == "raft" else len(tanks) + 2
+    lines.append(TakeoffLine("air_pump", "air pump/blower", 1, "unit"))
+    lines.append(TakeoffLine("air_stone", "air stones + tubing", n_stones, "unit"))
+
+    pipe_m = sum(
+        math.dist(a, b)
+        for p in layout.pipes for a, b in zip(p.path, p.path[1:])
+    ) * _PIPE_FITTING_FACTOR
+    lines.append(TakeoffLine("pvc_pipe_m", "PVC pipe + fitting allowance",
+                             round(pipe_m, 1), "m", "layout runs x 1.3 for fittings"))
+
+    gh = layout.greenhouse
+    gh_area = gh.width_m * gh.length_m
+    if greenhouse_mode == "shade":
+        lines.append(TakeoffLine("shade_net_m2", "shade-net structure", round(gh_area, 1), "m²"))
+    else:
+        lines.append(TakeoffLine("greenhouse_poly_m2", "poly tunnel (structure + film)",
+                                 round(gh_area, 1), "m²"))
+
+    fingerling_key = ("fingerling_clarias" if species_key == "clarias"
+                      else "fingerling_tilapia")
+    lines.append(TakeoffLine(fingerling_key, "fingerlings", out.fish_count, "head",
+                             "first stocking"))
+    return lines
+
+
+def opex_takeoff(out: DesignOutput) -> list[TakeoffLine]:
+    """Running quantities per year, from the same design numbers."""
+    feed_kg_yr = out.feed_g_per_day * 365.0 / 1000.0
+    kwh_yr = out.pump_power_w * 24.0 * 365.0 / 1000.0
+    water_m3_yr = out.makeup_water_lpd * 365.0 / 1000.0
+    return [
+        TakeoffLine("feed_kg", "fish feed", round(feed_kg_yr, 1), "kg/yr",
+                    "at the design feed rate; a growing cohort averages less in year one"),
+        TakeoffLine("electricity_kwh", "electricity (pump, continuous)",
+                    round(kwh_yr, 1), "kWh/yr", "aeration adds ~30-60% on top"),
+        TakeoffLine("water_m3", "make-up water", round(water_m3_yr, 1), "m³/yr"),
+    ]
+
+
+def _price(book_items: dict, line: TakeoffLine) -> CostLine:
+    it = book_items.get(line.key)
+    if not it:
+        return CostLine(takeoff=line)
+    return CostLine(takeoff=line, unit_price=float(it["price"]),
+                    low=float(it.get("low", it["price"])),
+                    high=float(it.get("high", it["price"])),
+                    source=str(it.get("source", "")))
+
+
+def estimate_cost(out: DesignOutput, layout: Layout, price_book: dict, region: str, *,
+                  species_key: str = "tilapia", greenhouse_mode: str = "poly") -> CostEstimate:
+    """Price the takeoff with one region's book. Raises KeyError for an unknown region —
+    a wrong region must fail loudly, not price Ouagadougou in Taiwan dollars."""
+    reg = price_book["regions"][region]
+    items = reg.get("items", {})
+    capex = tuple(_price(items, t) for t in takeoff(
+        out, layout, species_key=species_key, greenhouse_mode=greenhouse_mode))
+    opex = tuple(_price(items, t) for t in opex_takeoff(out))
+    unpriced = tuple(line.takeoff.label for line in capex + opex if line.unit_price is None)
+    return CostEstimate(region=region, currency=str(reg.get("currency", "?")),
+                        as_of=str(reg.get("as_of", "?")), capex=capex,
+                        opex_per_year=opex, unpriced=unpriced)
+
+
+def format_estimate(est: CostEstimate) -> str:
+    """Operator-facing cost sheet. Ranges, sources, and what is NOT in the number."""
+    def money(v: float) -> str:
+        return f"{v:,.0f}"
+
+    lines = [f"Cost estimate — {est.region} ({est.currency}, prices as of {est.as_of})", ""]
+    lines.append("BUILD (capex):")
+    for line in est.capex:
+        s = line.subtotal()
+        t = line.takeoff
+        if s:
+            lines.append(f"  {t.label:<38} {t.qty:g} {t.unit:<18} "
+                         f"{money(s[0])}–{money(s[2])}")
+        else:
+            lines.append(f"  {t.label:<38} {t.qty:g} {t.unit:<18} UNPRICED")
+    lo, mid, hi = est.capex_total()
+    lines.append(f"  {'TOTAL (priced lines)':<38} {'':<20} {money(lo)}–{money(hi)}"
+                 f"  (mid {money(mid)})")
+    lines.append("")
+    lines.append("RUN (opex, per year):")
+    for line in est.opex_per_year:
+        s = line.subtotal()
+        t = line.takeoff
+        if s:
+            lines.append(f"  {t.label:<38} {t.qty:g} {t.unit:<18} "
+                         f"{money(s[0])}–{money(s[2])}")
+        else:
+            lines.append(f"  {t.label:<38} {t.qty:g} {t.unit:<18} UNPRICED")
+    lo, mid, hi = est.opex_total()
+    lines.append(f"  {'TOTAL (priced lines)':<38} {'':<20} {money(lo)}–{money(hi)}")
+    if est.unpriced:
+        lines.append("")
+        lines.append("Unpriced in this region's book (total EXCLUDES these): "
+                     + ", ".join(dict.fromkeys(est.unpriced)))
+    lines += ["", "Not included: " + "; ".join(est.not_included[:4]) + "; ...",
+              "",
+              "These are researched price ranges with sources and dates "
+              "(data/price_book.json), not quotes — verify locally before budgeting."]
+    return "\n".join(lines)

--- a/aqua_model/costing.py
+++ b/aqua_model/costing.py
@@ -40,8 +40,6 @@ NOT_INCLUDED = (
 
 # Fitting allowance on straight pipe: elbows, tees and glue typically add ~30% to a run.
 _PIPE_FITTING_FACTOR = 1.3
-# Air stones scale with tanks and beds (FAO 589: one per 2-4 m2 of raft canal).
-_RAFT_M2_PER_AIRSTONE = 3.0
 
 
 @dataclass(frozen=True)
@@ -143,10 +141,10 @@ def takeoff(out: DesignOutput, layout: Layout, *, species_key: str = "tilapia",
     lines.append(TakeoffLine("pump_small", "water pump",
                              max(1, len(tanks) // 3 + 1), "unit",
                              f"≥{out.pump_turnover_lph:.0f} L/h at ~{out.pump_head_m:.1f} m head"))
-    n_stones = len(tanks) + max(1, round(out.grow_area_m2 / _RAFT_M2_PER_AIRSTONE)) \
-        if system.key == "raft" else len(tanks) + 2
-    lines.append(TakeoffLine("air_pump", "air pump/blower", 1, "unit"))
-    lines.append(TakeoffLine("air_stone", "air stones + tubing", n_stones, "unit"))
+    # Air stones ship bundled with pumps in every surveyed market; FAO 589 wants one
+    # stone per 2-4 m2 of raft canal, which sets the pump class, not a separate line.
+    lines.append(TakeoffLine("air_pump", "air pump/blower (incl. stones + tubing)", 1,
+                             "unit", "size for ~1 stone per 3 m² of raft area + 1 per tank"))
 
     pipe_m = sum(
         math.dist(a, b)

--- a/aqua_model/layout.py
+++ b/aqua_model/layout.py
@@ -185,7 +185,10 @@ def plan_layout(out: DesignOutput, *, crop_label: str = "", species_label: str =
 
     # --- grow zone ---
     role, bw, bl, bh, n_units, unit_label = _bed_units(out, system)
-    n_cols = max(1, math.ceil(math.sqrt(n_units * bw / max(bl, 1e-9))))
+    # Squarish envelope: columns span x at (bw + aisle) each, rows span y at (bl + aisle).
+    # Equal spans want n_cols ~ sqrt(n * (bl+aisle)/(bw+aisle)) — long beds need MORE
+    # columns, not fewer, or four 6 m raft beds stack into one 27 m tunnel.
+    n_cols = max(1, math.ceil(math.sqrt(n_units * (bl + AISLE_M) / (bw + AISLE_M))))
     n_cols = min(n_cols, n_units)
     n_rows = math.ceil(n_units / n_cols)
     beds_span_x = n_cols * bw + (n_cols - 1) * AISLE_M

--- a/aqua_model/production.py
+++ b/aqua_model/production.py
@@ -92,6 +92,27 @@ def start_state(*, volume_l: float, fish_count: int, start_weight_g: float,
     return ProductionState(nitrogen=nitrogen, fish=cohort, water_temp_c=water_temp_c)
 
 
+def start_state_from_design(out, species: FishSpecies, *, water_temp_c: float,
+                            start_weight_g: float = 20.0,
+                            cycled: bool = False) -> ProductionState:
+    """The agreed design, stocked on day one — the bridge from "here is your system"
+    to "here is what it will do".
+
+    Numbers come from the DesignOutput, not from the operator retyping them: fish count
+    and system volume are the sizing model's own, so the twin simulates exactly the
+    system that was designed. Fish start at fingerling weight (a new build stocks
+    fingerlings, not the harvest-size standing crop sizing plans around), and the
+    biofilter starts UNCYCLED by default, because a new build's does — the cycling
+    transient, nitrite spike included, is part of an honest first season. Pass
+    `cycled=True` only for a design being applied to an already-running system."""
+    if out.fish_count <= 0 or out.system_volume_l <= 0:
+        raise ValueError("design has no stocked fish or no volume — was it feasible?")
+    return start_state(
+        volume_l=out.system_volume_l, fish_count=out.fish_count,
+        start_weight_g=start_weight_g, water_temp_c=water_temp_c,
+        species=species, cycled=cycled)
+
+
 def step_production(
     state: ProductionState,
     day_weather: C.DailyClimate,

--- a/aqua_model/tests/test_costing.py
+++ b/aqua_model/tests/test_costing.py
@@ -1,0 +1,120 @@
+"""Costing: takeoff from the drawn layout, honest about every hole in the book."""
+
+import pytest
+
+from aqua_model.costing import (
+    NOT_INCLUDED, estimate_cost, format_estimate, opex_takeoff, takeoff,
+)
+from aqua_model.layout import plan_layout
+from aqua_model.sizing import size_system
+from aqua_model.validate import validate_design_input
+
+_BOOK = {
+    "regions": {
+        "testland": {
+            "currency": "TST",
+            "as_of": "2026-08",
+            "items": {
+                "tank_1000l": {"price": 100.0, "low": 80.0, "high": 140.0, "source": "test"},
+                "pump_small": {"price": 40.0, "source": "test"},
+                "air_pump": {"price": 30.0, "source": "test"},
+                "air_stone": {"price": 2.0, "source": "test"},
+                "pvc_pipe_m": {"price": 1.5, "source": "test"},
+                "raft_foam_m2": {"price": 6.0, "source": "test"},
+                "liner_m2": {"price": 4.0, "source": "test"},
+                "biofilter_media_m3": {"price": 250.0, "source": "test"},
+                "greenhouse_poly_m2": {"price": 12.0, "source": "test"},
+                "fingerling_tilapia": {"price": 0.3, "source": "test"},
+                "feed_kg": {"price": 1.2, "source": "test"},
+                "electricity_kwh": {"price": 0.15, "source": "test"},
+                "water_m3": {"price": 0.8, "source": "test"},
+            },
+        }
+    }
+}
+
+
+def _design(system_type="raft"):
+    out = size_system(validate_design_input(
+        "tilapia", "basil", 24.0, 27.0, 500.0, None, system_type))
+    return out, plan_layout(out)
+
+
+def test_takeoff_covers_the_things_a_build_needs():
+    out, layout = _design()
+    keys = {t.key for t in takeoff(out, layout)}
+    for k in ("tank_1000l", "raft_foam_m2", "pump_small", "air_pump", "pvc_pipe_m",
+              "greenhouse_poly_m2", "fingerling_tilapia"):
+        assert k in keys, f"takeoff is missing {k}"
+
+
+def test_takeoff_follows_the_system_type():
+    out, layout = _design("media_bed")
+    keys = {t.key for t in takeoff(out, layout)}
+    assert "gravel_m3" in keys and "raft_foam_m2" not in keys
+    assert "biofilter_media_m3" not in keys, "media beds ARE the biofilter"
+
+
+def test_a_complete_book_prices_everything():
+    out, layout = _design()
+    est = estimate_cost(out, layout, _BOOK, "testland")
+    assert est.unpriced == ()
+    lo, mid, hi = est.capex_total()
+    assert 0 < lo <= mid <= hi
+
+
+def test_a_hole_in_the_book_is_named_not_swallowed():
+    book = {"regions": {"testland": {
+        "currency": "TST", "as_of": "2026-08",
+        "items": {k: v for k, v in _BOOK["regions"]["testland"]["items"].items()
+                  if k != "greenhouse_poly_m2"}}}}
+    out, layout = _design()
+    est = estimate_cost(out, layout, book, "testland")
+    assert any("poly" in u for u in est.unpriced)
+    assert "UNPRICED" in format_estimate(est)
+    assert "EXCLUDES" in format_estimate(est)
+
+
+def test_an_unknown_region_fails_loudly():
+    out, layout = _design()
+    with pytest.raises(KeyError):
+        estimate_cost(out, layout, _BOOK, "atlantis")
+
+
+def test_opex_scales_with_the_design():
+    small, small_layout = _design()
+    big = size_system(validate_design_input("tilapia", "basil", 48.0, 27.0, 2000.0))
+    big_layout = plan_layout(big)
+    s = estimate_cost(small, small_layout, _BOOK, "testland").opex_total()[1]
+    b = estimate_cost(big, big_layout, _BOOK, "testland").opex_total()[1]
+    assert b > s
+
+
+def test_bigger_grow_area_costs_more_to_build():
+    small, sl = _design()
+    big = size_system(validate_design_input("tilapia", "basil", 48.0, 27.0, 2000.0))
+    bl = plan_layout(big)
+    assert (estimate_cost(big, bl, _BOOK, "testland").capex_total()[1]
+            > estimate_cost(small, sl, _BOOK, "testland").capex_total()[1])
+
+
+def test_shade_mode_swaps_the_envelope_line():
+    out, layout = _design()
+    keys = {t.key for t in takeoff(out, layout, greenhouse_mode="shade")}
+    assert "shade_net_m2" in keys and "greenhouse_poly_m2" not in keys
+
+
+def test_the_estimate_declares_what_it_leaves_out():
+    out, layout = _design()
+    est = estimate_cost(out, layout, _BOOK, "testland")
+    assert any("labour" in x for x in est.not_included)
+    assert "verify locally" in format_estimate(est)
+    assert len(NOT_INCLUDED) >= 4
+
+
+def test_every_priced_line_carries_its_source():
+    out, layout = _design()
+    est = estimate_cost(out, layout, _BOOK, "testland")
+    for line in est.capex + est.opex_per_year:
+        if line.unit_price is not None:
+            assert line.source, f"{line.takeoff.label} has a price but no source"

--- a/aqua_model/tests/test_production.py
+++ b/aqua_model/tests/test_production.py
@@ -137,3 +137,27 @@ def test_the_report_states_its_own_limits():
     assert "NOT modelled" in text
     assert "projection" in text
     assert "test site" in text
+
+
+def test_a_designed_system_flows_into_the_twin_unchanged():
+    """Path 1 of the intake procedure: the twin starts with the design's own numbers."""
+    from aqua_model.production import start_state_from_design
+    from aqua_model.sizing import size_system
+    from aqua_model.validate import validate_design_input
+
+    out = size_system(validate_design_input("tilapia", "basil", 24.0, 27.0, 500.0))
+    state = start_state_from_design(out, TILAPIA, water_temp_c=26.0, start_weight_g=20.0)
+    assert state.fish.count == out.fish_count
+    assert state.nitrogen.volume_l == out.system_volume_l
+    assert state.fish.mean_weight_g == 20.0
+    # a new build starts uncycled — the seed capacity, not a mature biofilter
+    assert state.nitrogen.aob_capacity_g_day < 0.1
+
+
+def test_an_infeasible_design_cannot_seed_the_twin():
+    from aqua_model.production import start_state_from_design
+    from aqua_model.types import DesignOutput
+
+    empty = DesignOutput(feasible=False)
+    with pytest.raises(ValueError, match="feasible"):
+        start_state_from_design(empty, TILAPIA, water_temp_c=26.0)

--- a/data/price_book.json
+++ b/data/price_book.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "1.0.0",
+  "description": "Regional component prices for aquaponics cost estimation (aqua_model/costing.py). Every item carries value/low/high in the region's currency, a source, and a basis tag: official = government/utility/manufacturer list price; retail_snapshot = e-commerce or store listing at as_of date; guide = extension/cost-guide aggregate; derived = unit conversion or interpolation performed by us and flagged. These are researched estimates to be replaced by local quotes — never quotes themselves. Missing items are deliberately absent: the estimator shows them as UNPRICED rather than inventing a number.",
+  "fx_note": "As of 2026-08: 1 USD ~= 31.9 TWD; 1 USD ~= 562 XOF (XOF pegged to EUR at 655.957).",
+  "regions": {
+    "burkina_faso": {
+      "currency": "XOF",
+      "as_of": "2026-08",
+      "items": {
+        "tank_1000l": {"price": 110000, "low": 95000, "high": 185000, "unit": "per 1000 L vessel", "basis": "retail_snapshot", "source": "Ouagadougou: used food-grade IBC 96,875 XOF (ouagadougou.online, page read) to 150,000 (FB vendor); new Polytank-type 1000 L 181,250 XOF (vendor price table parsed)"},
+        "pump_small": {"price": 13000, "low": 8000, "high": 18000, "unit": "per unit (20-45 W class)", "basis": "retail_snapshot", "source": "Côte d'Ivoire proxy (Jumia CI, read): 20 W 7,700-7,800; 35 W high-flow 17,900; 45 W 9,030 XOF — expect a Ouagadougou import markup; no BF shelf price found"},
+        "air_pump": {"price": 9000, "low": 3500, "high": 50000, "unit": "per unit incl. stones", "basis": "retail_snapshot", "source": "Hobby-class w/ 2 stones 3,500-9,000 XOF (Jumia CI, read); pond-class blower/compressor 33,000-50,000 XOF (Nigeria proxy, snippets) — pick by system size"},
+        "pvc_pipe_m": {"price": 1400, "low": 800, "high": 2000, "unit": "per metre, 32-50 mm pressure", "basis": "derived", "source": "CI/Senegal per-bar prices interpolated (Maison BCS Abidjan read: PVC32 2,000/bar, PVC50 4,500/bar; Senegal guide read); BF small-diameter bars not publicly priced. BF fittings verified: coude 32 = 150, coude 50 = 275 XOF (songnabadistribution.com, read)"},
+        "gravel_m3": {"price": 10000, "low": 8000, "high": 15000, "unit": "per m3 delivered", "basis": "derived", "source": "Bobo-Dioulasso truckload prices 2021 (~5,000-8,500 XOF/m3, L'Express du Faso, read) inflated to 2026 (our extrapolation); Abidjan ~14,000-15,000 XOF/m3 at 1.5-1.6 t/m3"},
+        "raft_foam_m2": {"price": 8000, "low": 6500, "high": 10500, "unit": "per m2 EPS 20-40 mm", "basis": "retail_snapshot", "source": "Abidjan EPS sheets (produitbat.ci, snippet-only): 20 mm ~6,500, 40 mm ~10,425 XOF/m2; CYPE CI generator ~5,800 installed. No BF listing found — phone-check before contracting"},
+        "greenhouse_poly_m2": {"price": 12000, "low": 7000, "high": 14000, "unit": "per m2 floor, TURNKEY incl. structure+film+install", "basis": "guide", "source": "Agro Serre Innovation CI (read): 250 m2 = 14,000 XOF/m2, 500-1,000 m2 = 12,000; Senegal semi-tunnel ~7,000-10,000. No Burkina-specific quote found"},
+        "shade_net_m2": {"price": 1000, "low": 430, "high": 1300, "unit": "per m2 NET MATERIAL ONLY", "basis": "retail_snapshot", "source": "Abidjan (constructeurdeserre.com, Dec 2025, read): 40% = 900, 50% = 1,000, 70% = 1,300 XOF/m2; Senegal roll ~430. Support STRUCTURE unpriced by any verifiable source — budget posts + wire + labour on top"},
+        "fingerling_tilapia": {"price": 100, "low": 60, "high": 250, "unit": "per fingerling", "basis": "official", "source": "Bagré, Burkina: 60-250 XOF by size (Sidwaya, 28 May 2023, article read); ~100 XOF for 10 g commonly quoted"},
+        "fingerling_clarias": {"price": 90, "low": 80, "high": 100, "unit": "per fingerling", "basis": "retail_snapshot", "source": "ENESA hatchery sales, 80-100 XOF (Ministry MAERAH FB, snippet); Benin CoinAfrique corroborates 60-100 by size"},
+        "feed_kg": {"price": 800, "low": 500, "high": 1200, "unit": "per kg floating pellet ~30% CP", "basis": "retail_snapshot", "source": "Local Faso Guulgo plant 500-550 XOF/kg (africavet, snippet); imported Ghanaian ~850-1,200 (Sidwaya, read); 2026 ad 640-800 XOF/kg by volume. CP% rarely stated — verify"},
+        "electricity_kwh": {"price": 105, "low": 96, "high": 138, "unit": "per kWh", "basis": "official", "source": "SONABEL grid (plateformewattia.com mirror, read; sonabel.bf unreachable): B1 monophasé 96/102/109 XOF by tranche; social tariff to 138; GlobalPetrolPrices avg 123 XOF (read)"},
+        "water_m3": {"price": 439, "low": 188, "high": 1104, "unit": "per m3", "basis": "official", "source": "ONEA 2021 tariff PDF (read): households 188 (0-8 m3) to 1,104 XOF/m3 (>25 m3); sociétés flat 1,104; eau brute (raw water) 439 — the realistic farm rate where available. Tranche 1 harmonised at 188 nationwide Apr 2026 (minute.bf, read)"},
+        "labour_day": {"price": 2500, "low": 2000, "high": 3000, "unit": "per helper-day, Ouagadougou", "basis": "derived", "source": "Tradesmen-reported manoeuvre rate 2,000-2,500 XOF/day (anecdotal, FB); Senegal benchmark 1,500-3,000 (read); SMIG 45,000 XOF/month (Nov 2023 decree). Mason 5,000-7,500/day is a neighbour-anchored estimate"}
+      }
+    },
+    "taiwan": {
+      "currency": "TWD",
+      "as_of": "2026-08",
+      "items": {
+        "tank_1000l": {"price": 4000, "low": 1800, "high": 5500, "unit": "per 1000 L vessel", "basis": "retail_snapshot", "source": "PE round tank NT$3,300-5,500 (lvneng.com.tw list/online, Shopee, findprice); used food-grade IBC totes NT$1,500-1,900 set the low end"},
+        "pump_small": {"price": 900, "low": 600, "high": 2100, "unit": "per unit (~3000 L/h class)", "basis": "retail_snapshot", "source": "UP/ISTA 3000 L/h submersibles, momo/PChome Aug 2026"},
+        "air_pump": {"price": 2000, "low": 500, "high": 5900, "unit": "per unit", "basis": "retail_snapshot", "source": "small dual-outlet aquarium pump NT$460-990 (momo/feebee); pond-scale ALITA AL-60 blower NT$4,290-5,880 (BigGo) — pick by system size"},
+        "pvc_pipe_m": {"price": 25, "low": 22, "high": 34, "unit": "per metre, 32-38 mm PVC-U", "basis": "official", "source": "Nan Ya (nanya-pipe.com) list price: W25 NT$22.58/m, W30 NT$27.25/m; hardware retail slightly higher"},
+        "gravel_m3": {"price": 750, "low": 540, "high": 900, "unit": "per m3", "basis": "derived", "source": "GSMMA national aggregate stats Jun 2026: crushed stone NT$359-372/tonne ex-plant, converted at 1.5-1.6 t/m3 (our conversion); ~NT$900/m3 delivered per Tainan-area quotes"},
+        "biofilter_media_m3": {"price": 12000, "low": 9000, "high": 36000, "unit": "per m3 K1-style carriers", "basis": "retail_snapshot", "source": "Taiwan retail NT$200-210/kg (~5.5 L/kg => ~NT$36,000/m3, twaqua/Yahoo); Alibaba bulk US$280-300/m3 FOB (~NT$9,000-9,600) — buy bulk, add freight"},
+        "raft_foam_m2": {"price": 500, "low": 270, "high": 980, "unit": "per m2", "basis": "retail_snapshot", "source": "EPE foam board ~NT$270/m2; dedicated EPS hydroponic float boards NT$790-980/m2 (BigGo, Aug 2026)"},
+        "liner_m2": {"price": 30, "low": 22, "high": 61, "unit": "per m2 HDPE-type membrane", "basis": "retail_snapshot", "source": "BigGo pond-liner rolls NT$22-61/m2 by thickness; heavy PVC canvas ponds are custom-quoted"},
+        "nft_channel_m": {"price": 240, "low": 218, "high": 265, "unit": "per metre incl. holes", "basis": "retail_snapshot", "source": "jeida.com.tw 6 m/30-hole channel NT$1,400 (NT$233/m); 1212.com.tw NT$218-263/m"},
+        "greenhouse_poly_m2": {"price": 900, "low": 756, "high": 1059, "unit": "per m2 floor, materials + erection", "basis": "guide", "source": "Simple steel-pipe + poly-film house NT$2,500-3,500/ping (PRO360 2026 cost guide; MOA portal quoting builder; farmer build ~NT$929/m2)"},
+        "shade_net_m2": {"price": 18, "low": 17, "high": 20, "unit": "per m2 NET MATERIAL ONLY", "basis": "retail_snapshot", "source": "60% shade net rolls, Yahoo listings — support structure NOT priced in this book; expect the structure to dominate the cost"},
+        "fingerling_tilapia": {"price": 6, "low": 4, "high": 10, "unit": "per fingerling", "basis": "retail_snapshot", "source": "YiHua hatchery (FB): 2 cm+ NT$4, 4 cm+ NT$6; 50-fish.com 6-7 cm NT$10 at 300+ pcs"},
+        "feed_kg": {"price": 50, "low": 32, "high": 77, "unit": "per kg floating pellet", "basis": "derived", "source": "Fwusow anchors: 23% CP tilapia pellet ~NT$32/kg, 43% CP ~NT$71-77/kg (Shopee, Aug 2026); a 32% CP grade falls between — midpoint is our interpolation, not a listing"},
+        "electricity_kwh": {"price": 3.78, "low": 1.78, "high": 6.44, "unit": "per kWh residential", "basis": "official", "source": "Taipower tariff (taipower.com.tw): non-time-of-use tiers NT$1.78-8.86 summer / 1.78-7.03 non-summer; ~NT$3.78 average after Oct-2025 adjustment"},
+        "water_m3": {"price": 11.55, "low": 7.35, "high": 12.08, "unit": "per m3 incl. 5% tax", "basis": "official", "source": "Taiwan Water Corporation tiers: NT$7.35 (<=10 m3/mo) to NT$12.075 (>50 m3/mo), plus meter base fee"}
+      }
+    },
+    "global_us": {
+      "currency": "USD",
+      "as_of": "2026-08",
+      "items": {
+        "tank_1000l": {"price": 350, "low": 150, "high": 380, "unit": "per 275-gal (1040 L) IBC", "basis": "retail_snapshot", "source": "New food-grade IBC $349.99 (ibctanks.com); reconditioned ~$150"},
+        "pump_small": {"price": 26, "low": 20, "high": 50, "unit": "per unit (~3000 L/h class)", "basis": "retail_snapshot", "source": "VIVOSUN 800 GPH $23.99-25.99 (Walmart/vivosun.com); hobby 35-100 W class $20-50"},
+        "air_pump": {"price": 50, "low": 35, "high": 60, "unit": "per unit", "basis": "retail_snapshot", "source": "VIVOHOME 32 W 6-outlet commercial air pump COMBO incl. 2 air stones + 25 ft tubing, $49.99 (Home Depot)"},
+        "pvc_pipe_m": {"price": 5.5, "low": 4.2, "high": 9.0, "unit": "per metre, 1.5-2 in Sch 40", "basis": "retail_snapshot", "source": "Ace $12.99 / Tractor Supply $14.99 per 1.5 in x 10 ft ($4.3-4.9/m); 2 in solid-core $9/m (Home Depot)"},
+        "gravel_m3": {"price": 60, "low": 39, "high": 105, "unit": "per m3 delivered", "basis": "guide", "source": "LawnStarter/HomeGuide/Angi 2025-26 aggregates: $30-80/cu yd materials"},
+        "biofilter_media_m3": {"price": 300, "low": 280, "high": 330, "unit": "per m3 K1-style carriers, FOB China", "basis": "retail_snapshot", "source": "Alibaba MBBR carriers ~500 m2/m3: $300/m3 (1-9 m3), $280/m3 (10+); add freight"},
+        "raft_foam_m2": {"price": 15, "low": 10, "high": 21, "unit": "per m2 (1-2 in XPS)", "basis": "retail_snapshot", "source": "Owens Corning FOAMULAR NGX F-250 2 in 4x8 ft $60.96 => $20.5/m2 (Home Depot); 1 in ~half"},
+        "liner_m2": {"price": 16, "low": 8, "high": 25, "unit": "per m2 EPDM 45-mil", "basis": "guide", "source": "EPDM pond liner $0.75-2.30/sq ft (Moore Water Gardens, HomeGuide/HomeAdvisor)"},
+        "nft_channel_m": {"price": 27, "low": 19, "high": 37, "unit": "per metre", "basis": "retail_snapshot", "source": "CropKing 10 in channel $68 per 6-12 ft channel => $18.6-37.2/m; unit ambiguity on 4.5 in line flagged"},
+        "greenhouse_poly_m2": {"price": 25, "low": 11, "high": 43, "unit": "per m2 floor, DIY materials", "basis": "guide", "source": "UMass Extension high tunnels $1-2/sq ft; Sheridan/UWyo build $3.1-3.6/sq ft; U. Arkansas FSA-6147 itemized budget"},
+        "shade_net_m2": {"price": 1.6, "low": 1.4, "high": 2.5, "unit": "per m2 CLOTH ONLY", "basis": "retail_snapshot", "source": "AMGO 50% shade cloth 10x12 ft $17.45 (Home Depot) — support structure NOT priced"},
+        "fingerling_tilapia": {"price": 1.0, "low": 0.45, "high": 1.65, "unit": "per fingerling", "basis": "retail_snapshot", "source": "Wholesale $0.45-0.50/inch min 1,000 (Miami Aquaculture); retail $0.89-1.63 each (Mineral Springs, Lakeway)"},
+        "feed_kg": {"price": 2.9, "low": 2.4, "high": 3.3, "unit": "per kg 32% CP floating pellet", "basis": "retail_snapshot", "source": "Purina AquaMax Grower 400 (32% CP) $74.37/50 lb = $3.28/kg; AquaMax 500 (41%) $2.42/kg"},
+        "electricity_kwh": {"price": 0.184, "low": 0.135, "high": 0.184, "unit": "per kWh", "basis": "official", "source": "EIA Electricity Monthly Update May 2026: residential avg 18.44 c/kWh, commercial 13.54 c/kWh; state spread not captured"},
+        "water_m3": {"price": 1.6, "low": 1.59, "high": 1.8, "unit": "per m3 water only, excl. sewer", "basis": "derived", "source": "AWWA 2022 rate survey ~$1.59/m3 at 7,500 gal/mo; +6%/yr per Bluefield => ~$1.7-1.8 in 2025-26 (our extrapolation)"}
+      }
+    }
+  }
+}

--- a/knowledge/economics_and_costs.md
+++ b/knowledge/economics_and_costs.md
@@ -45,6 +45,16 @@ an engineering one.
 - **Calibration** — matching stocking, feed, and grow area to what the system actually
   sustains avoids wasted feed, water, and materials.
 
+## Priced numbers live in the price book, not here
+
+Agronaut carries a **regional price book** (`data/price_book.json`) with researched
+prices — value, range, currency, source, and an as-of date — for the components its
+designs call for (tanks, pumps, aeration, pipe, media, rafts, envelope, fingerlings,
+feed, electricity, water), currently for Burkina Faso / West Africa, Taiwan, and a
+global/US baseline. The `estimate_system_cost` tool prices a sized design against it as
+a range, names anything the book cannot price, and always says: these are researched
+estimates to verify with local quotes, not quotes.
+
 ## How to think about feasibility
 
 Before building, estimate: annual energy cost (pump + aeration + climate control), annual


### PR DESCRIPTION
Stacked on #91 (production twin) — merge #90 then #91 first; this diff is the four commits above them. Implements the two-path intake procedure and location-aware cost estimation.

## The two front doors

**Path 1 — new system (design-first).** `simulate_season` gains a design mode: given the same validated inputs the design conversation agreed on, it re-sizes the system deterministically and stocks the twin with the design's own fish count and volume (`production.start_state_from_design`). Nobody retypes numbers between tools, and a new build starts with an uncycled biofilter — the cycling transient, nitrite spike included, is part of an honest first season.

**Path 2 — existing system (mirror-first).** New `simulate_my_system` tool reads the user's persistent profile (extended with `fish_count`, `fish_avg_weight_g`, `system_type`, `climate_site`) and simulates *their* farm. An incomplete profile returns the exact list of facts to collect, never a guess. Twin/costing tool args auto-persist through the existing fact-carrying-tool seam, with new failure markers so rejected inputs are never remembered as truth.

## Costing (`aqua_model/costing.py` + `data/price_book.json`)

- **Quantity takeoff** from the same `DesignOutput` + `Layout` the 3D view draws: tanks by drawn volume, media by bed volume, pipe from the plumbing runs × a fitting allowance, envelope by the derived greenhouse area, fingerlings by the stocked count, plus yearly feed/electricity/water.
- **Researched price book, three regions** — Burkina Faso (XOF), Taiwan (TWD), global/US (USD). Every item carries value/range, unit, a basis tag (official / retail_snapshot / guide / derived) and its source. Primary sources include SONABEL + ONEA tariffs (official PDF read), Taipower + Taiwan Water Corp tariffs, Nan Ya PVC list prices, EIA, Sidwaya (fingerling prices at Bagré), and Ouagadougou vendor price tables parsed from their own pages.
- **Honesty rules:** estimates are ranges, not quotes; a hole in the book becomes an explicit UNPRICED line the total loudly excludes (e.g. no verifiable West African bed-liner price exists); land/labour/delivery declared not included.
- New `estimate_system_cost` tool (22 tools total).

## Also

Fixes the layout column-packing heuristic (aspect ratio was inverted: four 6 m raft beds stacked into one 27 m tunnel — 248 m² of greenhouse for 24 m² of beds; now 101 m², capex −40%).

## Sanity anchors

- Burkina, 24 m² media-bed under shade net: ~1.0–2.0M XOF build, feed dominating opex — matching the feed-cost pain the Burkinabè press reports.
- Taiwan, 24 m² raft + poly tunnel: ~NT$125–279k build, envelope-dominated.

## Tests

Repo-wide 755 pass; the 2 failures are the known pre-existing environment-only RAG failures (missing optional deps), verified unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QG2dvkkSQJDrPzohMciSi