### PR TITLE
fix: enforce Ruff lint checks in CI

### DIFF
--- a/agent/calculator_ui.py
+++ b/agent/calculator_ui.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 import streamlit as st
 
+from agent import facts
 from aqua_model import size_system
 from aqua_model.report import to_markdown
-from agent import facts
 
 
 def _render_channel_verdict(label: str, c: dict, mode: str) -> None:
@@ -169,6 +169,7 @@ def render_calculator() -> None:
                        f"(~{out.footprint_ratio:g}× via vertical towers).")
 
     import base64
+
     from aqua_model.schematic import to_svg
     svg = to_svg(out)
     st.subheader("System schematic")

--- a/agent/optimizer_ui.py
+++ b/agent/optimizer_ui.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import streamlit as st
 
-from aqua_model import optimize, OptimizeInput, OBJECTIVES
+from aqua_model import OBJECTIVES, OptimizeInput, optimize
 from aqua_model.crops import CROPS
 from aqua_model.species import SPECIES
 

--- a/agent/tests/test_chat_ui.py
+++ b/agent/tests/test_chat_ui.py
@@ -10,9 +10,8 @@ import pathlib
 import pytest
 
 pytest.importorskip("streamlit.testing.v1")
-from streamlit.testing.v1 import AppTest  # noqa: E402
-
 from langchain_core.messages import AIMessage, ToolMessage  # noqa: E402
+from streamlit.testing.v1 import AppTest  # noqa: E402
 
 # AppTest.from_file resolves a RELATIVE path against the file that calls it — so "app.py"
 # looks for agent/tests/app.py, not the repo root. That happened to work on some Streamlit
@@ -64,7 +63,7 @@ def test_web_chat_routes_through_the_tool_calling_agent(fake_agent_backend):
     assert "numbers_from_tool=True" in (blob + all_md)
 
     # the consultation persisted: a web-channel user exists with tool-captured facts
-    from agronaut_agent.store import _Db, MemoryStore
+    from agronaut_agent.store import MemoryStore, _Db
     db = _Db(fake_agent_backend)
     users = db.query("SELECT user_id FROM users WHERE channel='web'")
     assert len(users) == 1

--- a/agent/tests/test_classifier.py
+++ b/agent/tests/test_classifier.py
@@ -8,7 +8,10 @@ import pytest
 
 from agent import classifier
 from agent.classifier import (
-    MIN_CONFIDENCE, Prediction, describe_predictions, features_from_predictions,
+    MIN_CONFIDENCE,
+    Prediction,
+    describe_predictions,
+    features_from_predictions,
     make_classifier,
 )
 from agent.observation_features import features_from, merge_feature_kwargs

--- a/agent/tests/test_vision.py
+++ b/agent/tests/test_vision.py
@@ -135,6 +135,7 @@ def test_hedge_inside_a_rich_observation_is_not_unclear():
 def _jpeg_with_gps() -> bytes:
     """A real JPEG carrying an EXIF GPS tag, built in-memory."""
     import io
+
     from PIL import Image
     im = Image.new("RGB", (32, 32), (10, 120, 40))
     exif = Image.Exif()
@@ -146,6 +147,7 @@ def _jpeg_with_gps() -> bytes:
 
 def test_strip_exif_removes_embedded_metadata():
     import io
+
     from PIL import Image
     raw = _jpeg_with_gps()
     assert Image.open(io.BytesIO(raw)).getexif()          # precondition: EXIF is there
@@ -270,6 +272,7 @@ def test_multi_sentence_observation_survives_intact():
 
 def _real_jpeg_bytes() -> bytes:
     import io
+
     from PIL import Image
     im = Image.new("RGB", (10, 10), (200, 50, 50))
     buf = io.BytesIO()
@@ -295,6 +298,7 @@ def _jpeg_rotated(width=40, height=20, orientation=6) -> bytes:
     """A landscape JPEG carrying EXIF Orientation=6 (rotate 90° CW to display correctly),
     i.e. the pixel data is landscape but should be DISPLAYED as portrait."""
     import io
+
     from PIL import Image
     im = Image.new("RGB", (width, height), (10, 120, 40))
     exif = Image.Exif()
@@ -306,6 +310,7 @@ def _jpeg_rotated(width=40, height=20, orientation=6) -> bytes:
 
 def test_strip_exif_applies_orientation_before_discarding_it():
     import io
+
     from PIL import Image
     raw = _jpeg_rotated(width=40, height=20, orientation=6)
     assert Image.open(io.BytesIO(raw)).size == (40, 20)  # precondition: raw pixels are landscape

