### PR TITLE
fix(telegram): the twin gave only text — measured causes, retry-before-fallback, and a 20x faster model

### DIFF
--- a/agent/llm.py
+++ b/agent/llm.py
@@ -170,8 +170,18 @@ class ResilientChat:
         try:
             return self.primary.invoke(messages)
         except Exception:  # timeout, 5xx, starved model — anything: don't kill the turn
-            log.warning("primary LLM failed; using fallback model", exc_info=True)
-            return self.fallback.invoke(messages)
+            # Retry the PRIMARY once before falling back. Free-tier 503s are transient
+            # (measured: NVIDIA's worker-limit errors clear in seconds), and the fallback
+            # is a much smaller model — silently dropping every congested turn to it is
+            # how "the bot only gives text answers" happens without anyone seeing an error.
+            log.warning("primary LLM failed; retrying once before fallback", exc_info=True)
+            import time as _time
+            _time.sleep(2.0)
+            try:
+                return self.primary.invoke(messages)
+            except Exception:
+                log.warning("primary LLM failed twice; using fallback model", exc_info=True)
+                return self.fallback.invoke(messages)
 
 
 def build_fallback_chat(provider: str | None = None, model: str | None = None):

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,8 @@ Needs (in .env or the environment):
   TELEGRAM_BOT_TOKEN   from @BotFather
   AGRONAUT_ALLOWED_IDS comma-separated Telegram user IDs allowed to use the bot
   LLM_PROVIDER=nvidia  NVIDIA_API_KEY=...   (tool-calling brain; free at build.nvidia.com)
