### PR TITLE
fix(twin): tell the operator what the twin has actually been shown to do

### DIFF
--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -467,7 +467,9 @@ def test_what_if_nitrogen_reports_relative_not_absolute():
                                  feed_g_per_day=150.0, temperature_c=27.0,
                                  change="double feed", new_feed_g_per_day=300.0)
     assert "x higher" in text or "x lower" in text or "No material change" in text
-    assert "unvalidated" in text
+    # The footer now reports what the validation record found rather than the single word
+    # "unvalidated" — strictly more informative, so assert the property.
+    assert "VALIDATION" in text or "UNMEASURED" in text
 
 
 def test_simulate_season_design_mode_stocks_the_designed_system():

--- a/aqua_model/production.py
+++ b/aqua_model/production.py
@@ -324,10 +324,7 @@ def format_summary(run: ProductionRun, *, site_label: str = "") -> str:
     if s.warnings:
         lines.append("")
         lines += [f"  ! {w}" for w in s.warnings[:6]]
-    lines += [
-        "",
-        "This is a projection from a model calibrated on literature seeds, not on your",
-        "system. Treat relative comparisons as the useful part, not the absolute kilograms.",
-        "NOT modelled: " + "; ".join(s.not_modelled[:4]) + "; ...",
-    ]
+    from .validation_status import validation_lines
+    lines += ["", *validation_lines(),
+              "NOT modelled: " + "; ".join(s.not_modelled[:4]) + "; ..."]
     return "\n".join(lines)

--- a/aqua_model/scenario.py
+++ b/aqua_model/scenario.py
@@ -234,10 +234,7 @@ def format_comparison(cmp: Comparison) -> str:
     if cmp.scenario.warnings:
         lines.append("")
         lines += [f"  ! {w}" for w in cmp.scenario.warnings]
-    lines += [
-        "",
-        "This is a projection from an unvalidated model: it has not been checked against a real",
-        "system, so treat the SHAPE of the change as the useful part, not the absolute numbers.",
-        "NOT modelled: " + "; ".join(cmp.scenario.not_modelled[:3]) + ".",
-    ]
+    from .validation_status import validation_lines
+    lines += ["", *validation_lines(),
+              "NOT modelled: " + "; ".join(cmp.scenario.not_modelled[:3]) + "."]
     return "\n".join(lines)

--- a/aqua_model/tests/test_scenario.py
+++ b/aqua_model/tests/test_scenario.py
@@ -133,12 +133,17 @@ def test_the_band_has_real_width_when_it_matters():
 
 # --- honesty surface ---------------------------------------------------------
 
-def test_the_output_states_it_is_unvalidated():
+def test_the_output_states_its_demonstrated_skill():
+    """Asserts the PROPERTY, not a particular word. The footer used to say "unvalidated"; it now
+    reports what the validation record actually found, which is strictly stronger — and a test
+    pinned to the old wording would have blocked the improvement."""
     state = _settled()
     text = format_comparison(compare(_baseline(state), run_scenario(
         state, SP, Intervention("triple feed", feed_g_per_day=FEED * 3), **_common())))
-    assert "unvalidated" in text.lower()
-    assert "not modelled" in text.lower()
+    low = text.lower()
+    assert "validation" in low or "unmeasured" in low
+    assert "never to predict a level" in low or "illustrative" in low
+    assert "not modelled" in low
 
 
 def test_limits_travel_with_the_result():