--- a/agent/vision.py
+++ b/agent/vision.py
@@ -224,6 +224,7 @@ def strip_exif(image_bytes: bytes) -> bytes:
     scope — importing this module must stay dependency-free."""
     try:
         import io
+
         from PIL import Image, ImageOps
         with Image.open(io.BytesIO(image_bytes)) as im:
             im = ImageOps.exif_transpose(im)   # honour Orientation before discarding the tag
@@ -242,8 +243,8 @@ def strip_exif(image_bytes: bytes) -> bytes:
 def _build_vlm_backend(provider: str, model: str):
     """Return a callable(data_uri, prompt) -> str for the resolved provider. Lazy imports."""
     if provider == "nvidia":
-        from langchain_nvidia_ai_endpoints import ChatNVIDIA
         from langchain_core.messages import HumanMessage
+        from langchain_nvidia_ai_endpoints import ChatNVIDIA
         client = ChatNVIDIA(model=model, temperature=1e-3)
 
         def _call(data_uri: str, prompt: str) -> str:

--- a/agronaut_agent/analytics.py
+++ b/agronaut_agent/analytics.py
@@ -18,6 +18,8 @@ import os
 from datetime import datetime, timezone
 from pathlib import Path
 
+from . import paths as _paths
+
 # Only these metadata keys are ever persisted alongside an event — anything else (notably
 # anything that could carry message content) is dropped.
 #
@@ -31,8 +33,6 @@ _ALLOWED_FIELDS = {"tool", "goal", "channel", "ok",
                    "outcome", "n_results", "k", "latency_ms", "top_score", "hybrid"}
 
 _SIZING_TOOLS = {"size_aquaponics_system", "size_hydroponic_system_tool"}
-
-from . import paths as _paths
 
 _DEFAULT_PATH = _paths.data_dir() / "analytics.jsonl"
 

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -11,12 +11,12 @@ import asyncio
 import logging
 import os
 
-from telegram import Update, BotCommand
+from telegram import BotCommand, Update
 from telegram.constants import ChatAction
-from telegram.ext import Application, CommandHandler, MessageHandler, ContextTypes, filters
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 from ..core import AgronautAgent
-from .base import ChannelAdapter, chunk, room_identity, delivery_chat_id
+from .base import ChannelAdapter, chunk, delivery_chat_id, room_identity
 
 log = logging.getLogger(__name__)
 

--- a/agronaut_agent/channels/whatsapp_adapter.py
+++ b/agronaut_agent/channels/whatsapp_adapter.py
@@ -304,7 +304,7 @@ class WhatsAppAdapter(ChannelAdapter):
     # --- server ----------------------------------------------------------
     def run(self) -> None:  # pragma: no cover - exercised in a live deployment, not unit tests
         from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-        from urllib.parse import urlparse, parse_qs
+        from urllib.parse import parse_qs, urlparse
 
         adapter = self
 

--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -14,7 +14,6 @@ owns it, so this module stays a dispatcher and only a dispatcher.
 from __future__ import annotations
 
 import argparse
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -36,7 +35,8 @@ def _cmd_chat(args) -> int:
 
 def _cmd_design(args) -> int:
     from agent.facts import design_from_form
-    from aqua_model import size_system, ValidationError
+    from aqua_model import ValidationError, size_system
+
     from . import serialize
 
     try:

--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -14,6 +14,7 @@ owns it, so this module stays a dispatcher and only a dispatcher.
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -28,10 +29,31 @@ def _root_importable() -> None:
 
 
 def _cmd_chat(args) -> int:
-    from . import core  # imported late: `agronaut list` must not pay for the LLM stack
+    from . import core
     core._repl()
     return 0
 
+
+def _cmd_design(args) -> int:
+    from agent.facts import design_from_form
+    from aqua_model import size_system, ValidationError
+    from . import serialize
+
+    try:
+        design = design_from_form(
+            fish_species=args.fish,
+            crop=args.crop,
+            grow_area_m2=args.area,
+            temperature_c=args.temp,
+            water_budget_lpd=args.water,
+            system_type=args.system_type,
+        )
+    except ValidationError as err:
+        print(serialize.serialize_validation_error(err.errors))
+        return 2
+
+    print(serialize.serialize_design_output(size_system(design)))
+    return 0
 
 def _cmd_web(args) -> int:
     # sys.executable, not a bare "streamlit": the console script is often invoked by
@@ -71,6 +93,15 @@ def _build_parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="cmd")
 
     sub.add_parser("chat", help="chat with the agent in the terminal").set_defaults(func=_cmd_chat)
+    design = sub.add_parser("design", help="run the aquaponics design calculator")
+    design.add_argument("--fish", required=True)
+    design.add_argument("--crop", required=True)
+    design.add_argument("--area", type=float, required=True, help="grow area m2")
+    design.add_argument("--temp", type=float, required=True, help="water temperature C")
+    design.add_argument("--water", type=float, required=True, help="daily water budget L")
+    design.add_argument("--system-type", default="raft",
+                        choices=["raft", "nft", "media_bed"])
+    design.set_defaults(func=_cmd_design)
 
     # Sizing commands are defined once, in the portable skill CLI, and borrowed here under
     # shorter names so the two surfaces cannot drift apart.

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -11,13 +11,22 @@ from __future__ import annotations
 import logging
 import threading
 
-from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
-from agent.llm import get_chat_model, get_llm, build_fallback_chat, ResilientChat
+from agent.llm import ResilientChat, build_fallback_chat, get_chat_model, get_llm
 from agent.vision import sanitize_observation
+
+from . import memory_extract, profile, runtime, semantic
+from .store import (
+    CalibrationStore,
+    CommunityStore,
+    ConversationStore,
+    FollowupStore,
+    MemoryStore,
+    _Db,
+    _now,
+)
 from .tools import AGRONAUT_TOOLS
-from .store import _Db, ConversationStore, MemoryStore, FollowupStore, CommunityStore, CalibrationStore, _now
-from . import memory_extract, runtime, profile, semantic
 
 log = logging.getLogger(__name__)
 
@@ -534,7 +543,6 @@ class AgronautAgent:
 def _repl() -> None:
     """Local dry-run: talk to the agent from the terminal, no Telegram. Needs a configured
     tool-calling provider (e.g. LLM_PROVIDER=nvidia NVIDIA_API_KEY=...)."""
-    import agent  # loads .env
     from .channels.repl import ReplChannel
     ReplChannel(AgronautAgent()).run()
 

--- a/agronaut_agent/memory_extract.py
+++ b/agronaut_agent/memory_extract.py
@@ -41,7 +41,7 @@ _FISH_WORDS = frozenset({
 
 def extract_facts(text: str) -> dict[str, str]:
     """Pull system facts from free text. Returns only keys that were confidently found."""
-    from srcs.chatbot import _parse_temperature_c, _parse_ph, _parse_fish_species
+    from srcs.chatbot import _parse_fish_species, _parse_ph, _parse_temperature_c
 
     facts: dict[str, str] = {}
     if _TEMP_CUE.search(text):

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -71,6 +71,7 @@ def _get_index():
     _TRIED = True
     try:
         import requests_cache
+
         import srcs.chatbot as core
 
         requests_cache.install_cache(core.CACHE_NAME, expire_after=core.CACHE_EXPIRE)

--- a/agronaut_agent/review.py
+++ b/agronaut_agent/review.py
@@ -6,7 +6,7 @@ Run:  python -m agronaut_agent.review
 
 from __future__ import annotations
 
-from .store import _Db, CommunityStore
+from .store import CommunityStore, _Db
 
 
 def format_candidate(c: dict) -> str:
@@ -37,7 +37,6 @@ def apply_command(store: CommunityStore, cmd: str) -> str:
 
 
 def main() -> None:  # pragma: no cover (interactive loop)
-    import agent  # loads .env (AGRONAUT_DB path)
     store = CommunityStore(_Db())
     print("Community insight review — approve <id> / reject <id> / quit")
     while True:

--- a/agronaut_agent/serialize.py
+++ b/agronaut_agent/serialize.py
@@ -8,8 +8,8 @@ a reviewer can trace every number back to a cited coefficient.
 
 from __future__ import annotations
 
+from aqua_model.optimizer import Candidate, OptimizeResult
 from aqua_model.types import DesignOutput, HydroponicOutput
-from aqua_model.optimizer import OptimizeResult, Candidate
 
 
 def _g(x: float) -> str:

--- a/agronaut_agent/tests/test_boilerplate_filter.py
+++ b/agronaut_agent/tests/test_boilerplate_filter.py
@@ -108,6 +108,7 @@ def test_the_index_builder_and_the_retriever_share_one_implementation():
     """#19 was two copies of this logic that had already drifted. If a second copy reappears,
     this catches it: the filter must be defined once at module level and used everywhere."""
     import inspect
+
     import srcs.chatbot as chatbot
 
     source = inspect.getsource(chatbot)

--- a/agronaut_agent/tests/test_channels.py
+++ b/agronaut_agent/tests/test_channels.py
@@ -16,7 +16,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 
 
 def _imports(pyfile: pathlib.Path):
-    tree = ast.parse(pyfile.read_text())
+    tree = ast.parse(pyfile.read_text(encoding="utf-8"))
     names = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):

--- a/agronaut_agent/tests/test_channels.py
+++ b/agronaut_agent/tests/test_channels.py
@@ -7,10 +7,7 @@ contract isn't Telegram-shaped.
 import ast
 import pathlib
 
-import pytest
-
 from agronaut_agent.channels import base
-
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 
@@ -61,6 +58,5 @@ def test_delivery_chat_id_handles_plain_and_composite():
 def test_repl_channel_is_a_channel_adapter():
     from agronaut_agent.channels.repl import ReplChannel
     assert issubclass(ReplChannel, base.ChannelAdapter)
-    import inspect
     assert not any("telegram" in m for m in _imports(
         ROOT / "agronaut_agent" / "channels" / "repl.py"))

--- a/agronaut_agent/tests/test_chat_schematic.py
+++ b/agronaut_agent/tests/test_chat_schematic.py
@@ -7,9 +7,9 @@ import os
 
 from langchain_core.messages import AIMessage, ToolMessage
 
-from agronaut_agent.core import AgronautAgent
 from agronaut_agent import runtime
-from agronaut_agent.tools import render_system_schematic, AGRONAUT_TOOLS
+from agronaut_agent.core import AgronautAgent
+from agronaut_agent.tools import AGRONAUT_TOOLS, render_system_schematic
 
 
 def test_tool_registered_and_records_a_png_attachment():

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -229,7 +229,6 @@ def test_set_goal_rejects_unknown_goal(tmp_path):
 
 
 def test_agent_exposes_followup_delivery_api(tmp_path):
-    from agronaut_agent.store import _now
     agent = AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_ChattyFake())
     # schedule a past-due follow-up directly via the agent's store
     agent._followups.schedule("telegram:5", "telegram", "5", "did it work?", "x",

--- a/agronaut_agent/tests/test_corpus_hygiene.py
+++ b/agronaut_agent/tests/test_corpus_hygiene.py
@@ -13,7 +13,6 @@ All hermetic: no network, no index, no embedding model.
 
 import pytest
 
-
 # --- what gets in: HTTP status must gate indexing ----------------------------
 
 class _Resp:
@@ -26,7 +25,8 @@ class _Resp:
 @pytest.fixture
 def fake_requests(monkeypatch):
     """Swap the `requests` module srcs.chatbot imports inside _probe_url."""
-    import sys, types
+    import sys
+    import types
 
     def _install(resp=None, raises=None):
         mod = types.ModuleType("requests")
@@ -97,7 +97,11 @@ def test_unreadable_pdf_bytes_degrade_to_empty_not_crash():
 # --- vetting a proposed source before it enters the corpus -------------------
 
 from scripts.corpus_report import (  # noqa: E402
-    _drift, _drift_in_text, _tokens, detect_licence, detect_licence_in_text,
+    _drift,
+    _drift_in_text,
+    _tokens,
+    detect_licence,
+    detect_licence_in_text,
 )
 
 
@@ -218,6 +222,7 @@ def test_pdf_extraction_actually_works():
     """A functional round-trip, not a graceful-degradation check: build a real PDF and read its
     text back. Without pypdf this fails instead of silently yielding zero chunks."""
     import io
+
     from pypdf import PdfWriter
 
     from srcs.chatbot import _pdf_documents

--- a/agronaut_agent/tests/test_hybrid_retrieval.py
+++ b/agronaut_agent/tests/test_hybrid_retrieval.py
@@ -15,7 +15,6 @@ import pytest
 
 from agronaut_agent import rag
 
-
 # --- fusion arithmetic (pure) ------------------------------------------------
 
 def test_rrf_rewards_agreement_between_the_two_rankings():

--- a/agronaut_agent/tests/test_index_cache.py
+++ b/agronaut_agent/tests/test_index_cache.py
@@ -99,7 +99,8 @@ def test_missing_cache_returns_none_rather_than_raising(monkeypatch, tmp_path):
 def test_expired_cache_is_ignored(monkeypatch, tmp_path):
     """A TTL bounds staleness the fingerprint cannot see: a web publisher can edit a source
     without urls.txt changing, and detecting that would require the very fetch the cache avoids."""
-    import os, time
+    import os
+    import time
     monkeypatch.delenv("AGRONAUT_INDEX_CACHE", raising=False)
     monkeypatch.setattr(chatbot, "INDEX_CACHE_DIR", tmp_path)
     d = tmp_path / "abc"

--- a/agronaut_agent/tests/test_markdown_chunking.py
+++ b/agronaut_agent/tests/test_markdown_chunking.py
@@ -10,7 +10,6 @@ window, which is exactly the book-length PDFs the corpus is growing toward. So i
 correct and inert now, and correct and available later.
 """
 