-  LLM_MODEL            optional, e.g. meta/llama-3.1-70b-instruct
+  LLM_MODEL            optional; mistralai/mistral-nemotron measured 20x faster than
+                       llama-3.3-70b with correct tool calls (docs/telegram_twin_testing.md)
 """
 
 from __future__ import annotations

--- a/docs/telegram_twin_testing.md
+++ b/docs/telegram_twin_testing.md
@@ -1,0 +1,79 @@
+# Testing the twin over Telegram: setup, the script, and what "working" looks like
+
+## Before anything: pulling code does not reload a running bot
+
+A running `python bot.py` keeps executing the code it started with. After `git pull` you
+MUST restart the process, and it is worth verifying what the process will actually run:
+
+```bash
+git log --oneline -1          # should show the twin merge (PR #97 or later)
+pkill -f "python bot.py"      # or stop it however you run it (systemd, tmux, ...)
+python bot.py
+```
+
+`/help` in Telegram is the quickest freshness check: the new build advertises
+*Simulate*, *Mirror ... LIVE*, *Estimate*, and *Show ... in 3D*. If `/help` does not
+mention Simulate, the process is still running old code.
+
+## The model matters — and the default was the problem
+
+The twin flows are multi-step tool conversations, and two measured facts about the
+NVIDIA free tier (2026-08, this repo's own benchmark) decide the experience:
+
+| model | one LLM round-trip | tool selection on twin flows |
+|---|---|---|
+| `meta/llama-3.3-70b-instruct` (old default) | **~56 s** | correct |
+| `mistralai/mistral-nemotron` | **~2-3 s** | correct |
+| `meta/llama-3.1-8b-instruct` (the fallback) | ~1 s | shaky on complex flows |
+
+A turn uses 2-6 round-trips, so the old default produced **3-5 minute replies**, and under
+free-tier congestion (503s are routine) every failed call silently fell back to the 8B
+model — which answers in text instead of calling tools. That combination reads exactly as
+"the twin doesn't work, I only get text." Two fixes shipped with this doc: the primary is
+retried once before falling back, and the recommended config is now:
+
+```
+LLM_PROVIDER=nvidia
+LLM_MODEL=mistralai/mistral-nemotron
+```
+
+Set it in the server's `.env` and restart. (Any tool-capable hosted model works; this one
+measured 20x faster with correct tool choice on the twin flows.)
+
+## The test script — six messages, in order
+
+Each step names the tool that should fire and what arriving proof looks like. Watch the
+server log too: every tool call is logged.
+
+1. **"I want to design a system with catfish and lettuce, about 15 m², media bed,
+   in Bobo-Dioulasso. My power is sometimes unreliable and I'm still learning."**
+   → after it gathers water budget/temperature: `design_full_system`. Proof: a component
+   list with reasons ("Architecture: COUPLED... settling tank — ..."), a power warning,
+   and a **3D HTML file delivered as a document** you can open in the phone browser.
+2. **"How much will it produce over a year?"**
+   → `fetch_site_climate` (first time only — it geocodes the town and pulls real NASA
+   weather; no commands to run), then `simulate_season`. Proof: a season projection with
+   kg fish, kg crop, the limiting factor, and honesty lines.
+3. **"What would it cost to build here, and does it make money if I sell at the market?"**
+   → `estimate_system_cost` / `business_case` (channel='direct'). Proof: ranged costs in
+   XOF with sources, margin, payback — or a plainly stated loss.
+4. **"My system is running: 2000 L tank, 60 catfish around 200 g."**
+   → `update_profile` saves it. Then:
+5. **"Today I measured ammonia 0.5, nitrate 40, water 27."**
+   → `log_my_readings`. Proof: drift notes — "model was X% low on nitrate — pulled toward
+   yours" — and a one-line snapshot. This is the LIVE twin: its state now persists.
+6. **"How's my system doing? What will this week do to it?"**
+   → `my_system_forecast`. Proof: "advanced N day(s) through your site's real weather" and
+   a forecast over the actual coming days.
+
+## When a step gives only text
+
+- **Check the server log first.** A `primary LLM failed` warning means free-tier
+  congestion; the retry usually rides it out, but a hammered hour is a hammered hour.
+- **The model may be asking a fair question** — the consultation gathers essentials
+  before acting. "Which water budget?" is the design working, not failing.
+- **Rephrase toward the concrete.** Small hosted models tool-call best on specific asks
+  ("simulate a season for X at Y") and worst on vague ones ("tell me about my system").
+- If text-only persists across all six steps after a restart with the recommended model,
+  capture the server log of one turn and open an issue — the log shows whether the model
+  never called a tool or a tool errored.


### PR DESCRIPTION
Field report: after pulling the twin merge, the Telegram bot "doesn't work — only text responses". Reproduced against the live NVIDIA endpoint with the server's own config; three compounding causes, all measured:

1. **A running bot doesn't reload on `git pull`** — restart required (now the first line of the new doc).
2. **The old primary was unusably slow under congestion**: `meta/llama-3.3-70b-instruct` measured **~56 s per LLM round-trip**; a multi-step twin conversation = 3–5 minutes. One probe even returned the model's own confusion text after 282 s.
3. **Every transient 503 silently downgraded the turn to the 8B fallback**, which answers in text instead of calling tools. Free-tier `ResourceExhausted` errors are routine (hit one within three benchmark calls). This is exactly "only text".

## Fixes

- `ResilientChat` retries the primary once (2 s backoff) before falling back — the measured congestion errors clear in seconds. Existing resilience tests pass unchanged.
- Recommended model → **`mistralai/mistral-nemotron`**: measured **2–3 s per round-trip** with correct tool selection on the twin flows (`simulate_season` with the right args; `design_full_system` with the needs). `bot.py` hint updated.
- **`docs/telegram_twin_testing.md`**: restart-and-verify checklist, the benchmark table, and a six-message test script that names the tool each step should fire and what proof looks like (the 3D file arriving as a Telegram document, drift notes from `log_my_readings`).

## Verification

Full brain loop (the bot's exact code path) completed a season simulation end-to-end — surviving a live 500 mid-conversation via the new retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QG2dvkkSQJDrPzohMciSi