### PR TITLE
fix(agent): the scaffold was teaching the model to fabricate tool results

### DIFF
--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -27,6 +27,34 @@ def _parse_allowlist(raw: str | None) -> set[str]:
     return {x.strip() for x in (raw or "").split(",") if x.strip()}
 
 
+# Readings syntax /log accepts, deliberately forgiving:
+#   /log ammonia 0.5 nitrate 40 temp 27
+#   /log ammonia=0.5, no2: 0.3, weight 210, count 58, shade
+_LOG_KEYS = {
+    "ammonia": "ammonia_mg_l", "nh3": "ammonia_mg_l", "nh4": "ammonia_mg_l",
+    "nitrite": "nitrite_mg_l", "no2": "nitrite_mg_l",
+    "nitrate": "nitrate_mg_l", "no3": "nitrate_mg_l",
+    "temp": "water_temp_c", "temperature": "water_temp_c", "water": "water_temp_c",
+    "weight": "fish_avg_weight_g", "count": "fish_count", "fish": "fish_count",
+}
+
+
+def parse_log_args(text: str) -> dict:
+    """Parse a /log command's free-form readings into log_my_readings kwargs. Pure and
+    unit-tested — this is a farmer's data-entry path and must not surprise anyone."""
+    import re
+    text = (text or "").lower()
+    args: dict = {}
+    for key, val in re.findall(r"([a-z][a-z0-9_]*)\s*[:=]?\s*(-?\d+(?:\.\d+)?)", text):
+        field = _LOG_KEYS.get(key)
+        if field:
+            args[field] = int(float(val)) if field == "fish_count" else float(val)
+    for mode in ("shade", "poly", "heated"):
+        if mode in text:
+            args["greenhouse"] = mode
+    return args
+
+
 class TelegramAdapter(ChannelAdapter):
     channel_name = "telegram"
 
@@ -83,6 +111,9 @@ class TelegramAdapter(ChannelAdapter):
             "• *Hear* a voice note and reply in your language\n"
             "• *Remember* your setup across chats\n\n"
             "Commands:\n"
+            "/log — put readings into your LIVE twin (works even when I'm slow):\n"
+            "    /log ammonia 0.5 nitrate 40 temp 27\n"
+            "/forecast — your twin now + the week ahead (add shade/poly/heated)\n"
             "/design — size a new system\n"
             "/optimize — best fish/crop ratio\n"
             "/troubleshoot — diagnose a problem\n"
@@ -93,6 +124,38 @@ class TelegramAdapter(ChannelAdapter):
             "/delete\\_me — permanently erase all your data",
             parse_mode="Markdown",
         )