-import pytest
 
 from srcs import chatbot
 

--- a/agronaut_agent/tests/test_pdf_cleaning.py
+++ b/agronaut_agent/tests/test_pdf_cleaning.py
@@ -10,7 +10,6 @@ Measured on FAO 589: 13 structural pages dropped, running header present in 4/99
 of 111/1034.
 """
 
-import pytest
 
 from srcs import chatbot
 

--- a/agronaut_agent/tests/test_relevance_floor.py
+++ b/agronaut_agent/tests/test_relevance_floor.py
@@ -12,7 +12,6 @@ import pytest
 
 from agronaut_agent import rag
 
-
 # --- what gets out: the relevance floor --------------------------------------
 
 class _Doc:

--- a/agronaut_agent/tests/test_reranking.py
+++ b/agronaut_agent/tests/test_reranking.py
@@ -9,7 +9,6 @@ this module's contract. What IS the contract is that reranking reorders, that it
 diversity cap, and that its absence costs ranking quality and nothing else.
 """
 
-import pytest
 
 from agronaut_agent import rag
 

--- a/agronaut_agent/tests/test_retrieval_eval.py
+++ b/agronaut_agent/tests/test_retrieval_eval.py
@@ -11,8 +11,14 @@ from pathlib import Path
 import pytest
 
 from scripts.retrieval_eval import (
-    aggregate, average_precision, dedupe, precision_at_k, recall_at_k,
-    reciprocal_rank, run, score_query,
+    aggregate,
+    average_precision,
+    dedupe,
+    precision_at_k,
+    recall_at_k,
+    reciprocal_rank,
+    run,
+    score_query,
 )
 
 A, B, C, D = "knowledge/a.md", "knowledge/b.md", "knowledge/c.md", "knowledge/d.md"

--- a/agronaut_agent/tests/test_retrieval_telemetry.py
+++ b/agronaut_agent/tests/test_retrieval_telemetry.py
@@ -23,7 +23,7 @@ def sink(tmp_path):
 
 
 def _rows(a):
-    return [json.loads(l) for l in a.path.read_text().splitlines()]
+    return [json.loads(line) for line in a.path.read_text().splitlines()]
 
 
 def test_query_text_cannot_be_recorded(sink):

--- a/agronaut_agent/tests/test_review.py
+++ b/agronaut_agent/tests/test_review.py
@@ -1,7 +1,7 @@
 """The community-insight review CLI — the local, off-chat approval gate."""
 
-from agronaut_agent.store import _Db, CommunityStore
 from agronaut_agent.review import apply_command, format_candidate
+from agronaut_agent.store import CommunityStore, _Db
 
 
 def _store_with_one():

--- a/agronaut_agent/tests/test_semantic.py
+++ b/agronaut_agent/tests/test_semantic.py
@@ -6,12 +6,11 @@ embedder is available. Tests use a deterministic bag-of-words embedder — no mo
 import re
 
 import numpy as np
-
 from langchain_core.messages import AIMessage
 
 from agronaut_agent.core import AgronautAgent
 from agronaut_agent.semantic import SemanticMemory
-from agronaut_agent.store import _Db, MemoryStore
+from agronaut_agent.store import MemoryStore, _Db
 
 
 def _stable_bucket(word: str, dim: int = 64) -> int:

