### PR TITLE
docs: add winter/cold-season operation knowledge base document

### DIFF
--- a/docs/dpg/CORPUS.md
+++ b/docs/dpg/CORPUS.md
@@ -34,7 +34,7 @@ smaller. Nothing in the code depends on that source existing.
 
 | Source | Licence | Role |
 |---|---|---|
-| 21 × `knowledge/*.md` | First-party | **The answer layer.** Hand-written operator guidance |
+| 22 × `knowledge/*.md` | First-party | **The answer layer.** Hand-written operator guidance |
 | FAO 589 (Somerville et al., 2014) | FAO permissive (NC) | **The depth layer.** 275-page canonical reference |
 | Goddek, Joyce, Kotzen & Burnell eds. (2019), *Aquaponics Food Production Systems*, Springer Open | CC BY 4.0 (confirmed from the book's own copyright page) | **The research layer.** 619-page, 24-chapter open-access book; the source behind many of `aqua_model`'s cited coefficients (see `docs/twin_parameter_dossier.md`). Indexed via the OAPEN mirror because link.springer.com serves a bot challenge; ~2,576 chunks, which roughly triples the corpus — the hybrid-retrieval weighting sweep must be re-run before trusting hybrid over dense-only (see `agronaut_agent/rag.py`) |
 | Applications, technologies and evaluation methods in smart aquaponics (Artif Intell Rev, 2024) | CC BY 4.0 | Systematic review; IoT/ML framing |

--- a/knowledge/winter_cold_season_operation.md
+++ b/knowledge/winter_cold_season_operation.md
@@ -1,0 +1,46 @@
+# Winter / Cold-Season Operation
+
+Cooler water slows everything in the system: fish appetite drops, plant growth stalls, and nitrifying bacteria
+work less efficiently. **The goal in winter is to keep the system stable and alive, not to grow fast** — adjust
+feeding, aeration, and loading to match the reduced metabolism of the whole loop.
+
+## What slows down in the cold
+- **Fish metabolism** — appetite and growth fall with temperature. Feeding the summer ration into a cold tank
+  simply fouls the water; uneaten feed decays and drives ammonia up.
+- **Biofilter activity** — nitrifying bacteria are temperature-sensitive. Below ~15 °C they work noticeably slower,
+  so the same feed load produces a higher ammonia spike. The filter does not "break", it just needs less input.
+- **Plant uptake** — most aquaponic crops slow or stop growing in cold water, so nutrient uptake drops and
+  nitrate can accumulate.
+
+## What to feed (and when to stop)
+- **Cut feed as temperature falls** — halve the ration for every few degrees below the species' optimum, and
+  watch the fish: if they are not actively taking food, do not throw more in.
+- **Skip feeding entirely below the species' cold threshold** — warm-water fish (e.g. tilapia) stop feeding below
+  roughly 15 °C. Below that, stop feeding; the fish will live off their stores until it warms.
+- **Never feed "on schedule" in winter** — feed on observed appetite, not on a calendar.
+
+## Aeration and oxygen
+- Cold water holds *more* oxygen, but fish are sluggish and the biofilter needs oxygen too.
+- Keep the aeration running — a stalled pump or dead air stone in winter turns a "fine" cold tank into a
+  low-oxygen one faster than expected, because nobody is watching daily.
+- If you cut feeding, you can also reduce the biological load, which lowers the oxygen demand on the filter.
+
+## Stocking and loading
+- If possible, reduce stocking density before winter, not during it. A lighter load means lower ammonia
+  production and a smaller biofilter burden.
+- Avoid adding new fish or big water changes in the coldest weeks — stress + cold = disease risk.
+
+## What keeps working
+- Insulation and thermal mass (covered tanks, greenhouse, large DWC sump) are the cheapest winter tools — see
+  `temperature_and_climate_control.md`.
+- Monitoring (pH, ammonia, DO) matters *more* in winter, because problems develop slowly and quietly.
+
+## Key signals to watch
+- Fish at the surface gasping → DO problem, even in cold water.
+- Ammonia creeping up with no feeding change → biofilter is cold-stressed; cut feed further.
+- Plants yellowing with nitrate still high → uptake has stalled; expect this, adjust expectations.
+
+## Related knowledge
+- `temperature_and_climate_control.md` — heating, insulation, and species-to-climate matching.
+- `nitrogen_cycle_and_cycling.md` — how the biofilter behaves when it is cold.
+- `dissolved_oxygen_and_aeration.md` — oxygen management at any temperature.

--- a/knowledge/winter_cold_season_operation.md
+++ b/knowledge/winter_cold_season_operation.md
@@ -7,7 +7,7 @@ feeding, aeration, and loading to match the reduced metabolism of the whole loop
 ## What slows down in the cold
 - **Fish metabolism** — appetite and growth fall with temperature. Feeding the summer ration into a cold tank
   simply fouls the water; uneaten feed decays and drives ammonia up.
-- **Biofilter activity** — nitrifying bacteria are temperature-sensitive. Below ~15 °C they work noticeably slower,
+- **Biofilter activity** — nitrifying bacteria are temperature-sensitive. Below ~17 °C they work noticeably slower,
   so the same feed load produces a higher ammonia spike. The filter does not "break", it just needs less input.
 - **Plant uptake** — most aquaponic crops slow or stop growing in cold water, so nutrient uptake drops and
   nitrate can accumulate.
@@ -16,7 +16,7 @@ feeding, aeration, and loading to match the reduced metabolism of the whole loop
 - **Cut feed as temperature falls** — halve the ration for every few degrees below the species' optimum, and
   watch the fish: if they are not actively taking food, do not throw more in.
 - **Skip feeding entirely below the species' cold threshold** — warm-water fish (e.g. tilapia) stop feeding below
-  roughly 15 °C. Below that, stop feeding; the fish will live off their stores until it warms.
+  roughly 17 °C. Below that, stop feeding; the fish will live off their stores until it warms.
 - **Never feed "on schedule" in winter** — feed on observed appetite, not on a calendar.
 
 ## Aeration and oxygen
@@ -44,3 +44,5 @@ feeding, aeration, and loading to match the reduced metabolism of the whole loop
 - `temperature_and_climate_control.md` — heating, insulation, and species-to-climate matching.
 - `nitrogen_cycle_and_cycling.md` — how the biofilter behaves when it is cold.
 - `dissolved_oxygen_and_aeration.md` — oxygen management at any temperature.
+
+Reference level: Somerville et al. (2014), FAO 589


### PR DESCRIPTION
## Summary

Adds the missing **Winter / cold-season operation** knowledge base document (`knowledge/winter_cold_season_operation.md`), covering one of the topics listed as missing in the knowledge base:
- what slows down in the cold (fish metabolism, biofilter, plant uptake)
- what to feed and when to stop feeding entirely
- aeration and oxygen management in winter
- stocking/loading adjustments
- key signals to watch
- cross-references to existing knowledge documents

## Changes

- New file: `knowledge/winter_cold_season_operation.md` (no code changes)

## Acceptance criteria

- [x] Document written with cited sources / cross-references to existing docs
- [x] Follows the formatting style of existing `knowledge/*.md` files
- [x] No code changes