+
+    async def _on_log(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        """Deterministic path into the LIVE twin — no LLM between the reading and the
+        state. Measured free-tier LLM failure modes (narrated-but-not-logged readings)
+        motivated this: a farmer's data must never depend on model weather."""
+        if not self._allowed(update):
+            return await self._deny(update)
+        args = parse_log_args(" ".join(ctx.args or []))
+        if not args:
+            return await update.message.reply_text(
+                "Give me readings, e.g.:\n/log ammonia 0.5 nitrate 40 temp 27\n"
+                "(keys: ammonia, nitrite/no2, nitrate/no3, temp, weight, count; "
+                "add shade/poly/heated for your cover)")
+        reply = await asyncio.to_thread(
+            self.agent.log_readings_direct, self.channel_name, self._identity(update), args)
+        await update.message.reply_text(reply)
+
+    async def _on_forecast(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        """Deterministic /forecast — the live twin advanced through real weather, no LLM."""
+        if not self._allowed(update):
+            return await self._deny(update)
+        days, greenhouse = 7, "poly"
+        for a in (ctx.args or []):
+            if a.isdigit():
+                days = max(2, min(int(a), 15))
+            elif a.lower() in ("shade", "poly", "heated"):
+                greenhouse = a.lower()
+        reply = await asyncio.to_thread(
+            self.agent.forecast_direct, self.channel_name, self._identity(update),
+            days, greenhouse)
+        for part in chunk(reply):
+            await update.message.reply_text(part)
 
     async def _on_whoami(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
@@ -281,6 +344,8 @@ class TelegramAdapter(ChannelAdapter):
             ("design", self._on_design, "Mode: size a new system"),
             ("optimize", self._on_optimize, "Mode: best fish/crop ratio"),
             ("troubleshoot", self._on_troubleshoot, "Mode: diagnose a problem"),
+            ("log", self._on_log, "Log readings into your LIVE twin"),
+            ("forecast", self._on_forecast, "Your live twin: now + the week ahead"),
             ("whoami", self._on_whoami, "What I remember about you"),
             ("export", self._on_export, "Download all my data (JSON)"),
             ("reset", self._on_reset, "Clear this conversation"),

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -175,6 +175,14 @@ _VERDICT_INSTRUCTION = (
 _MAX_ITERS = 6
 _TOOL_REPLAY_MAX_CHARS = 2000
 
+# A reply that ANNOUNCES an action — "I'll log your readings", "Let me check your
+# forecast" — and then stops, the promise substituting for the tool call. Measured on the
+# six-step live validation: three consecutive turns of narration with no effect. The
+# corrective nudge is safe for the ask-a-question case (see the nudge text).
+import re as _re
+
+_PROMISE = _re.compile(r"\b(i['’]ll|i will|let me|i am going to|i'm going to)\b", _re.I)
+
 
 class AgronautAgent:
     def __init__(self, llm_provider=None, llm_model=None, db_path=None, chat_model=None,
@@ -355,6 +363,7 @@ class AgronautAgent:
     # --- the tool-calling loop -------------------------------------------
     def _run_tool_loop(self, messages: list, user_id: str) -> str:
         fabrication_nudged = False
+        promise_nudged = False
         for _ in range(_MAX_ITERS):
             ai = self._bound.invoke(messages)
             messages.append(ai)
@@ -393,6 +402,15 @@ class AgronautAgent:
                     return ("I almost gave you numbers without computing them — caught it. "
                             "Ask me that again in one message and I'll run the real "
                             "calculation.")
+                if _PROMISE.search(text) and not promise_nudged:
+                    promise_nudged = True
+                    messages.append(SystemMessage(content=(
+                        "You ANNOUNCED an action but called no tool in that reply, so "
+                        "nothing actually happened. If the action needs a tool (logging "
+                        "readings, a forecast, saving the profile, sizing, costing), CALL "
+                        "the tool NOW and answer from its real output. If you were only "
+                        "asking the user a question, return your question unchanged.")))
+                    continue
                 return text or "I'm not sure how to help with that yet."
             for call in tool_calls:
                 tool = self._tools_by_name.get(call["name"])
@@ -584,6 +602,38 @@ class AgronautAgent:
         user_id = self._conv.get_or_create_user(channel, channel_user)
         block = self._recall_block(user_id)
         return block or "I don't know anything about your system yet. Tell me about it!"
+
+    def _run_tool_direct(self, channel: str, channel_user: str, tool_name: str,
+                         args: dict) -> str:
+        """Run one tool deterministically for a user, NO LLM in the path — backs the
+        /log and /forecast commands. The point is a guarantee: free-tier LLM weather
+        (congestion, leaked tool calls, narration instead of action — all measured) must
+        never stand between an operator and their own live twin. The result is recorded
+        in the conversation like any tool turn, so the LLM sees it as context later."""
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        tool = {t.name: t for t in AGRONAUT_TOOLS}[tool_name]
+        runtime.set_current(self._mem, user_id, self._followups, self._community,
+                            self._calibration)
+        try:
+            result = tool.invoke(args)
+        except Exception as exc:  # noqa: BLE001 — a command must answer, not stack-trace
+            result = f"That didn't work: {exc}"
+        finally:
+            runtime.clear_current()
+        self._conv.append_message(user_id, "tool", result, tool_name=tool_name)
+        self._analytics.record("tool_call", user_id=user_id, tool=tool_name,
+                               ok=not str(result).startswith("TOOL_ERROR"))
+        return result
+
+    def log_readings_direct(self, channel: str, channel_user: str, args: dict) -> str:
+        """Deterministic /log: readings straight into the live twin."""
+        return self._run_tool_direct(channel, channel_user, "log_my_readings", args)
+
+    def forecast_direct(self, channel: str, channel_user: str, days: int = 7,
+                        greenhouse: str = "poly") -> str:
+        """Deterministic /forecast: the live twin, advanced and projected."""
+        return self._run_tool_direct(channel, channel_user, "my_system_forecast",
+                                     {"days_ahead": days, "greenhouse": greenhouse})
 
     def reset(self, channel: str, channel_user: str) -> None:
         """Clear the conversation thread. Long-term memory (facts/memories) is kept."""

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -92,11 +92,18 @@ the twin says WHAT HAPPENS: harvests, seasons, money. Offer it, don't wait to be
 - "Can I double the feed / add fish / what does a cold week do?" on a live system ->
   what_if_nitrogen. Its verdicts are ratios, not absolutes, on purpose.
 - THE LIVE MIRROR, for a user with a running system and a fetched site: their twin
-  persists between chats and advances through their site's REAL weather. When they report
-  a reading (test kit, fish weighing, a death) -> log_my_readings; share the drift notes
-  it returns ("model was 30% low on nitrate") — that honesty builds trust. For "how's my
-  system / what will this week do" -> my_system_forecast. Pass the envelope they actually
-  run (greenhouse='shade'/'poly'/'heated') to both.
+  persists between chats and advances through their site's REAL weather. THREE MUSTS —
+  these are not answerable from memory, because the answer lives in stored state your
+  context cannot see:
+  * the user states their running system's facts (tank litres, fish count, weights) ->
+    you MUST call update_profile before replying, or the facts are lost when this chat ends;
+  * the user reports a MEASUREMENT (ammonia/nitrite/nitrate/pH/temperature values, a fish
+    weighing, deaths) -> you MUST call log_my_readings BEFORE replying — an unlogged
+    reading never reaches the twin, and a reply without the call is a guess dressed as an
+    update. Share the drift notes it returns ("model was 30% low on nitrate");
+  * "how's my system / what will this week/heatwave do" -> you MUST call
+    my_system_forecast — only it knows the persisted state and the real forecast.
+  Pass the envelope they actually run (greenhouse='shade'/'poly'/'heated') to both.
 - For the COMPLETE component design — which tanks, settling, biofilter, degasser,
   mineralization, coupled or decoupled, each with its reason — design_full_system is the
   design conversation's closing move (it also sends the 3D). It adapts to needs: ask about
@@ -147,10 +154,13 @@ HARD RULES (these are your credibility):
   Also check search_community_knowledge for real-world operator tips, and present anything it
   returns as "reported by other operators", never as verified fact or a number.
 
-ANSWERING FOLLOW-UPS: use the conversation, YOUR SYSTEM, and earlier tool results first. If a
-number was already computed or a fact already known, answer from it directly — don't re-run a
-tool. To judge whether a value is safe (temperature, pH, DO), read the operating_envelope from
-the prior sizing result; don't search the knowledge base for it."""
+ANSWERING FOLLOW-UPS: reuse earlier tool results ONLY when the result literally appears
+earlier in this conversation — reread it there. If the number the user needs was never
+computed in this conversation, CALL the tool now. NEVER write "[earlier result from ...]",
+never reconstruct, paraphrase-from-memory, or imagine what a tool would have returned:
+a fabricated tool result is the worst failure this assistant can produce, worse than no
+answer. To judge whether a value is safe (temperature, pH, DO), read the operating_envelope
+from the prior sizing result — if there is no prior sizing result, run the sizing tool."""
 
 # Attached when the vision model names a condition. Its observation enters the turn as a
 # user-provided fact, which the agent has no reason to distrust — so the doubt has to be
@@ -228,21 +238,38 @@ class AgronautAgent:
         if recall:
             messages.append(SystemMessage(content=recall))
 
-        for m in self._conv.recent_context_messages(user_id, limit=20):
+        # Two passes over history. Past tool results go into ONE leading system-side
+        # reference block; the visible transcript stays strictly user/assistant.
+        #
+        # Both halves of that sentence were paid for with a measured failure each:
+        # - Tool results were once replayed as AIMessages prefixed "[earlier result from
+        #   X]", and a validation run caught the model IMITATING that apparent house
+        #   style — minting fabricated "[earlier result …]" answers for tools that never
+        #   ran. The scaffold was teaching the fabrication. (A bare tool role without a
+        #   matching tool_call is rejected by OpenAI-compatible APIs, so real
+        #   ToolMessages cannot carry history either.)
+        # - Moved to SystemMessages interleaved in the transcript, the strict chat
+        #   templates of some hosted models (mistral on NVIDIA NIM) returned EMPTY
+        #   replies. Mid-conversation system messages are not portable.
+        history = self._conv.recent_context_messages(user_id, limit=20)
+        replayed = []
+        for m in history:
+            if m["role"] == "tool":
+                content = m["content"] or ""
+                if len(content) > _TOOL_REPLAY_MAX_CHARS:
+                    content = content[:_TOOL_REPLAY_MAX_CHARS] + " …[truncated]"
+                replayed.append(f"--- {m['tool_name']} (earlier turn) ---\n{content}")
+        if replayed:
+            messages.append(SystemMessage(content=(
+                "REFERENCE — tool outputs computed in earlier turns of this conversation. "
+                "Reuse these numbers plainly when they answer a follow-up; anything not "
+                "here has NOT been computed, so call the tool.\n\n" + "\n\n".join(replayed))))
+
+        for m in history:
             if m["role"] == "user":
                 messages.append(HumanMessage(content=m["content"]))
             elif m["role"] == "assistant":
                 messages.append(AIMessage(content=m["content"]))
-            elif m["role"] == "tool":
-                # Replay past tool results as assistant-side context (a bare tool role with
-                # no matching tool_call is rejected by OpenAI-compatible APIs). Without this,
-                # every computed number vanishes on the next turn and follow-ups re-run
-                # tools or guess.
-                content = m["content"] or ""
-                if len(content) > _TOOL_REPLAY_MAX_CHARS:
-                    content = content[:_TOOL_REPLAY_MAX_CHARS] + " …[truncated]"
-                messages.append(AIMessage(
-                    content=f"[earlier result from {m['tool_name']}]\n{content}"))
         return messages
 
     def _recall_block(self, user_id: str, query: str | None = None) -> str:
@@ -283,12 +310,33 @@ class AgronautAgent:
 
     # --- the tool-calling loop -------------------------------------------
     def _run_tool_loop(self, messages: list, user_id: str) -> str:
+        fabrication_nudged = False
         for _ in range(_MAX_ITERS):
             ai = self._bound.invoke(messages)
             messages.append(ai)
             tool_calls = getattr(ai, "tool_calls", None)
             if not tool_calls:
-                return (ai.content or "").strip() or "I'm not sure how to help with that yet."
+                text = (ai.content or "").strip()
+                # Tripwire: a reply that cites an "earlier result" is only honest if this
+                # conversation actually ran a tool. Measured failure (validation run,
+                # 2026-08): a model told to reuse earlier results started PREFIXING
+                # fabricated tool output with "[earlier result from X]" — invented costs,
+                # invented forecasts — without calling anything. One corrective iteration,
+                # once; if the model insists, the fabrication is refused outright rather
+                # than delivered as truth.
+                if "[earlier result" in text.lower():
+                    if not fabrication_nudged:
+                        fabrication_nudged = True
+                        messages.append(SystemMessage(content=(
+                            "STOP: '[earlier result from ...]' is a fabrication marker. If "
+                            "that result truly appears earlier in this conversation, restate "
+                            "its actual numbers plainly with no stage directions. If it does "
+                            "not, CALL the tool now and answer only from its real output.")))
+                        continue
+                    return ("I almost gave you numbers without computing them — caught it. "
+                            "Ask me that again in one message and I'll run the real "
+                            "calculation.")
+                return text or "I'm not sure how to help with that yet."
             for call in tool_calls:
                 tool = self._tools_by_name.get(call["name"])
                 if tool is None:

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -308,6 +308,50 @@ class AgronautAgent:
             parts.append("PAST SUMMARY: " + summary)
         return "\n\n".join(parts)
 
+    def _rescue_leaked_tool_call(self, text: str) -> dict | None:
+        """Parse a tool call leaked as plain text into a structured call, or None when the
+        text is not a leak (or names no known tool, or carries an unparseable payload —
+        those fall through to the normal no-tool path rather than guessing).
+
+        Two dialects, both measured live on NVIDIA NIM under load (validation runs,
+        2026-08), in both of which the model had chosen the RIGHT tool with the RIGHT
+        arguments and the adapter delivered it as gibberish text:
+          1. mistral-native:  [TOOL_CALLS]update_profile{"updates": {...}}
+          2. bare JSON-ish:   {"name": "log_my_readings", "parameters": {... True, None}}
+             — with Python literals, so json.loads alone cannot read it."""
+        import ast
+        import json as _json
+        import re
+
+        def _payload(raw: str):
+            try:
+                obj, _end = _json.JSONDecoder().raw_decode(raw)
+                return obj
+            except ValueError:
+                try:
+                    return ast.literal_eval(raw.strip())
+                except (ValueError, SyntaxError):
+                    return None
+
+        m = re.search(r"\[TOOL_CALLS\]\s*(\w+)\s*\{", text)
+        if m and m.group(1) in self._tools_by_name:
+            args = _payload(text[m.end() - 1:])
+            if isinstance(args, dict):
+                return {"name": m.group(1), "args": args, "id": "rescued-leaked-call"}
+            return None
+
+        brace = text.find("{")
+        if brace >= 0:
+            obj = _payload(text[brace:])
+            if (isinstance(obj, dict) and obj.get("name") in self._tools_by_name):
+                args = obj.get("parameters") or obj.get("arguments") or obj.get("args") or {}
+                if isinstance(args, dict):
+                    # None-valued optionals mean "not given" — drop them so tool defaults
+                    # apply instead of exploding on float(None).
+                    args = {k: v for k, v in args.items() if v is not None}
+                    return {"name": obj["name"], "args": args, "id": "rescued-leaked-call"}
+        return None
+
     # --- the tool-calling loop -------------------------------------------
     def _run_tool_loop(self, messages: list, user_id: str) -> str:
         fabrication_nudged = False
@@ -315,6 +359,19 @@ class AgronautAgent:
             ai = self._bound.invoke(messages)
             messages.append(ai)
             tool_calls = getattr(ai, "tool_calls", None)
+            if not tool_calls:
+                # Rescue leaked tool calls. Measured (validation run, 2026-08): mistral on
+                # NVIDIA NIM sometimes emits its NATIVE tool-call syntax as plain text —
+                # `[TOOL_CALLS]update_profile{"updates": {...}}` — which the adapter fails
+                # to parse into structured tool_calls, so a correct decision by the model
+                # dies as gibberish text. Parse it ourselves and run the call: the leaked
+                # AIMessage is replaced with a well-formed one so the transcript stays
+                # valid for strict OpenAI-compatible templates.
+                rescued = self._rescue_leaked_tool_call(ai.content or "")
+                if rescued is not None:
+                    messages.pop()
+                    messages.append(AIMessage(content="", tool_calls=[rescued]))
+                    tool_calls = [rescued]
             if not tool_calls:
                 text = (ai.content or "").strip()
                 # Tripwire: a reply that cites an "earlier result" is only honest if this

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -506,3 +506,35 @@ def test_the_bare_json_leak_dialect_is_rescued_too(tmp_path):
     reply = agent_.handle_message("cli", "u4", "what fish do you support?")
     assert fake.calls == 2
     assert "Tilapia" in reply and "{" not in reply
+
+
+class _PromisingFake:
+    """Announces an action without calling a tool, then complies when nudged."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import AIMessage
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(content="I'll check the supported species for you now.")
+        if self.calls == 2:
+            return AIMessage(content="", tool_calls=[{
+                "name": "list_supported_species_and_crops", "args": {}, "id": "c1"}])
+        return AIMessage(content="We support tilapia and more.")
+
+
+def test_a_promise_without_action_is_nudged_into_the_call(tmp_path):
+    """Measured: 'I'll log your readings' as a final reply, with nothing logged. The
+    nudge converts the narration into the actual tool call."""
+    from agronaut_agent.core import AgronautAgent
+
+    fake = _PromisingFake()
+    agent_ = AgronautAgent(db_path=str(tmp_path / "e.sqlite3"), chat_model=fake)
+    reply = agent_.handle_message("cli", "u5", "what species do you support?")
+    assert fake.calls >= 2, "the promise must trigger a corrective iteration"
+    assert "tilapia" in reply.lower() or "species" in reply.lower()

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -448,3 +448,61 @@ def test_a_stubborn_fabricator_is_refused_not_delivered(tmp_path):
     assert "profit greatly" not in reply
     assert "[earlier result" not in reply
     assert "without computing" in reply
+
+
+class _LeakyFake:
+    """Emits a tool call as mistral's native text syntax (the measured NIM leak), then
+    answers normally once the rescued tool result arrives."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import AIMessage
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(content='[TOOL_CALLS]list_supported_species_and_crops{}')
+        return AIMessage(content="We support tilapia and lettuce, among others.")
+
+
+def test_a_leaked_text_tool_call_is_rescued_and_executed(tmp_path):
+    from agronaut_agent.core import AgronautAgent
+
+    fake = _LeakyFake()
+    agent_ = AgronautAgent(db_path=str(tmp_path / "c.sqlite3"), chat_model=fake)
+    reply = agent_.handle_message("cli", "u3", "what species do you support?")
+    assert "[TOOL_CALLS]" not in reply
+    assert fake.calls == 2, "the loop must continue after the rescued call, not end on the leak"
+    assert "tilapia" in reply
+
+
+class _BareJsonLeakFake:
+    """The second measured NIM leak dialect: a bare JSON-ish call with Python literals."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import AIMessage
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(content=(
+                '{"name": "list_supported_species_and_crops", "parameters": '
+                '{"unused": None, "flag": True}}'))
+        return AIMessage(content="Tilapia is supported.")
+
+
+def test_the_bare_json_leak_dialect_is_rescued_too(tmp_path):
+    from agronaut_agent.core import AgronautAgent
+
+    fake = _BareJsonLeakFake()
+    agent_ = AgronautAgent(db_path=str(tmp_path / "d.sqlite3"), chat_model=fake)
+    reply = agent_.handle_message("cli", "u4", "what fish do you support?")
+    assert fake.calls == 2
+    assert "Tilapia" in reply and "{" not in reply

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -401,3 +401,50 @@ def test_tool_rows_do_not_shrink_conversation_window(tmp_path):
 
     blob = "\n".join(str(getattr(m, "content", "")) for m in agent._build_context(uid))
     assert "FIRST_QUESTION" in blob  # 18 tool rows must not push it out of a 20-row window
+
+
+class _FabricatingFake:
+    """A model that fabricates a tool result on the first ask, then complies when nudged."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import AIMessage
+        self.calls += 1
+        if self.calls == 1:
+            return AIMessage(content="[earlier result from estimate_system_cost] It costs 1,200,000 XOF.")
+        return AIMessage(content="Let me actually compute that for you — one moment.")
+
+
+class _StubbornFabricator:
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        from langchain_core.messages import AIMessage
+        return AIMessage(content="[earlier result from business_case] You will profit greatly.")
+
+
+def test_a_fabricated_tool_result_is_caught_and_retried(tmp_path):
+    """Measured live failure: the model prefixed invented numbers with '[earlier result
+    from X]' without calling anything. The tripwire forces one corrective iteration."""
+    from agronaut_agent.core import AgronautAgent
+
+    agent_ = AgronautAgent(db_path=str(tmp_path / "a.sqlite3"), chat_model=_FabricatingFake())
+    reply = agent_.handle_message("cli", "u1", "what will it cost?")
+    assert "[earlier result" not in reply
+    assert "compute" in reply.lower()
+
+
+def test_a_stubborn_fabricator_is_refused_not_delivered(tmp_path):
+    from agronaut_agent.core import AgronautAgent
+
+    agent_ = AgronautAgent(db_path=str(tmp_path / "b.sqlite3"), chat_model=_StubbornFabricator())
+    reply = agent_.handle_message("cli", "u2", "will it make money?")
+    assert "profit greatly" not in reply
+    assert "[earlier result" not in reply
+    assert "without computing" in reply

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -563,3 +563,32 @@ def test_the_live_mirror_asks_for_what_it_needs():
     finally:
         runtime.clear_current()
     assert "fetch_site_climate" in text and "tank_volume_l" in text
+
+
+def test_log_command_parsing_is_forgiving_and_exact():
+    """The /log deterministic path: a farmer's data entry must not surprise anyone."""
+    from agronaut_agent.channels.telegram_adapter import parse_log_args
+
+    a = parse_log_args("ammonia 0.5 nitrate 40 temp 27")
+    assert a == {"ammonia_mg_l": 0.5, "nitrate_mg_l": 40.0, "water_temp_c": 27.0}
+    b = parse_log_args("no2: 0.3, weight=210, count 58, shade")
+    assert b == {"nitrite_mg_l": 0.3, "fish_avg_weight_g": 210.0,
+                 "fish_count": 58, "greenhouse": "shade"}
+    assert parse_log_args("hello there") == {}
+
+
+def test_direct_tool_path_needs_no_llm(tmp_path):
+    """/log and /forecast back onto _run_tool_direct — a dead or drunk LLM must not
+    stand between an operator and their twin."""
+    from agronaut_agent.core import AgronautAgent
+
+    class _DeadModel:
+        def bind_tools(self, tools):
+            return self
+
+        def invoke(self, messages):
+            raise RuntimeError("LLM is down")
+
+    b = AgronautAgent(db_path=str(tmp_path / "f.sqlite3"), chat_model=_DeadModel())
+    reply = b.log_readings_direct("telegram", "42", {"ammonia_mg_l": 0.5})
+    assert "live twin needs" in reply.lower() or "logged" in reply.lower()

--- a/docs/telegram_twin_testing.md
+++ b/docs/telegram_twin_testing.md
@@ -29,16 +29,31 @@ NVIDIA free tier (2026-08, this repo's own benchmark) decide the experience:
 A turn uses 2-6 round-trips, so the old default produced **3-5 minute replies**, and under
 free-tier congestion (503s are routine) every failed call silently fell back to the 8B
 model — which answers in text instead of calling tools. That combination reads exactly as
-"the twin doesn't work, I only get text." Two fixes shipped with this doc: the primary is
-retried once before falling back, and the recommended config is now:
+"the twin doesn't work, I only get text." The recommended config:
 
 ```
 LLM_PROVIDER=nvidia
 LLM_MODEL=mistralai/mistral-nemotron
 ```
 
-Set it in the server's `.env` and restart. (Any tool-capable hosted model works; this one
-measured 20x faster with correct tool choice on the twin flows.)
+Set it in the server's `.env` (it is NOT in git — pulling does not change it) and restart.
+
+**What five full validation runs taught about the free tier, so nobody relearns it:**
+model behavior is weather. The same model, same prompt, hours apart, produced: correct
+structured tool calls; tool calls leaked as plain text (two dialects); "I'll log that
+now" narration with no call; and once, plain confident fabrication of a cost figure.
+The agent now carries guards for every *marked* failure (a fabrication tripwire, a
+leaked-call rescue parser, a promise-without-action nudge — each born from a measured
+incident and unit-tested), and the primary is retried before any fallback. But no guard
+catches unmarked confident fiction from a small model, and no free tier promises a
+response window. Hence the two-layer design:
+
+- **Conversational layer** — best-effort, guarded, and self-auditable:
+  `python scripts/validate_telegram_flows.py` runs the six flows against the live model
+  and names exactly which ones it fumbles today.
+- **Command layer — the guarantee.** `/log` and `/forecast` drive the live twin by
+  direct tool invocation with NO LLM in the path. They work identically in every model
+  weather, including a fully dead endpoint.
 
 ## The automated check, before the phone
 

--- a/docs/telegram_twin_testing.md
+++ b/docs/telegram_twin_testing.md
@@ -40,6 +40,14 @@ LLM_MODEL=mistralai/mistral-nemotron
 Set it in the server's `.env` and restart. (Any tool-capable hosted model works; this one
 measured 20x faster with correct tool choice on the twin flows.)
 
+## The automated check, before the phone
+
+`python scripts/validate_telegram_flows.py` runs the six-step conversation below through
+the bot's exact brain against the real configured LLM and reports which tools actually
+fired. Run it on the server after any pull: 6/6 means the conversational path works right
+now; misses name exactly which flow the current model is fumbling. `/log` and `/forecast`
+work regardless — they never touch the LLM.
+
 ## The test script — six messages, in order
 
 Each step names the tool that should fire and what arriving proof looks like. Watch the

--- a/scripts/validate_telegram_flows.py
+++ b/scripts/validate_telegram_flows.py
@@ -1,0 +1,97 @@
+"""Live acceptance test: the six-step twin conversation, through the bot's exact brain.
+
+Runs the same AgronautAgent the Telegram adapter wraps, against the REAL configured LLM,
+and checks per step that the expected tool actually fired (a recorder wraps every tool —
+narration, leaked-as-text calls and fabricated results all count as misses, which is the
+point). This harness caught, in one week: fabricated "[earlier result ...]" replies, tool
+calls leaked as text in two dialects, promises substituting for actions, and a default
+model taking 56 seconds per round-trip. Run it before claiming the twin works end to end:
+
+    python scripts/validate_telegram_flows.py
+
+Needs the LLM config in .env and network. NVIDIA free-tier congestion will fail some runs
+— that is a finding about the deployment, not a flake in the harness. Exit 0 iff all six
+steps fired their expected tool.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+os.chdir(REPO_ROOT)
+
+logging.basicConfig(level=logging.ERROR)
+
+import agent  # noqa: E402  — loads .env
+from agronaut_agent import tools as T  # noqa: E402
+from agronaut_agent.core import AgronautAgent  # noqa: E402
+
+CALLS: list[str] = []
+for _t in T.AGRONAUT_TOOLS:
+    def _make(name, orig):
+        def rec(*a, **k):
+            CALLS.append(name)
+            return orig(*a, **k)
+        return rec
+    _t.func = _make(_t.name, _t.func)
+
+STEPS = [
+    ("design_full_system",
+     "I want to design a complete aquaponic system: catfish (clarias) and lettuce, 15 m2 "
+     "media bed, water temperature 26 C, water budget 400 L per day, located in "
+     "Bobo-Dioulasso. My power is sometimes unreliable and I am a beginner. "
+     "Design the full system please.",
+     ["design_full_system"]),
+    ("season simulation",
+     "How much will that system produce over a year here in Bobo-Dioulasso?",
+     ["simulate_season"]),
+    ("money",
+     "What will it cost to build in Burkina Faso, and does it make money if I sell at "
+     "the market? I can work about 10 hours per week on it.",
+     ["business_case", "estimate_system_cost"]),
+    ("profile",
+     "Actually my real system is already running: 2000 L tank, 60 catfish at about "
+     "200 g average weight.",
+     ["update_profile"]),
+    ("live log",
+     "Today I measured: ammonia 0.5, nitrate 40, water temperature 27. It's under "
+     "shade net.",
+     ["log_my_readings"]),
+    ("live forecast",
+     "How is my system doing, and what will this coming week do to it?",
+     ["my_system_forecast"]),
+]
+
+
+def main() -> int:
+    brain = AgronautAgent(db_path=":memory:")
+    user = "validate-flows"
+    n_pass = 0
+    print("===== TELEGRAM FLOW VALIDATION =====")
+    for label, msg, expect in STEPS:
+        before = len(CALLS)
+        t0 = time.time()
+        try:
+            reply = brain.handle_message("cli", user, msg)
+        except Exception as exc:  # noqa: BLE001 — a dead endpoint is a result to report
+            print(f"[FAIL] {label:18} ERROR {exc}")
+            continue
+        fired = CALLS[before:]
+        atts = [a.rsplit("/", 1)[-1] for a in brain.take_attachments("cli", user)]
+        ok = any(e in fired for e in expect)
+        n_pass += ok
+        print(f"[{'PASS' if ok else 'MISS'}] {label:18} {time.time() - t0:4.0f}s "
+              f"tools={fired} att={atts}", flush=True)
+        print(f"        reply: {reply[:150].replace(chr(10), ' ')!r}")
+    print(f"\n{n_pass}/{len(STEPS)} steps fired their expected tool")
+    return 0 if n_pass == len(STEPS) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Deep-validation of the six-step Telegram script caught the worst failure this assistant can produce: turns 3–6 returned confident numbers — costs, drift notes, forecasts — prefixed `[earlier result from X]` with **no tool having run**. Invented XOF totals; a fictional "model was 30% low on nitrate".

**Root cause was ours, not the model's.** `_build_context` replayed past tool results into the transcript as *assistant* messages in exactly that bracket format — so the model saw `[earlier result from …]` as its own house style and imitated it for tools that never ran. The scaffold taught the fabrication.

## Three layers, each validated

1. **History replay restructured**: past tool outputs travel in one leading system-side REFERENCE block; the visible transcript stays strictly user/assistant. (The intermediate attempt — SystemMessages interleaved mid-transcript — made mistral's strict chat template return **empty** replies; both failure modes are recorded in the comment so nobody walks back into either.)
2. **Deterministic tripwire** in the tool loop: a reply containing the bracket pattern gets one corrective iteration; a stubborn fabricator is refused outright ("I almost gave you numbers without computing them — caught it") rather than delivered as truth. Unit-tested with fake fabricating models.
3. **Live-mirror flows are explicit MUSTs** (log a reported measurement *before* replying; never answer "how's my system" from memory) — the answer lives in persisted state the context cannot see.

## Live validation status

After layers 1–2: design (3D file attached), climate+season simulation, and cost+business case all fire their real tools with real price-book numbers — no fabrication survives. The live-mirror steps (layer 3) are being re-validated as soon as NVIDIA's free tier stops hard-throttling (it began mid-validation — its own argument for the retry shipped in #98). Merge waits on that result.

798 tests pass (2 known env-only failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QG2dvkkSQJDrPzohMciSi