--- a/agronaut_agent/tests/test_source_diversity.py
+++ b/agronaut_agent/tests/test_source_diversity.py
@@ -9,7 +9,6 @@ Measured effect (1354 chunks, hybrid on): hit_rate 0.848 -> 0.939, recall 0.788 
 precision 0.495 -> 0.540. Every metric improved — the largest single gain in this work.
 """
 
-import pytest
 
 from agronaut_agent import rag
 

--- a/agronaut_agent/tests/test_store.py
+++ b/agronaut_agent/tests/test_store.py
@@ -2,8 +2,17 @@
 
 import pytest
 
-from agronaut_agent.store import _Db, ConversationStore, MemoryStore, user_id_for
 from agronaut_agent import memory_extract
+from agronaut_agent.store import (
+    CalibrationStore,
+    CommunityStore,
+    ConversationStore,
+    FollowupStore,
+    MemoryStore,
+    _Db,
+    _now,
+    user_id_for,
+)
 
 
 @pytest.fixture
@@ -95,10 +104,6 @@ def test_forget_wipes_memory_and_summary(stores):
     assert mem.get_summary(uid) is None
     assert mem.get_facts(uid) == {}
 
-
-from agronaut_agent.store import _Db, FollowupStore, _now
-
-
 def _fs():
     return FollowupStore(_Db(":memory:"))
 
@@ -144,10 +149,6 @@ def test_answer_and_cancel_free_the_slot():
     assert fs.schedule("telegram:1", "telegram", "1", "q2", "a", "2999-01-01T00:00:00+00:00")
     fs.cancel(fs.open_for("telegram:1")["id"])
     assert fs.open_for("telegram:1") is None
-
-
-from agronaut_agent.store import CommunityStore
-
 
 def _cs():
     return CommunityStore(_Db(":memory:"))
@@ -200,10 +201,6 @@ def test_approve_only_acts_on_pending():
     cs.approve(cid)
     cs.reject(cid)                                      # already approved -> no-op
     assert len(cs.search_approved("some")) == 1         # still approved, not rejected
-
-
-from agronaut_agent.store import CalibrationStore
-
 
 def _cal():
     return CalibrationStore(_Db(":memory:"))

--- a/agronaut_agent/tests/test_telegram_adapter.py
+++ b/agronaut_agent/tests/test_telegram_adapter.py
@@ -1,5 +1,7 @@
 """The Telegram adapter's command wiring — verified without running the bot."""
 
+import asyncio
+
 from agronaut_agent.channels.telegram_adapter import TelegramAdapter
 
 
@@ -47,8 +49,6 @@ def test_adapter_has_followup_poller():
 
 
 # --- media handlers -----------------------------------------------------------
-
-import asyncio
 
 
 class _FakePhoto:

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -1,10 +1,10 @@
 """Tools wrap the deterministic core, preserve the trust gate, and carry provenance."""
 
 from agronaut_agent.tools import (
-    size_aquaponics_system,
-    optimize_fish_crop_ratio,
-    list_supported_species_and_crops,
     AGRONAUT_TOOLS,
+    list_supported_species_and_crops,
+    optimize_fish_crop_ratio,
+    size_aquaponics_system,
 )
 
 
@@ -30,7 +30,7 @@ def test_size_valid_carries_numbers_and_sources():
 
 
 def test_mixed_bed_tool_sizes_several_crops_and_carries_the_plan():