--- a/aqua_model/tests/test_validation_status.py
+++ b/aqua_model/tests/test_validation_status.py
@@ -1,0 +1,111 @@
+"""What the projection footer tells an operator about the twin's demonstrated skill.
+
+The footer used to say the model was "calibrated on literature seeds, not on your system". True,
+and weaker than what is now known: scored against seven real ponds, it beat both null baselines on
+none of them. "Not tuned to you" invites trusting the shape and discounting the precision;
+"tested, and level prediction is not demonstrated" tells an operator not to act on the numbers.
+Someone with fish in the water needs the second.
+
+The wording is DERIVED from `data/twin_validation.json`, so it cannot drift from the evidence.
+These tests pin that, and pin the direction it fails in when the evidence is absent.
+"""
+
+import json
+
+import pytest
+
+from aqua_model import validation_status as vs
+
+
+def _artifact(tmp_path, *, n=7, both=0, shape=5, r=0.297):
+    p = tmp_path / "v.json"
+    p.write_text(json.dumps({"summary": {
+        "n_scored": n, "n_beats_both_nulls": both,
+        "n_positive_shape_correlation": shape, "holdout_r_median": r}}))
+    return p
+
+
+def test_it_reports_the_real_current_state():
+    """Against the committed record: zero of seven beat both baselines."""
+    lines = " ".join(vs.validation_lines())
+    assert "7 real ponds" in lines
+    assert "0 of 7" in lines
+    assert "compare options, never to predict a level" in lines
+
+
+def test_it_cites_evidence_that_can_be_checked():
+    lines = " ".join(vs.validation_lines())
+    assert "data/twin_validation.json" in lines
+    assert "scripts/validate_twin.py" in lines
+
+
+def test_it_does_not_overstate_the_failure(tmp_path):
+    """`n_beats_both_nulls` counts ponds beating BOTH baselines. Calling that "beat a no-change
+    baseline" would be wrong in the pessimistic direction — one pond does beat the flat null while
+    losing to the trend — and being more negative than the evidence is as inaccurate as being
+    less."""
+    lines = " ".join(vs.validation_lines(_artifact(tmp_path)))
+    assert "both a flat and a trend baseline" in lines
+
+
+def test_the_wording_follows_the_evidence(tmp_path):
+    """Improve the validation and the footer improves on its own — nobody has to remember to
+    rewrite a sentence that has quietly become false."""
+    good = " ".join(vs.validation_lines(_artifact(tmp_path, n=10, both=8, shape=9, r=0.81)))
+    assert "8 of 10" in good
+    assert "0.81" in good
+
+
+def test_a_missing_record_makes_the_caveat_stronger_not_weaker(tmp_path):
+    """The failure direction that matters. An absent artifact must never read as an absent
+    problem — an unmeasured model is not a validated one."""
+    lines = " ".join(vs.validation_lines(tmp_path / "nope.json"))
+    assert "UNMEASURED" in lines
+    assert "illustrative" in lines
+
+
+def test_a_corrupt_record_does_not_break_a_projection(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    assert "UNMEASURED" in " ".join(vs.validation_lines(bad))
+
+
+def test_an_empty_summary_is_treated_as_unmeasured(tmp_path):
+    p = tmp_path / "e.json"
+    p.write_text(json.dumps({"summary": {"n_scored": 0}}))
+    assert "UNMEASURED" in " ".join(vs.validation_lines(p))
+
+
+# --- the gate ----------------------------------------------------------------
+
+def test_level_prediction_is_not_currently_demonstrated():
+    """Currently False, and that is the honest state rather than a bug to route around."""
+    assert vs.level_prediction_demonstrated() is False
+
+
+def test_the_gate_needs_a_majority(tmp_path):
+    assert vs.level_prediction_demonstrated(_artifact(tmp_path, n=7, both=3)) is False
+    assert vs.level_prediction_demonstrated(_artifact(tmp_path, n=7, both=4)) is True
+
+
+def test_the_gate_fails_closed_without_evidence(tmp_path):
+    assert vs.level_prediction_demonstrated(tmp_path / "nope.json") is False
+
+
+# --- it reaches the operator -------------------------------------------------
+
+def test_the_season_projection_carries_it():
+    """The farmer-facing path. A projection printing kilograms and mg/L reads as a forecast
+    whatever hedging surrounds it, so the hedge has to be specific enough to overcome that."""
+    from aqua_model.production import ProductionRun
+    import aqua_model.production as prod
+    src = (prod.__file__)
+    text = open(src).read()
+    assert "validation_lines" in text
+    assert "calibrated on literature seeds" not in text
+
+
+def test_the_scenario_comparison_carries_it():
+    import aqua_model.scenario as sc
+    text = open(sc.__file__).read()
+    assert "validation_lines" in text

--- a/aqua_model/validation_status.py
+++ b/aqua_model/validation_status.py
@@ -1,0 +1,92 @@
+"""What the twin's predictions have actually been shown to do — read from the evidence.
+
+The projection footer used to say the model was "calibrated on literature seeds, not on your
+system". True, and weaker than what is now known: it reads as *not yet tuned to you*, when the
+model has since been scored against seven real ponds and **did not beat a flat-line null on six
+of them** (`data/twin_validation.json`, produced by `scripts/validate_twin.py`).
+
+Those are different admissions. "Not tuned to you" invites an operator to trust the shape and
+discount the precision. "Tested, and level prediction is not demonstrated" tells them not to act
+on the numbers at all. The second is the true one, and it is the one that matters to someone with
+fish in the water.
+
+The statement is DERIVED from the artifact rather than written next to it, so it cannot drift
+from the evidence: improve the validation and the wording follows on its own. If the artifact is
+missing the caveat gets stronger, never weaker — an unmeasured model is not a validated one.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+ARTIFACT = _REPO_ROOT / "data" / "twin_validation.json"
+
+_UNKNOWN = (
+    "PREDICTIVE SKILL UNMEASURED: no validation record was found, so nothing here has been "
+    "checked against a real system. Treat every number as illustrative.",
+)
+
+
+def _load(path: Path | str | None = None) -> dict | None:
+    try:
+        return json.loads(Path(path or ARTIFACT).read_text())
+    except Exception:      # a missing or unreadable record must never break a projection
+        return None
+
+
+def validation_lines(path: Path | str | None = None) -> tuple[str, ...]:
+    """Two or three lines stating, from the record, what the twin has been shown to do.
+
+    Deliberately blunt about the failure. A projection that prints kilograms and mg/L reads as a
+    forecast whatever hedging surrounds it, so the hedge has to be specific enough to overcome
+    that: not "treat with caution" but "on six of seven real ponds this was worse than assuming
+    nothing changes".
+    """
+    data = _load(path)
+    if not data:
+        return _UNKNOWN
+    s = data.get("summary") or {}
+    n = int(s.get("n_scored") or 0)
+    both = int(s.get("n_beats_both_nulls") or 0)
+    shape = int(s.get("n_positive_shape_correlation") or 0)
+    r_med = s.get("holdout_r_median")
+    if not n:
+        return _UNKNOWN
+
+    beaten = n - both
+    # "both nulls" is the honest phrasing: the record scores against a flat baseline AND a
+    # linear-trend baseline, and this counts ponds that beat BOTH. Saying "a no-change baseline"
+    # would overstate the failure — one pond does beat the flat null while losing to the trend —
+    # and being more negative than the evidence is as inaccurate as being less.
+    head = (
+        f"VALIDATION: scored against {n} real ponds on held-out data. It beat both a flat and a "
+        f"trend baseline on {both} of {n}"
+    )
+    head += (
+        f" — on the other {beaten} a simple baseline predicted the level as well or better."
+        if beaten else "."
+    )
+    mid = (
+        f"It tracked the DIRECTION of change on {shape} of {n}"
+        + (f" (median correlation {float(r_med):.2f})" if isinstance(r_med, (int, float)) else "")
+        + ". So use it to compare options, never to predict a level."
+    )
+    return (head, mid, f"Evidence: {ARTIFACT.relative_to(_REPO_ROOT)} "
+                       f"(regenerate with scripts/validate_twin.py).")
+
+
+def level_prediction_demonstrated(path: Path | str | None = None) -> bool:
+    """True only if the twin beat both null models on a majority of scored ponds.
+
+    The gate for whether a forward number may be presented as a prediction at all. It is
+    currently False, and that is the honest state, not a bug to route around.
+    """
+    data = _load(path)
+    if not data:
+        return False
+    s = data.get("summary") or {}
+    n = int(s.get("n_scored") or 0)
+    both = int(s.get("n_beats_both_nulls") or 0)
+    return n > 0 and both > n / 2


### PR DESCRIPTION
## The problem

Both farmer-facing twin surfaces — the season projection and the scenario comparison — ended with a caveat that has quietly become false:

> *"This is a projection from a model calibrated on literature seeds, not on your system."*

True when written. Weaker than what is now known.

Since #96 the twin has been scored against seven real ponds on held-out data, and `data/twin_validation.json` records the outcome:

```
pond           r      rmse_twin   rmse_flat   beats flat?  beats trend?
IoTPond2     -0.027      2361.9       628.0      False        False
IoTPond3      0.297      1307.4       788.2      False        False
IoTPond4      0.257      1090.7      1110.3      True         False
IoTPond6      0.565      1835.7      1090.1      False        False
IoTPond7      0.977      1293.7       325.4      False        False
IoTPond9      0.089       939.4       872.4      False        False
IoTpond1      0.327      1032.2       659.3      False        False
```

**Zero of seven beat both baselines.** On six, a simple no-change baseline predicted nitrate level as well or better — sometimes 3–4× better by RMSE. It does track *direction* on five of seven (median r = 0.30).

**"Not tuned to you" and "tested, and level prediction is not demonstrated" are different admissions.** The first invites an operator to trust the shape and discount the precision. The second tells them not to act on the numbers. A projection printing kilograms and mg/L reads as a forecast whatever hedging surrounds it, so the hedge has to be specific enough to overcome that — and someone with fish in the water needs the true one.

## What both footers now say

```
VALIDATION: scored against 7 real ponds on held-out data. It beat both a flat and a
trend baseline on 0 of 7 — on the other 7 a simple baseline predicted the level as well
or better. It tracked the DIRECTION of change on 5 of 7 (median correlation 0.30). So
use it to compare options, never to predict a level.
Evidence: data/twin_validation.json (regenerate with scripts/validate_twin.py).
```

## Derived, not written beside

The wording comes **from** the artifact, so it cannot drift from the evidence. Improve the validation and the sentence improves on its own — nobody has to notice that a hand-written caveat has gone stale, which is exactly how this one did.

It also fails in the right direction: a missing or corrupt record yields a **stronger** caveat (`PREDICTIVE SKILL UNMEASURED`), never a weaker one. An unmeasured model is not a validated one.

`level_prediction_demonstrated()` is the gate for whether a forward number may be presented as a prediction at all. It returns **False**. That's the honest state, not something to route around — and it gives phase 3 of #85 a concrete definition of done.

## One correction inside the change

An earlier draft said *"beat a no-change baseline on 0 of 7"*. That **overstates** the failure: `n_beats_both_nulls` counts ponds beating *both* baselines, and IoTPond4 does beat the flat null while losing to the trend. Being more negative than the evidence is as inaccurate as being less. A test pins the distinction.

## How it was verified

```
$ pytest -q
937 passed

$ python -m scripts.safety_eval
Advice-safety golden set: 373/373 passed (score 1.000)
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

Two existing tests asserted the literal word `"unvalidated"` and failed against the stronger message. They now assert the **property** — that the output discloses its demonstrated skill — rather than a phrase, because a test pinned to old wording blocks the improvement it should be protecting.

### Trust-zone checklist

- [x] No new import of an LLM, network, or UI library — `json` and `pathlib`, matching the existing precedent in `datasets.py` which already reads a committed artifact
- [x] Any new number lives in `coefficients.py` with value, range, unit, source — no new coefficients; every number is read from the validation record
- [x] Any new user-facing result states what it does **not** model — this change *is* that statement, made specific
- [x] Model-proposed values still reach the core only through a validation gate

## What this does NOT do

- **It does not make the twin better.** It makes what the twin is honest. The numbers in a projection are unchanged; only the claim attached to them is.
- **It does not stop the twin producing numbers.** `simulate_season` still returns kilograms and mg/L, because the *warnings* around them are genuinely useful and don't depend on the nitrogen model being right — "water exceeds tilapia's survivable range on 27 days" comes from real climate data. Gating output on `level_prediction_demonstrated()` is a bigger product decision and belongs with whoever owns that call.
- **It does not explain WHY validation failed.** The record attributes it to uncalibrated pond sensors rather than model structure. That is plausible and untested; distinguishing "our model is wrong" from "their sensors are" needs the better data #87 is still chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYe3JRXxqYfRYQRRj5nF3U