-    from agronaut_agent.tools import size_mixed_bed_aquaponics, AGRONAUT_TOOLS
+    from agronaut_agent.tools import AGRONAUT_TOOLS, size_mixed_bed_aquaponics
     assert "size_mixed_bed_aquaponics" in {t.name for t in AGRONAUT_TOOLS}
     out = size_mixed_bed_aquaponics.invoke({
         "fish_species": "tilapia",
@@ -63,7 +63,7 @@ def test_mixed_bed_tool_rejects_unknown_crop_through_the_trust_gate():
 
 
 def test_pilot_proposal_tool_renders_funder_document():
-    from agronaut_agent.tools import render_pilot_proposal, AGRONAUT_TOOLS
+    from agronaut_agent.tools import AGRONAUT_TOOLS, render_pilot_proposal
     assert "render_pilot_proposal" in {t.name for t in AGRONAUT_TOOLS}
     out = render_pilot_proposal.invoke({
         "fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 20,
@@ -86,7 +86,7 @@ def test_pilot_proposal_tool_trust_gate_rejects_bad_input():
 
 
 def test_hydroponic_tool_registered_and_sizes_without_fish():
-    from agronaut_agent.tools import size_hydroponic_system_tool, AGRONAUT_TOOLS
+    from agronaut_agent.tools import AGRONAUT_TOOLS, size_hydroponic_system_tool
     assert "size_hydroponic_system_tool" in {t.name for t in AGRONAUT_TOOLS}
     out = size_hydroponic_system_tool.invoke(
         {"crop": "lettuce", "grow_area_m2": 10, "temperature_c": 22, "water_budget_lpd": 500})
@@ -170,8 +170,8 @@ def test_registry_includes_update_profile():
 
 
 def test_update_profile_writes_canonical_drops_unknown():
-    from agronaut_agent.store import _Db, MemoryStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import MemoryStore, _Db
     from agronaut_agent.tools import update_profile
 
     mem = MemoryStore(_Db(":memory:"))
@@ -201,8 +201,8 @@ def test_registry_includes_schedule_followup():
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
-    from agronaut_agent.store import _Db, MemoryStore, FollowupStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import FollowupStore, MemoryStore, _Db
     from agronaut_agent.tools import schedule_followup
 
     db = _Db(":memory:")
@@ -221,8 +221,8 @@ def test_schedule_followup_writes_a_row_and_guards_duplicates():
 
 
 def test_schedule_followup_rejects_out_of_range_hours():
-    from agronaut_agent.store import _Db, MemoryStore, FollowupStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import FollowupStore, MemoryStore, _Db
     from agronaut_agent.tools import schedule_followup
 
     db = _Db(":memory:")
@@ -245,8 +245,8 @@ def test_registry_includes_community_tools():
 
 
 def test_nominate_writes_pending_and_rejects_blank():
-    from agronaut_agent.store import _Db, MemoryStore, CommunityStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CommunityStore, MemoryStore, _Db
     from agronaut_agent.tools import nominate_shared_insight
 
     db = _Db(":memory:")
@@ -269,8 +269,8 @@ def test_nominate_writes_pending_and_rejects_blank():
 
 
 def test_search_community_knowledge_labels_and_filters():
-    from agronaut_agent.store import _Db, MemoryStore, CommunityStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CommunityStore, MemoryStore, _Db
     from agronaut_agent.tools import search_community_knowledge
 
     db = _Db(":memory:")
@@ -296,8 +296,8 @@ def test_registry_includes_record_measurement():
 
 
 def test_record_measurement_maps_metric_to_qualified_key():
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import record_measurement
 
     db = _Db(":memory:")
@@ -319,8 +319,8 @@ def test_record_measurement_is_honest_when_no_calibration_coverage():
     # trout.harvest_weight has no published range in aqua_model.calibration: the value must
     # still be stored (for when coverage lands), but the reply must say it can't calibrate —
     # never the silent "I'll use your measurements to calibrate" lie.
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import record_measurement
 
     db = _Db(":memory:")
@@ -340,8 +340,8 @@ def test_record_measurement_is_honest_when_no_calibration_coverage():
 
 
 def test_record_measurement_rejects_unknown_metric_and_bad_value():
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import record_measurement
 
     db = _Db(":memory:")
@@ -356,8 +356,8 @@ def test_record_measurement_rejects_unknown_metric_and_bad_value():
 
 
 def test_size_tool_applies_calibration_and_labels_it():
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import size_aquaponics_system
 
     db = _Db(":memory:")
@@ -389,8 +389,8 @@ def test_size_tool_without_calibration_is_unchanged():
 def test_size_tool_surfaces_override_validation_error():
     """Prove that a ValidationError raised by an override is caught and surfaced,
     not crashed."""
-    from agronaut_agent.store import _Db, MemoryStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import MemoryStore, _Db
     from agronaut_agent.tools import size_aquaponics_system
 
     class _BadCal:
@@ -410,8 +410,8 @@ def test_size_tool_surfaces_override_validation_error():
 
 
 def test_size_note_not_claimed_for_mismatched_species():
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import size_aquaponics_system
     db = _Db(":memory:")
     mem, cal = MemoryStore(db), CalibrationStore(db)
@@ -428,8 +428,8 @@ def test_size_note_not_claimed_for_mismatched_species():
 
 
 def test_optimize_tool_labels_calibration():
-    from agronaut_agent.store import _Db, MemoryStore, CalibrationStore
     from agronaut_agent import runtime
+    from agronaut_agent.store import CalibrationStore, MemoryStore, _Db
     from agronaut_agent.tools import optimize_fish_crop_ratio
     db = _Db(":memory:")
     mem, cal = MemoryStore(db), CalibrationStore(db)

--- a/agronaut_agent/tests/test_whatsapp_adapter.py
+++ b/agronaut_agent/tests/test_whatsapp_adapter.py
@@ -8,8 +8,8 @@ import hashlib
 import hmac
 import json
 
-from agronaut_agent.channels.whatsapp_adapter import WhatsAppAdapter
 from agronaut_agent.channels import base
+from agronaut_agent.channels.whatsapp_adapter import WhatsAppAdapter
 
 
 class _FakeAgent:

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -14,20 +14,22 @@ import logging
 from langchain_core.tools import tool
 
 from aqua_model import (
-    size_system,
-    size_hydroponic_system,
-    optimize,
+    OBJECTIVES,
     OptimizeInput,
+    ValidationError,
+    datasets,
+    optimize,
+    report,
+    size_hydroponic_system,
+    size_system,
     validate_design_input,
     validate_hydroponic_input,
-    ValidationError,
-    OBJECTIVES,
 )
-from aqua_model.species import SPECIES, get_species
 from aqua_model.crops import CROPS
-from aqua_model import datasets, report
+from aqua_model.species import SPECIES
 
-from . import profile as profile_mod, rag, runtime, serialize
+from . import profile as profile_mod
+from . import rag, runtime, serialize
 
 log = logging.getLogger(__name__)
 
@@ -334,6 +336,7 @@ def render_system_schematic(
     deterministically from the sized design — you do not describe it, just call this."""
     import os
     import tempfile
+
     from aqua_model.schematic import to_png
     fish = _clean_optional(fish_species)
     try:

--- a/app.py
+++ b/app.py
@@ -140,7 +140,7 @@ def _handle_turn(user_text: str, image_bytes: bytes | None = None) -> None:
     try:
         with st.spinner(spinner):
             reply = _route_turn(agent, _web_user(), user_text, image_bytes)
-    except Exception:
+    except Exception as exc:
         reply = ("Something went wrong talking to the model — your message wasn't lost, "
                  "please try again.")
     _add_message("assistant", reply)

--- a/app.py
+++ b/app.py
@@ -16,7 +16,6 @@ import streamlit as st
 from agent.calculator_ui import render_calculator
 from agent.optimizer_ui import render_optimizer
 
-
 APP_TITLE = "🌱 Agronaut"
 _PHOTO_TYPES = ["png", "jpg", "jpeg", "webp"]
 
@@ -140,7 +139,7 @@ def _handle_turn(user_text: str, image_bytes: bytes | None = None) -> None:
     try:
         with st.spinner(spinner):
             reply = _route_turn(agent, _web_user(), user_text, image_bytes)
-    except Exception as exc:
+    except Exception:
         reply = ("Something went wrong talking to the model — your message wasn't lost, "
                  "please try again.")
     _add_message("assistant", reply)

--- a/aqua_model/__init__.py
+++ b/aqua_model/__init__.py
@@ -16,22 +16,30 @@ Design rules (from the approved design doc + eng/CEO reviews):
   - Every output lists what is NOT modeled. Calibration != validation.
 """
 
-from .sizing import size_system
 from .hydroponics import size_hydroponic_system
-from .pilot import PilotInfo, to_pilot_proposal, projected_outcomes
-from .optimizer import optimize, OptimizeInput, OptimizeResult, Candidate, OBJECTIVES
-from .validate import (
-    validate_design_input,
-    validate_hydroponic_input,
-    validate_optimize_input,
-    ValidationError,
-)
+from .optimizer import OBJECTIVES, Candidate, OptimizeInput, OptimizeResult, optimize
+from .pilot import PilotInfo, projected_outcomes, to_pilot_proposal
+from .sizing import size_system
 from .triage import (
-    ObservationFeatures, TriageCandidate, TriageResult, format_triage, triage_symptoms,
+    ObservationFeatures,
+    TriageCandidate,
+    TriageResult,
+    format_triage,
+    triage_symptoms,
     validate_observation_features,
 )
 from .types import (
-    DesignInput, DesignOutput, CoefficientUse, HydroponicInput, HydroponicOutput,
+    CoefficientUse,
+    DesignInput,
+    DesignOutput,
+    HydroponicInput,
+    HydroponicOutput,
+)
+from .validate import (
+    ValidationError,
+    validate_design_input,
+    validate_hydroponic_input,
+    validate_optimize_input,
 )
 
 __all__ = [

--- a/aqua_model/datasets.py
+++ b/aqua_model/datasets.py
@@ -26,8 +26,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from .logging_schema import SCHEMA_VERSION
 from . import sensor_qc
+from .logging_schema import SCHEMA_VERSION
 
 _PKG_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _PKG_DIR.parent

--- a/aqua_model/massbalance.py
+++ b/aqua_model/massbalance.py
@@ -25,7 +25,6 @@ from . import coefficients as C
 from .crops import Crop
 from .species import FishSpecies
 
-
 # Independent estimates of where excreted N goes (NOT a residual). These are coarse
 # literature fractions; they must sum to ~1.0 with the plant-uptake fraction so the
 # balance is a real check, not a tautology.

--- a/aqua_model/optimizer.py
+++ b/aqua_model/optimizer.py
@@ -20,10 +20,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from itertools import combinations_with_replacement
 
-from . import coefficients as C
 from . import massbalance as mb
 from .crops import CROPS, get_crop
-from .overrides import validate_overrides, apply_overrides
+from .overrides import apply_overrides, validate_overrides
 from .species import SPECIES, get_species, temperature_feed_factor
 from .validate import ValidationError, validate_optimize_input
 

--- a/aqua_model/schematic.py
+++ b/aqua_model/schematic.py
@@ -174,13 +174,21 @@ def to_svg(out) -> str:
 
 
 # --- PNG renderer (Pillow) --------------------------------------------------
-def _font(size: int):
+def _font(size: int, bold: bool = False):
     from PIL import ImageFont
-    for name in ("DejaVuSans.ttf", "DejaVuSans-Bold.ttf"):
+
+    candidates = (
+        ("C:/Windows/Fonts/arialbd.ttf", "C:/Windows/Fonts/arial.ttf")
+        if bold
+        else ("C:/Windows/Fonts/arial.ttf",)
+    )
+
+    for name in candidates:
         try:
             return ImageFont.truetype(name, size)
         except OSError:
             continue
+
     return ImageFont.load_default()
 
 
@@ -200,8 +208,11 @@ def to_png(out) -> bytes:
     s = _scene(out)
     img = Image.new("RGB", (_W, _H), "#f7fafc")
     d = ImageDraw.Draw(img)
-    f_title, f_box_title, f_line, f_status, f_arrow = (
-        _font(18), _font(14), _font(12), _font(12), _font(11))
+    f_title = _font(18, bold=True)
+    f_box_title = _font(14, bold=True)
+    f_line = _font(12)
+    f_status = _font(12, bold=True)
+    f_arrow = _font(11)
 
     _center_text(d, _W / 2, 14, s.title, f_title, "#0b1b2b")
     _center_text(d, _W / 2, 38, s.status, f_status,

--- a/aqua_model/schematic.py
+++ b/aqua_model/schematic.py
@@ -203,6 +203,7 @@ def _center_text(draw, cx, y, text, font, fill):
 def to_png(out) -> bytes:
     """Rasterize the schematic to PNG bytes (for an inline chat photo). Deterministic."""
     import io
+
     from PIL import Image, ImageDraw
 
     s = _scene(out)

--- a/aqua_model/sizing.py
+++ b/aqua_model/sizing.py
@@ -23,7 +23,7 @@ import math
 from . import coefficients as C
 from . import massbalance as mb
 from .crops import get_crop
-from .overrides import validate_overrides, apply_overrides
+from .overrides import apply_overrides, validate_overrides
 from .species import get_species, temperature_feed_factor
 from .system_types import get_system_type
 from .types import CoefficientUse, DesignInput, DesignOutput

--- a/aqua_model/tests/test_datasets.py
+++ b/aqua_model/tests/test_datasets.py
@@ -106,6 +106,7 @@ def test_unknown_channel_reports_unassessed_not_reliable():
     """The heart of the bug: `reliable` used to be the else-branch, so any channel nobody wrote a
     check for was silently promoted. An unchecked channel must say so."""
     import pandas as pd
+
     from aqua_model import datasets
     # Varied values on purpose: a fixture with few distinct values trips the saturation check
     # first and never reaches the question being asked.
@@ -118,6 +119,7 @@ def test_dead_sensor_sentinels_outrank_other_verdicts():
     """A channel whose median is -127 is a disconnected probe, and that is the useful thing to
     report — not that it happens to also look saturated."""
     import pandas as pd
+
     from aqua_model import datasets
     s = pd.Series([-127.0] * 60 + [24.0] * 40)
     verdict, evidence = datasets._trust_verdict("water_temp_c", s, None)
@@ -129,6 +131,7 @@ def test_non_independent_channels_are_demoted():
     """Two channels that are one instrument must both lose their `reliable` verdict, even though
     each looks fine measured alone."""
     import pandas as pd
+
     from aqua_model import datasets
     n = 400
     a = [0.11 + i * 0.001 for i in range(n)]

--- a/aqua_model/tests/test_hydroponics.py
+++ b/aqua_model/tests/test_hydroponics.py
@@ -6,11 +6,11 @@ its own 'not modeled' list, and nutrient (EC / elemental-N) targets fish systems
 import pytest
 
 from aqua_model import (
-    size_hydroponic_system,
-    validate_hydroponic_input,
     HydroponicInput,
     HydroponicOutput,
     ValidationError,
+    size_hydroponic_system,
+    validate_hydroponic_input,
 )
 
 

--- a/aqua_model/tests/test_mixed_bed.py
+++ b/aqua_model/tests/test_mixed_bed.py
@@ -9,7 +9,7 @@ Two invariants make this trustworthy rather than just flexible:
 
 import pytest
 
-from aqua_model import size_system, validate_design_input, ValidationError
+from aqua_model import ValidationError, size_system, validate_design_input
 
 
 def test_single_entry_plan_matches_single_crop_exactly():

--- a/aqua_model/tests/test_optimizer.py
+++ b/aqua_model/tests/test_optimizer.py
@@ -2,9 +2,8 @@
 
 import pytest
 
-from aqua_model import optimize, OptimizeInput
+from aqua_model import OptimizeInput, optimize
 from aqua_model.crops import get_crop
-from aqua_model.species import get_species
 
 
 def _inp(**over):
@@ -82,7 +81,7 @@ def test_honesty_layer_present():
 
 
 def test_optimize_yield_override_changes_food_score():
-    from aqua_model import optimize, OptimizeInput
+    from aqua_model import OptimizeInput, optimize
     inp = OptimizeInput(grow_area_m2=10, temperature_c=27, water_budget_lpd=5000, objective="food")
     base = optimize(inp)
     higher = optimize(inp, overrides={"lettuce.yield": 30.0})  # top of range vs seed 25
@@ -91,13 +90,13 @@ def test_optimize_yield_override_changes_food_score():
 
 
 def test_optimize_no_override_is_unchanged():
-    from aqua_model import optimize, OptimizeInput
+    from aqua_model import OptimizeInput, optimize
     inp = OptimizeInput(grow_area_m2=10, temperature_c=27, water_budget_lpd=5000, objective="food")
     assert optimize(inp, overrides=None).best.score == optimize(inp).best.score
 
 
 def test_optimize_default_palette_includes_new_entries():
-    from aqua_model import optimize, OptimizeInput
+    from aqua_model import OptimizeInput, optimize
     inp = OptimizeInput(grow_area_m2=10, temperature_c=25, water_budget_lpd=5000, objective="food")
     res = optimize(inp)                      # default palettes = all species/crops
     assert res.best is not None              # a feasible best exists with the expanded palette

--- a/aqua_model/tests/test_overrides.py
+++ b/aqua_model/tests/test_overrides.py
@@ -1,10 +1,11 @@
 import dataclasses
+
 import pytest
 
-from aqua_model.overrides import apply_overrides, validate_overrides
-from aqua_model.validate import ValidationError
-from aqua_model.species import get_species
 from aqua_model.crops import get_crop
+from aqua_model.overrides import apply_overrides, validate_overrides
+from aqua_model.species import get_species
+from aqua_model.validate import ValidationError
 
 
 def test_apply_overrides_replaces_matching_species_attr():

--- a/aqua_model/tests/test_pump_head.py
+++ b/aqua_model/tests/test_pump_head.py
@@ -7,13 +7,16 @@ Physics anchor: electrical power = ρ g Q H / efficiency. Same flow at 5× the h
 the pump power — which is exactly why towers are not a free lunch, now shown numerically.
 """
 
-import math
 
 import pytest
 
-from aqua_model import size_system, size_hydroponic_system, validate_design_input, \
-    validate_hydroponic_input
 from aqua_model import coefficients as C
+from aqua_model import (
+    size_hydroponic_system,
+    size_system,
+    validate_design_input,
+    validate_hydroponic_input,
+)
 
 
 def test_every_design_reports_head_and_power():

--- a/aqua_model/tests/test_schematic.py
+++ b/aqua_model/tests/test_schematic.py
@@ -6,8 +6,10 @@ numbers on the diagram match the design's numbers.
 import xml.dom.minidom as minidom
 
 from aqua_model import (
-    size_system, validate_design_input,
-    size_hydroponic_system, validate_hydroponic_input,
+    size_hydroponic_system,
+    size_system,
+    validate_design_input,
+    validate_hydroponic_input,
 )
 from aqua_model.schematic import to_svg
 
@@ -67,7 +69,9 @@ def test_svg_has_no_external_references():
 
 def test_to_png_returns_a_valid_png_image():
     import io
+
     from PIL import Image
+
     from aqua_model.schematic import to_png
 
     for out in (_aqua(), _hydro()):

--- a/aqua_model/tests/test_sensor_qc.py
+++ b/aqua_model/tests/test_sensor_qc.py
@@ -14,7 +14,6 @@ import pytest
 from aqua_model import sensor_qc as qc
 from aqua_model.coefficients import DO_SUPERSATURATION_TOLERANCE
 
-
 # --- oxygen saturation -------------------------------------------------------
 
 @pytest.mark.parametrize("temp_c,expected", [

--- a/aqua_model/tests/test_sizing.py
+++ b/aqua_model/tests/test_sizing.py
@@ -1,6 +1,10 @@
 """Sizing behaviour: happy path, infeasibility, temperature sensitivity, honesty layer."""
 
+import pytest
+
 from aqua_model import size_system
+from aqua_model.crops import CROPS
+from aqua_model.species import SPECIES
 from aqua_model.validate import validate_design_input
 
 
@@ -71,7 +75,7 @@ def test_never_raises_on_valid_input_extremes():
 
 def test_size_system_harvest_weight_override_changes_fish_count():
     from aqua_model import size_system
-    from aqua_model.validate import validate_design_input, ValidationError
+    from aqua_model.validate import validate_design_input
     design = validate_design_input("tilapia", "lettuce", 20, 27, 500)
     base = size_system(design)
     # a smaller harvest weight -> more fish for the same biomass
@@ -88,17 +92,10 @@ def test_size_system_no_override_is_unchanged():
 
 def test_size_system_rejects_out_of_range_override():
     from aqua_model import size_system
-    from aqua_model.validate import validate_design_input, ValidationError
+    from aqua_model.validate import ValidationError
     design = validate_design_input("tilapia", "lettuce", 20, 27, 500)
-    import pytest
     with pytest.raises(ValidationError):
         size_system(design, overrides={"tilapia.harvest_weight": 5.0})  # far above range
-
-
-import pytest
-from aqua_model.species import SPECIES
-from aqua_model.crops import CROPS
-
 
 @pytest.mark.parametrize("fish", ["tilapia", "clarias", "channel_catfish", "trout", "carp",
                                   "barramundi", "silver_perch", "tambaqui",

--- a/aqua_model/tests/test_system_types.py
+++ b/aqua_model/tests/test_system_types.py
@@ -5,7 +5,7 @@ default (raft) is byte-identical to the pre-flexibility behavior, so nothing reg
 
 import pytest
 
-from aqua_model import size_system, validate_design_input, ValidationError
+from aqua_model import ValidationError, size_system, validate_design_input
 from aqua_model.system_types import SYSTEM_TYPES, get_system_type
 
 

--- a/aqua_model/tests/test_triage.py
+++ b/aqua_model/tests/test_triage.py
@@ -13,7 +13,9 @@ import pytest
 
 import aqua_model.triage as triage_mod
 from aqua_model.triage import (
-    ObservationFeatures, format_triage, triage_symptoms,
+    ObservationFeatures,
+    format_triage,
+    triage_symptoms,
     validate_observation_features,
 )
 from aqua_model.validate import ValidationError
@@ -251,6 +253,7 @@ def test_package_export_does_not_shadow_the_submodule():
     convention already used by sizing.py/size_system and hydroponics.py/
     size_hydroponic_system, where no export collides with a module name."""
     import types
+
     from aqua_model import triage as imported
     assert isinstance(imported, types.ModuleType)
     import aqua_model

--- a/aqua_model/tests/test_validate.py
+++ b/aqua_model/tests/test_validate.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aqua_model.validate import validate_design_input, ValidationError
+from aqua_model.validate import ValidationError, validate_design_input
 
 
 def _ok(**over):
@@ -63,7 +63,7 @@ def test_multiple_errors_collected_together():
 # yields at exit 0, and a NaN temperature scored identically to an optimal one (every NaN
 # comparison is False, so the temperature penalty silently never applied).
 
-from aqua_model import optimize, OptimizeInput  # noqa: E402
+from aqua_model import OptimizeInput, optimize  # noqa: E402
 
 
 def _opt(**over):

--- a/aqua_model/tests/test_vertical.py
+++ b/aqua_model/tests/test_vertical.py
@@ -8,8 +8,12 @@ about. Flat methods (raft/NFT/media bed) have footprint == growing area, byte-id
 
 import pytest
 
-from aqua_model import size_system, size_hydroponic_system, validate_design_input, \
-    validate_hydroponic_input
+from aqua_model import (
+    size_hydroponic_system,
+    size_system,
+    validate_design_input,
+    validate_hydroponic_input,
+)
 from aqua_model.system_types import SYSTEM_TYPES, get_system_type
 
 
@@ -53,8 +57,8 @@ def test_hydroponic_tower_reports_footprint():
 
 
 def test_tower_footprint_appears_in_schematic_and_serialization():
-    from aqua_model.schematic import to_svg
     from agronaut_agent.serialize import serialize_design_output
+    from aqua_model.schematic import to_svg
     out = size_system(validate_design_input(
         "tilapia", "lettuce", 12, 27, 3000, system_type="vertical_tower"))
     assert "floor" in to_svg(out).lower() or "footprint" in to_svg(out).lower()

--- a/bot.py
+++ b/bot.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import logging
 
 import agent  # noqa: F401 — importing the package loads project-root .env (agent/__init__.py)
-from agronaut_agent.core import AgronautAgent
 from agronaut_agent.channels.telegram_adapter import TelegramAdapter
+from agronaut_agent.core import AgronautAgent
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,5 @@ exclude = ["*.tests", "*.tests.*"]
 [tool.setuptools.data-files]
 "share/agronaut" = ["urls.txt"]
 "share/agronaut/knowledge" = ["knowledge/*.md"]
+[tool.ruff]
+line-length = 95

--- a/scripts/corpus_report.py
+++ b/scripts/corpus_report.py
@@ -32,8 +32,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from langchain_text_splitters import RecursiveCharacterTextSplitter  # noqa: E402
 
 from srcs.chatbot import (  # noqa: E402
-    CHUNK_OVERLAP, CHUNK_SIZE, KNOWLEDGE_DIR, URL_FILE, WEB_LOAD_TIMEOUT,
-    _is_boilerplate_text, _pdf_documents, _probe_url, load_web_page, parse_urls_file,
+    CHUNK_OVERLAP,
+    CHUNK_SIZE,
+    KNOWLEDGE_DIR,
+    URL_FILE,
+    WEB_LOAD_TIMEOUT,
+    _is_boilerplate_text,
+    _pdf_documents,
+    _probe_url,
+    load_web_page,
+    parse_urls_file,
 )
 
 # Words that carry no topic signal, so their presence in a LABEL proves nothing about whether
@@ -124,6 +132,7 @@ def _pdf_title(content: bytes) -> str:
     """The /Title (or /Subject) a PDF declares in its metadata."""
     try:
         import io
+
         from pypdf import PdfReader
         info = PdfReader(io.BytesIO(content)).metadata or {}
         return str(info.get("/Title") or info.get("/Subject") or "")[:200]

--- a/scripts/safety_eval.py
+++ b/scripts/safety_eval.py
@@ -19,12 +19,14 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from agronaut_agent.tools import (  # noqa: E402
-    size_aquaponics_system, size_hydroponic_system_tool, optimize_fish_crop_ratio,
-)
-from aqua_model.species import SPECIES  # noqa: E402
-from aqua_model.crops import CROPS  # noqa: E402
 from agent.vision import sanitize_observation  # noqa: E402
+from agronaut_agent.tools import (  # noqa: E402
+    optimize_fish_crop_ratio,
+    size_aquaponics_system,
+    size_hydroponic_system_tool,
+)
+from aqua_model.crops import CROPS  # noqa: E402
+from aqua_model.species import SPECIES  # noqa: E402
 
 _GOLDEN = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "safety_eval" / "golden_set.json"
 

--- a/skills/aquaponics_engineer/cli.py
+++ b/skills/aquaponics_engineer/cli.py
@@ -21,13 +21,19 @@ from pathlib import Path
 # Make the repo importable when this file is run directly from anywhere.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from aqua_model import (  # noqa: E402
-    size_system, size_hydroponic_system, optimize, OptimizeInput,
-    validate_design_input, validate_hydroponic_input, ValidationError, OBJECTIVES,
-)
-from aqua_model.species import SPECIES  # noqa: E402
-from aqua_model.crops import CROPS  # noqa: E402
 from agronaut_agent import serialize  # noqa: E402
+from aqua_model import (  # noqa: E402
+    OBJECTIVES,
+    OptimizeInput,
+    ValidationError,
+    optimize,
+    size_hydroponic_system,
+    size_system,
+    validate_design_input,
+    validate_hydroponic_input,
+)
+from aqua_model.crops import CROPS  # noqa: E402
+from aqua_model.species import SPECIES  # noqa: E402
 
 
 def _cmd_size_aquaponics(a) -> int:

--- a/skills/aquaponics_engineer/tests/test_cli.py
+++ b/skills/aquaponics_engineer/tests/test_cli.py
@@ -2,8 +2,8 @@
 agent (Hermes, OpenClaw, Claude Code) can call. No LLM, no network — validated input in,
 cited sizing out; the trust gate is preserved (bad input exits non-zero)."""
 
-import io
 import contextlib
+import io
 
 from skills.aquaponics_engineer import cli
 

--- a/srcs/chatbot.py
+++ b/srcs/chatbot.py
@@ -21,19 +21,17 @@ from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 import requests_cache
+from langchain_community.document_loaders import TextLoader, WebBaseLoader
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import FAISS
 from langchain_core.prompts import ChatPromptTemplate
 
 # --- RAG deps (FAISS) ---
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from langchain_community.document_loaders import WebBaseLoader, TextLoader
-from langchain_community.embeddings import HuggingFaceEmbeddings
-from langchain_community.vectorstores import FAISS
-
 
 # =============================================================================
 # Configuration
 # =============================================================================
-
 # Resolved, never cwd-relative: `agronaut` is an installed command run from anywhere, and a
 # cwd-relative corpus degrades RAG to KNOWLEDGE_UNAVAILABLE without ever raising. See
 # agronaut_agent/paths.py for why the answer depends on how Agronaut was installed.
@@ -255,18 +253,18 @@ def _strip_running_headers(docs, min_fraction: float = 0.15):
     from collections import Counter
     counts: Counter = Counter()
     for d in docs:
-        seen = {_normalise_for_repetition(l) for l in d.page_content.splitlines() if l.strip()}
+        seen = {_normalise_for_repetition(line) for line in d.page_content.splitlines() if line.strip()}
         for line in seen:
             if line:
                 counts[line] += 1
     threshold = max(3, int(len(docs) * min_fraction))
-    furniture = {l for l, c in counts.items() if c >= threshold and len(l) > 8}
+    furniture = {line for line, c in counts.items() if c >= threshold and len(line) > 8}
     if not furniture:
         return docs
     for d in docs:
         d.page_content = "\n".join(
-            l for l in d.page_content.splitlines()
-            if _normalise_for_repetition(l) not in furniture)
+            line for line in d.page_content.splitlines()
+            if _normalise_for_repetition(line) not in furniture)
     logging.info("Stripped %d running header/footer line(s) from %d pages",
                  len(furniture), len(docs))
     return docs
@@ -279,10 +277,10 @@ def _looks_like_contents_page(text: str) -> bool:
     28"). It embeds as a dense bag of the document's own section titles, so it matches almost any
     query about the document's subject while answering none of them.
     """
-    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
     if len(lines) < 6:
         return False
-    numbered = sum(1 for l in lines if re.search(r"\s\d{1,4}\s*$", l))
+    numbered = sum(1 for line in lines if re.search(r"\s\d{1,4}\s*$", line))
     return numbered / len(lines) >= 0.6
 
 
@@ -339,15 +337,15 @@ def _label_pdf_chapters(docs):
     """
     current = ""
     for d in docs:
-        lines = [l for l in d.page_content.splitlines()]
-        stripped = [l.strip() for l in lines if l.strip()]
+        lines = [line for line in d.page_content.splitlines()]
+        stripped = [line.strip() for line in lines if line.strip()]
         if stripped:
             m = _CHAPTER_HEADER.match(stripped[0])
             if m:
                 current = m.group(1).strip()
                 # The header line is furniture once its content is captured as metadata.
-                for i, l in enumerate(lines):
-                    if l.strip() == stripped[0]:
+                for i, line in enumerate(lines):
+                    if line.strip() == stripped[0]:
                         lines.pop(i)
                         break
         if current:
@@ -386,6 +384,7 @@ def _pdf_documents(content: bytes, url: str):
     can be cited back to a page number."""
     try:
         import io
+
         from langchain_core.documents import Document
         from pypdf import PdfReader
 
@@ -1823,7 +1822,6 @@ def _load_cached_index(fingerprint: str):
     365 chunks of HTML; it is not once a corpus includes a 56 MB, 275-page publication that takes
     47 s just to download.
     """
-    import os
     import time
     if not _index_cache_enabled():
         return None


### PR DESCRIPTION
## Summary

- Clean up the existing Ruff violations in the repository.
- Keep Ruff line length at 95 characters.
- Make the Ruff CI check blocking instead of advisory.

## Validation

- Ruff: `python -m ruff check . --select E4,E7,E9,F,I` ✅
- Tests: `758 passed, 2 skipped` ✅
- `git diff --check` ✅