### PR TITLE
feat(twin): the dashboard — and the history the twin was throwing away

### DIFF
--- a/agent/tests/test_chat_ui.py
+++ b/agent/tests/test_chat_ui.py
@@ -153,3 +153,15 @@ def test_chat_mode_still_renders_with_the_file_accepting_input(fake_agent_backen
     at = _open_chat(AppTest.from_file(_APP))
     assert not at.exception
     assert at.chat_input
+
+
+def test_my_twin_mode_is_reachable_and_needs_no_llm(monkeypatch):
+    """The twin tab must appear beside the other modes and render without a chat model —
+    the whole point of the deterministic layer is that model weather cannot take it down."""
+    at = AppTest.from_file(_APP).run(timeout=60)
+    assert "My Twin" in at.sidebar.radio[0].options
+
+    at.sidebar.radio[0].set_value("My Twin").run(timeout=60)
+
+    assert not at.exception
+    assert "My Twin" in [s.value for s in at.subheader]

--- a/agent/tests/test_chat_ui.py
+++ b/agent/tests/test_chat_ui.py
@@ -155,9 +155,21 @@ def test_chat_mode_still_renders_with_the_file_accepting_input(fake_agent_backen
     assert at.chat_input
 
 
+def _no_tool_calling_llm(monkeypatch):
+    """Force the deployment where no tool-calling provider is configured. Pinned via env
+    rather than left to the machine: a developer's .env made this pass locally and fail in
+    CI, which is the wrong way round for a test about running WITHOUT credentials."""
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+
 def test_my_twin_mode_is_reachable_and_needs_no_llm(monkeypatch):
-    """The twin tab must appear beside the other modes and render without a chat model —
-    the whole point of the deterministic layer is that model weather cannot take it down."""
+    """The twin tab must appear beside the other modes and render with NO tool-calling
+    model available — surviving model weather is the whole promise of the command layer,
+    and a provider that cannot bind tools is the harshest weather there is."""
+    _no_tool_calling_llm(monkeypatch)
+
     at = AppTest.from_file(_APP).run(timeout=60)
     assert "My Twin" in at.sidebar.radio[0].options
 
@@ -165,3 +177,14 @@ def test_my_twin_mode_is_reachable_and_needs_no_llm(monkeypatch):
 
     assert not at.exception
     assert "My Twin" in [s.value for s in at.subheader]
+
+
+def test_chat_still_reports_that_it_needs_a_provider(monkeypatch):
+    """Making the twin survive a missing LLM must not silently promise a working chat."""
+    _no_tool_calling_llm(monkeypatch)
+
+    at = AppTest.from_file(_APP).run(timeout=60)
+    at.sidebar.radio[0].set_value("Assistant (chat)").run(timeout=60)
+
+    assert not at.exception
+    assert any("provider" in str(w.value).lower() for w in at.warning)

--- a/agent/tests/test_twin_ui.py
+++ b/agent/tests/test_twin_ui.py
@@ -1,0 +1,128 @@
+"""Headless test of the My Twin Streamlit view.
+
+Drives the real view against a real agent and a stubbed weather boundary — no browser,
+no LLM. The twin path must never reach a model, and this proves it: the agent is built
+with a chat model that raises if anything calls it.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+pytest.importorskip("streamlit.testing.v1")
+from streamlit.testing.v1 import AppTest  # noqa: E402
+
+
+class _NoLLM:
+    def bind_tools(self, tools):
+        return self
+    def invoke(self, *a, **k):
+        raise AssertionError("the twin dashboard must never call an LLM")
+
+
+def _offline(monkeypatch):
+    from aqua_model.climate import DailyClimate
+    from agronaut_agent import tools as T
+
+    def fake(lat, lon, past_days, forecast_days):
+        n = min(92, max(0, past_days)) + min(16, max(1, forecast_days))
+        start = date.today() - timedelta(days=min(92, max(0, past_days)))
+        dates = [(start + timedelta(days=i)).isoformat() for i in range(n)]
+        days = tuple(DailyClimate(t_mean_c=26.0, t_min_c=22.0, t_max_c=30.0,
+                                  solar_mj_m2=18.0) for _ in range(n))
+        return dates, days
+    monkeypatch.setattr(T, "_live_weather", fake)
+
+
+def _brain(tmp_path):
+    from agronaut_agent.core import AgronautAgent
+    return AgronautAgent(db_path=tmp_path / "ui.sqlite3", chat_model=_NoLLM())
+
+
+def _complete(brain, user="u1"):
+    uid = brain._conv.get_or_create_user("web", user)
+    brain._mem.set_facts(uid, {
+        "fish_species": "tilapia", "crop": "basil", "grow_area_m2": 15,
+        "tank_volume_l": 2000, "fish_count": 60, "fish_avg_weight_g": 200,
+        "climate_site": "taichung_2025", "site_lat": 24.15, "site_lon": 120.68},
+        source="user_stated")
+
+
+# AppTest.from_function recompiles a function body without its module globals, so the
+# view is driven as a script that imports it. The fixture is handed over through this
+# test module rather than a hook inside the production view.
+_SHARED: dict = {}
+
+_SCRIPT = (
+    "from agent.tests.test_twin_ui import _SHARED\n"
+    "from agent.twin_ui import render_twin\n"
+    "render_twin(brain=_SHARED['brain'], user=_SHARED['user'])\n"
+)
+
+
+def _run(brain, user="u1"):
+    _SHARED["brain"], _SHARED["user"] = brain, user
+    return AppTest.from_string(_SCRIPT).run(timeout=60)
+
+
+def test_incomplete_profile_offers_a_form_instead_of_a_robot_message(tmp_path, monkeypatch):
+    """The gate a farmer used to hit said "call fetch_site_climate" — an instruction
+    addressed to a model. Here it must be a form they can actually fill in."""
+    _offline(monkeypatch)
+    at = _run(_brain(tmp_path))
+
+    assert not at.exception
+    labels = [n.label for n in at.number_input]
+    assert "Tank volume (L)" in labels
+    assert "Number of fish" in labels
+    assert "Average fish weight (g)" in labels
+    assert not any("fetch_site_climate" in str(m.value) for m in at.markdown)
+
+
+def test_the_form_starts_the_twin_without_an_llm(tmp_path, monkeypatch):
+    _offline(monkeypatch)
+    brain = _brain(tmp_path)
+    uid = brain._conv.get_or_create_user("web", "u1")
+    brain._mem.set_facts(uid, {"fish_species": "tilapia", "crop": "basil",
+                               "grow_area_m2": 15, "climate_site": "taichung_2025",
+                               "site_lat": 24.15, "site_lon": 120.68}, source="user_stated")
+
+    at = _run(brain)
+    at.number_input(key="twin_tank_l").set_value(2000.0)
+    at.number_input(key="twin_fish_count").set_value(60)
+    at.number_input(key="twin_fish_weight_g").set_value(200.0)
+    at.button[0].click()
+    at.run(timeout=60)
+
+    assert not at.exception
+    facts = brain._mem.get_facts(uid)
+    assert float(facts["tank_volume_l"]) == 2000.0
+    assert int(float(facts["fish_count"])) == 60
+
+
+def test_a_started_twin_shows_state_and_a_forecast_chart(tmp_path, monkeypatch):
+    _offline(monkeypatch)
+    brain = _brain(tmp_path)
+    _complete(brain)
+
+    at = _run(brain)
+
+    assert not at.exception
+    metrics = {m.label: m.value for m in at.metric}
+    assert "Fish" in metrics and "Water" in metrics
+    # st.line_chart surfaces as a vega-lite spec in AppTest
+    assert len(at.get("vega_lite_chart")) >= 2, "the forecast series are not charted"
+
+
+def test_logged_readings_appear_as_drift(tmp_path, monkeypatch):
+    _offline(monkeypatch)
+    brain = _brain(tmp_path)
+    _complete(brain)
+    brain.log_readings_direct("web", "u1", {"nitrate_mg_l": 40.0, "water_temp_c": 27.0})
+
+    at = _run(brain)
+
+    assert not at.exception
+    body = " ".join(str(m.value) for m in at.markdown) + " ".join(
+        str(getattr(d, "value", "")) for d in at.dataframe)
+    assert "nitrate" in body.lower() or len(at.dataframe) >= 1

--- a/agent/twin_ui.py
+++ b/agent/twin_ui.py
@@ -1,0 +1,218 @@
+"""Streamlit view of the LIVE twin — the same computation `/forecast` speaks as prose.
+
+No LLM is reached from this file. The twin is deterministic by design (that is the whole
+point of the command layer), so the dashboard reads `AgronautAgent.twin_snapshot()` and
+renders numbers. If a farmer's profile is not yet complete, this view offers the FORM that
+starts their twin — the bot's own gate used to answer with instructions addressed to a
+model ("call fetch_site_climate"), which no operator can act on.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import streamlit as st
+
+# The three numbers that separate "a design I sketched" from "the pond I actually run".
+_START_FIELDS = ("tank_volume_l", "fish_count", "fish_avg_weight_g")
+
+_SERIES_LABELS = {
+    "ammonia_mg_l": "ammonia (NH3/TAN)",
+    "nitrite_mg_l": "nitrite (NO2)",
+    "nitrate_mg_l": "nitrate (NO3)",
+    "water_temp_c": "water temperature",
+    "fish_avg_weight_g": "average fish weight",
+    "fish_count": "fish count",
+}
+
+
+def render_twin(brain=None, user: str | None = None, channel: str = "web") -> None:
+    """Render the My Twin tab. `brain` is an AgronautAgent; `user` the channel identity."""
+    st.subheader("My Twin")
+    st.caption(
+        "Your actual system, mirrored. Deterministic — the same model behind /log and "
+        "/forecast on Telegram, with no AI in the path."
+    )
+
+    if brain is None or user is None:
+        st.info("The twin needs a session. Reload the page.")
+        return
+
+    snap = brain.twin_snapshot(channel, user, days=7, greenhouse=_greenhouse())
+
+    if not snap.ready:
+        _render_start_form(brain, user, channel, snap)
+        return
+
+    _render_state(snap)
+    _render_forecast(snap)
+    _render_history(snap)
+    _render_log_form(brain, user, channel)
+
+
+def _greenhouse() -> str:
+    return st.sidebar.selectbox(
+        "Cover", ("shade", "poly", "heated"), index=0,
+        help="The envelope you actually run. It changes water temperature, and "
+             "temperature usually decides the harvest.",
+    )
+
+
+def _render_start_form(brain, user, channel, snap) -> None:
+    """The bootstrap. Everything here writes straight to the profile — no model involved."""
+    uid = brain._conv.get_or_create_user(channel, user)
+    facts = brain._mem.get_facts(uid) or {}
+    blocked = [m for m in snap.missing if not any(f in m for f in _START_FIELDS)]
+
+    st.info(
+        "Your twin hasn't started yet. Tell it what you're actually running and it will "
+        "begin mirroring today."
+    )
+
+    with st.form("twin_start"):
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            tank = st.number_input(
+                "Tank volume (L)", min_value=50.0, max_value=1_000_000.0,
+                value=float(facts.get("tank_volume_l") or 1000.0), step=100.0,
+                key="twin_tank_l")
+        with col2:
+            count = st.number_input(
+                "Number of fish", min_value=1, max_value=1_000_000,
+                value=int(float(facts.get("fish_count") or 50)), step=1,
+                key="twin_fish_count")
+        with col3:
+            weight = st.number_input(
+                "Average fish weight (g)", min_value=0.1, max_value=50_000.0,
+                value=float(facts.get("fish_avg_weight_g") or 100.0), step=10.0,
+                key="twin_fish_weight_g")
+        started = st.form_submit_button("Start my twin")
+
+    if started:
+        brain._mem.set_facts(uid, {"tank_volume_l": float(tank),
+                                   "fish_count": int(count),
+                                   "fish_avg_weight_g": float(weight)},
+                             source="user_stated")
+        st.success("Saved. Your twin starts from these numbers.")
+        _rerun()
+
+    if blocked:
+        st.warning(
+            "Still needed before the twin can run: " + ", ".join(blocked) +
+            ". The species, crop, growing area and site come from a design "
+            "conversation — set them in the Assistant tab, then come back."
+        )
+
+
+def _render_state(snap) -> None:
+    if snap.notes:
+        st.caption(" · ".join(snap.notes))
+    state = snap.state
+    biomass = state.fish.count * state.fish.mean_weight_g / 1000.0
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Fish", f"{state.fish.count} @ {state.fish.mean_weight_g:.0f} g")
+    c2.metric("Biomass", f"{biomass:.1f} kg")
+    c3.metric("Water", f"{state.water_temp_c:.1f} °C")
+    c4.metric("Nitrate", f"{state.nitrogen.no3_mg_l:.0f} mg/L")
+
+    c5, c6, c7 = st.columns(3)
+    c5.metric("Ammonia (TAN)", f"{state.nitrogen.tan_mg_l:.2f} mg/L")
+    c6.metric("Nitrite", f"{state.nitrogen.no2_mg_l:.2f} mg/L")
+    c7.metric("Harvested", f"{state.harvested_fish_kg:.1f} kg fish · "
+                           f"{state.harvested_crop_kg:.1f} kg crop")
+
+
+def _render_forecast(snap) -> None:
+    if snap.summary is None or not snap.trajectory:
+        st.info("No forecast available for this site right now.")
+        return
+    s = snap.summary
+    st.markdown(f"**Next {s.days} days** — most limiting: **{s.limiting_factor}**")
+
+    rows = []
+    for i, day in enumerate(snap.trajectory, start=1):
+        rows.append({
+            "day": i,
+            "ammonia (NH3/TAN)": day.state.nitrogen.tan_mg_l,
+            "nitrite (NO2)": day.state.nitrogen.no2_mg_l,
+            "nitrate (NO3)": day.state.nitrogen.no3_mg_l,
+            "water temperature": day.state.water_temp_c,
+        })
+    frame = pd.DataFrame(rows).set_index("day")
+
+    st.line_chart(frame[["ammonia (NH3/TAN)", "nitrite (NO2)", "nitrate (NO3)"]],
+                  height=240)
+    st.line_chart(frame[["water temperature"]], height=180)
+
+    c1, c2, c3 = st.columns(3)
+    c1.metric("Fish harvested", f"{s.fish_harvested_kg:.1f} kg",
+              help=f"{s.fish_standing_kg:.1f} kg still standing in the tank")
+    c2.metric("Crop harvested", f"{s.crop_harvested_kg:.1f} kg")
+    c3.metric("Feed used", f"{s.feed_used_kg:.1f} kg",
+              help=f"realized FCR {s.realized_fcr:.2f}")
+
+    for w in s.warnings or ():
+        st.warning(w)
+    if s.not_modelled:
+        with st.expander("What this model does NOT include"):
+            st.caption(s.not_modelled if isinstance(s.not_modelled, str)
+                       else "; ".join(s.not_modelled))
+    st.caption(
+        "A projection from a model calibrated on literature seeds, not on your system. "
+        "The relative comparisons are the useful part, not the absolute kilograms."
+    )
+
+
+def _render_history(snap) -> None:
+    """Logged readings against what the twin believed — the drift that makes it a twin."""
+    if not snap.history:
+        st.caption("No readings logged yet. Log one below and the twin starts learning "
+                   "how far off it is.")
+        return
+
+    st.markdown("**Your readings vs the twin**")
+    rows = []
+    for entry in snap.history:
+        obs, mod = entry["observed"], entry["modelled"]
+        for key, value in obs.items():
+            rows.append({
+                "when": entry["recorded_at"],
+                "reading": _SERIES_LABELS.get(key, key),
+                "you measured": value,
+                "twin thought": mod.get(key),
+                "drift": None if mod.get(key) is None else round(value - mod[key], 2),
+            })
+    st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
+
+
+def _render_log_form(brain, user, channel) -> None:
+    with st.expander("Log a reading"):
+        with st.form("twin_log"):
+            c1, c2, c3 = st.columns(3)
+            with c1:
+                ammonia = st.number_input("Ammonia (mg/L)", min_value=0.0, max_value=100.0,
+                                          value=0.0, step=0.1, key="log_ammonia")
+            with c2:
+                nitrite = st.number_input("Nitrite (mg/L)", min_value=0.0, max_value=100.0,
+                                          value=0.0, step=0.1, key="log_nitrite")
+            with c3:
+                nitrate = st.number_input("Nitrate (mg/L)", min_value=0.0, max_value=1000.0,
+                                          value=0.0, step=1.0, key="log_nitrate")
+            temp = st.number_input("Water temperature (°C)", min_value=0.0, max_value=60.0,
+                                   value=0.0, step=0.5, key="log_temp",
+                                   help="Leave at 0 for any reading you did not take.")
+            submitted = st.form_submit_button("Log it")
+
+        if submitted:
+            args = {k: v for k, v in (("ammonia_mg_l", ammonia), ("nitrite_mg_l", nitrite),
+                                      ("nitrate_mg_l", nitrate), ("water_temp_c", temp))
+                    if v}
+            if not args:
+                st.warning("Enter at least one reading.")
+                return
+            st.success(brain.log_readings_direct(channel, user, args))
+            _rerun()
+
+
+def _rerun() -> None:
+    if hasattr(st, "rerun"):
+        st.rerun()

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -16,8 +16,8 @@ from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, Tool
 from agent.llm import get_chat_model, get_llm, build_fallback_chat, ResilientChat
 from agent.vision import sanitize_observation
 from .tools import AGRONAUT_TOOLS
-from .store import _Db, ConversationStore, MemoryStore, FollowupStore, CommunityStore, CalibrationStore, _now
-from . import memory_extract, runtime, profile, semantic
+from .store import _Db, ConversationStore, MemoryStore, FollowupStore, CommunityStore, CalibrationStore, _now, ReadingStore
+from . import memory_extract, runtime, profile, semantic, twin_view
 
 log = logging.getLogger(__name__)
 
@@ -206,6 +206,7 @@ class AgronautAgent:
         self._followups = FollowupStore(db)
         self._community = CommunityStore(db)
         self._calibration = CalibrationStore(db)
+        self._readings = ReadingStore(db)
         # Semantic recall over memories — injectable for tests; lazily built for the real
         # path (model loads on first search). None -> recency fallback, the old behaviour.
         if embed_fn is None and chat_model is None:
@@ -474,7 +475,8 @@ class AgronautAgent:
         elif open_fu and open_fu["status"] == "pending":
             self._followups.cancel(open_fu["id"])
 
-        runtime.set_current(self._mem, user_id, self._followups, self._community, self._calibration)  # tools reach this user
+        runtime.set_current(self._mem, user_id, self._followups, self._community,
+                            self._calibration, self._readings)  # tools reach this user
         try:
             messages = self._build_context(user_id, query=text)
             if capture_note:
@@ -613,7 +615,7 @@ class AgronautAgent:
         user_id = self._conv.get_or_create_user(channel, channel_user)
         tool = {t.name: t for t in AGRONAUT_TOOLS}[tool_name]
         runtime.set_current(self._mem, user_id, self._followups, self._community,
-                            self._calibration)
+                            self._calibration, self._readings)
         try:
             result = tool.invoke(args)
         except Exception as exc:  # noqa: BLE001 — a command must answer, not stack-trace
@@ -634,6 +636,16 @@ class AgronautAgent:
         """Deterministic /forecast: the live twin, advanced and projected."""
         return self._run_tool_direct(channel, channel_user, "my_system_forecast",
                                      {"days_ahead": days, "greenhouse": greenhouse})
+
+    def twin_snapshot(self, channel: str, channel_user: str, days: int = 7,
+                      greenhouse: str = "poly"):
+        """The live twin as STRUCTURE, for a dashboard — no LLM, no prose.
+
+        Backs the same computation `/forecast` renders as words, so the two surfaces can
+        never disagree about the pond."""
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        return twin_view.compute(self._mem, user_id, days=days, greenhouse=greenhouse,
+                                 readings=self._readings)
 
     def reset(self, channel: str, channel_user: str) -> None:
         """Clear the conversation thread. Long-term memory (facts/memories) is kept."""
@@ -658,6 +670,7 @@ class AgronautAgent:
             "summary": self._mem.get_summary(user_id),
             "messages": self._conv.recent_messages(user_id, limit=100000),
             "measurements": self._calibration.export(user_id),
+            "twin_readings": self._readings.history(user_id),
             "exported_at": _now(),
         }
 
@@ -668,6 +681,7 @@ class AgronautAgent:
         self._conv.reset_conversation(user_id)
         self._mem.forget(user_id)
         self._calibration.purge(user_id)
+        self._readings.purge(user_id)
 
     # --- follow-up delivery API (called by a channel poller) ----------------
     def due_followups(self, channel: str) -> list:

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -187,18 +187,29 @@ _PROMISE = _re.compile(r"\b(i['’]ll|i will|let me|i am going to|i'm going to)\
 class AgronautAgent:
     def __init__(self, llm_provider=None, llm_model=None, db_path=None, chat_model=None,
                  fallback_model=None, embed_fn=None, describe_fn=None, transcribe_fn=None,
-                 classify_fn=None):
-        # chat_model injectable for tests (a fake bindable model); else build from config.
-        base = chat_model if chat_model is not None else get_chat_model(llm_provider, llm_model)
-        # Resilience: if the primary errors/times out, fall back to a fast model so a turn is
-        # never lost. Only auto-built for the real config path; injectable for tests.
-        fb = fallback_model
-        if fb is None and chat_model is None:
-            fb = build_fallback_chat(llm_provider, llm_model)
-        if fb is not None:
-            base = ResilientChat(base, fb)
-        self._base = base                       # unbound: used to force a final text answer
-        self._bound = base.bind_tools(AGRONAUT_TOOLS)
+                 classify_fn=None, require_tools: bool = True):
+        """`require_tools=False` builds an agent whose DETERMINISTIC surfaces work even when
+        no tool-calling provider is configured — the live twin (/log, /forecast, the twin
+        dashboard) reaches no model, so a missing NVIDIA_API_KEY must not deny an operator
+        their own system. Chat then reports `chat_error` instead of answering."""
+        self._chat_error: str | None = None
+        try:
+            # chat_model injectable for tests (a fake bindable model); else build from config.
+            base = chat_model if chat_model is not None else get_chat_model(llm_provider, llm_model)
+            # Resilience: if the primary errors/times out, fall back to a fast model so a turn is
+            # never lost. Only auto-built for the real config path; injectable for tests.
+            fb = fallback_model
+            if fb is None and chat_model is None:
+                fb = build_fallback_chat(llm_provider, llm_model)
+            if fb is not None:
+                base = ResilientChat(base, fb)
+            self._base = base                   # unbound: used to force a final text answer
+            self._bound = base.bind_tools(AGRONAUT_TOOLS)
+        except Exception as exc:  # noqa: BLE001 — surfaced as chat_error, or re-raised
+            if require_tools:
+                raise
+            self._base = self._bound = None
+            self._chat_error = str(exc)
         self._tools_by_name = {t.name: t for t in AGRONAUT_TOOLS}
         db = _Db(db_path)
         self._conv = ConversationStore(db)
@@ -454,6 +465,10 @@ class AgronautAgent:
         every later turn. Image turns therefore pass their caption (the only part the user
         actually wrote); voice turns pass nothing, because a transcript IS the user's words.
         """
+        if self._bound is None:
+            return ("I can't hold a conversation right now — no tool-calling model is "
+                    f"configured ({self._chat_error}). Your live twin still works: "
+                    "/log and /forecast never touch a model.")
         user_id = self._conv.get_or_create_user(channel, channel_user, display_name)
         self._analytics.record("message", user_id=user_id, channel=channel)
         source_text = text if fact_text is None else fact_text
@@ -636,6 +651,12 @@ class AgronautAgent:
         """Deterministic /forecast: the live twin, advanced and projected."""
         return self._run_tool_direct(channel, channel_user, "my_system_forecast",
                                      {"days_ahead": days, "greenhouse": greenhouse})
+
+    @property
+    def chat_error(self) -> str | None:
+        """Why chat is unavailable, or None when a tool-calling model is bound. The
+        deterministic twin surfaces work either way."""
+        return self._chat_error
 
     def twin_snapshot(self, channel: str, channel_user: str, days: int = 7,
                       greenhouse: str = "poly"):

--- a/agronaut_agent/runtime.py
+++ b/agronaut_agent/runtime.py
@@ -13,14 +13,17 @@ _current = contextvars.ContextVar("agronaut_current", default=None)
 _followups = contextvars.ContextVar("agronaut_followups", default=None)
 _community = contextvars.ContextVar("agronaut_community", default=None)
 _calibration = contextvars.ContextVar("agronaut_calibration", default=None)
+_readings = contextvars.ContextVar("agronaut_readings", default=None)
 _attachments = contextvars.ContextVar("agronaut_attachments", default=None)
 
 
-def set_current(memory_store, user_id: str, followups=None, community=None, calibration=None) -> None:
+def set_current(memory_store, user_id: str, followups=None, community=None,
+                calibration=None, readings=None) -> None:
     _current.set((memory_store, user_id))
     _followups.set(followups)
     _community.set(community)
     _calibration.set(calibration)
+    _readings.set(readings)
     _attachments.set([])   # fresh per-turn sink for files a tool wants to send back
 
 
@@ -29,6 +32,7 @@ def clear_current() -> None:
     _followups.set(None)
     _community.set(None)
     _calibration.set(None)
+    _readings.set(None)
     _attachments.set(None)
 
 
@@ -62,3 +66,8 @@ def get_community():
 def get_calibration():
     """Return the CalibrationStore for the in-flight message, or None if unset."""
     return _calibration.get()
+
+
+def get_readings():
+    """Return the ReadingStore for the in-flight message, or None if unset."""
+    return _readings.get()

--- a/agronaut_agent/store.py
+++ b/agronaut_agent/store.py
@@ -10,6 +10,7 @@ single-process event loop safe. Stdlib only — no ORM, no heavy deps.
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import threading
@@ -114,6 +115,19 @@ CREATE TABLE IF NOT EXISTS measurements (
     recorded_at TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_measurements_user ON measurements(user_id, coefficient);
+-- Append-only history of readings a user logged into their LIVE twin, paired with what
+-- the twin predicted at that moment. The twin state itself keeps only "today" (each /log
+-- overwrites the snapshot), so without this the drift report is computed, spoken once and
+-- lost — and "is the model getting closer to MY pond?" becomes unanswerable.
+CREATE TABLE IF NOT EXISTS twin_readings (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     TEXT NOT NULL,
+    recorded_at TEXT NOT NULL,
+    greenhouse  TEXT NOT NULL,
+    observed    TEXT NOT NULL,
+    modelled    TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_twin_readings_user ON twin_readings(user_id, id);
 """
 
 
@@ -469,3 +483,44 @@ class CalibrationStore:
                 "in_range": in_range,
             })
         return report
+
+
+class ReadingStore:
+    """Append-only log of what the farmer measured vs what the twin thought at the time.
+
+    The live twin is a single overwritten snapshot by design — it models TODAY. This table
+    is the memory that snapshot cannot keep: every logged reading with the model's value
+    beside it, so drift can be charted over weeks instead of narrated once and forgotten.
+    """
+
+    def __init__(self, db: _Db | None = None, path=None):
+        self.db = db or _Db(path)
+
+    def record(self, user_id: str, observed: dict, modelled: dict,
+               greenhouse: str = "poly", recorded_at: str | None = None) -> None:
+        """Store one logged reading. `observed` is what the user measured, `modelled` what
+        the twin held for those same fields — keys absent from either are simply absent."""
+        self.db.execute(
+            "INSERT INTO twin_readings(user_id, recorded_at, greenhouse, observed, modelled)"
+            " VALUES (?,?,?,?,?)",
+            (user_id, recorded_at or _now(), str(greenhouse),
+             json.dumps(_clean_readings(observed)), json.dumps(_clean_readings(modelled))),
+        )
+
+    def history(self, user_id: str) -> list[dict]:
+        """Every reading for this user, oldest first."""
+        rows = self.db.query(
+            "SELECT recorded_at, greenhouse, observed, modelled FROM twin_readings"
+            " WHERE user_id=? ORDER BY id", (user_id,))
+        return [{"recorded_at": r["recorded_at"], "greenhouse": r["greenhouse"],
+                 "observed": json.loads(r["observed"]), "modelled": json.loads(r["modelled"])}
+                for r in rows]
+
+    def purge(self, user_id: str) -> None:
+        self.db.execute("DELETE FROM twin_readings WHERE user_id=?", (user_id,))
+
+
+def _clean_readings(d: dict | None) -> dict:
+    """Drop unset fields and coerce to plain floats — the caller passes a dict with None
+    for every reading the user did not take."""
+    return {k: float(v) for k, v in (d or {}).items() if v is not None}

--- a/agronaut_agent/tests/test_store.py
+++ b/agronaut_agent/tests/test_store.py
@@ -239,3 +239,49 @@ def test_calibration_report_reflects_status():
     assert rep["tilapia.fcr"]["n"] == 2
     assert rep["tilapia.fcr"]["applied"] is True
     assert rep["tilapia.fcr"]["mean"] == 1.5
+
+
+# --- twin reading history -------------------------------------------------
+# The live twin keeps only "today": each /log overwrites the snapshot and the drift
+# report is printed, then discarded. These readings are what makes the twin auditable
+# over time — "was the model getting closer?" — so they are stored append-only.
+
+from agronaut_agent.store import ReadingStore
+
+
+@pytest.fixture
+def readings():
+    return ReadingStore(_Db(":memory:"))
+
+
+def test_readings_round_trip_in_order(readings):
+    readings.record("telegram:1", {"nitrate_mg_l": 40.0}, {"nitrate_mg_l": 12.0},
+                    greenhouse="shade", recorded_at="2026-08-20")
+    readings.record("telegram:1", {"nitrate_mg_l": 38.0}, {"nitrate_mg_l": 31.0},
+                    greenhouse="shade", recorded_at="2026-08-27")
+
+    hist = readings.history("telegram:1")
+
+    assert [h["recorded_at"] for h in hist] == ["2026-08-20", "2026-08-27"]
+    assert hist[0]["observed"]["nitrate_mg_l"] == 40.0
+    assert hist[0]["modelled"]["nitrate_mg_l"] == 12.0
+    assert hist[1]["greenhouse"] == "shade"
+
+
+def test_readings_are_scoped_per_user(readings):
+    readings.record("telegram:1", {"water_temp_c": 27.0}, {"water_temp_c": 25.0})
+    readings.record("telegram:2", {"water_temp_c": 19.0}, {"water_temp_c": 20.0})
+
+    assert len(readings.history("telegram:1")) == 1
+    assert readings.history("telegram:1")[0]["observed"]["water_temp_c"] == 27.0
+    assert readings.history("nobody")== []
+
+
+def test_readings_purge_is_user_scoped(readings):
+    readings.record("telegram:1", {"water_temp_c": 27.0}, {"water_temp_c": 25.0})
+    readings.record("telegram:2", {"water_temp_c": 19.0}, {"water_temp_c": 20.0})
+
+    readings.purge("telegram:1")
+
+    assert readings.history("telegram:1") == []
+    assert len(readings.history("telegram:2")) == 1

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -592,3 +592,73 @@ def test_direct_tool_path_needs_no_llm(tmp_path):
     b = AgronautAgent(db_path=str(tmp_path / "f.sqlite3"), chat_model=_DeadModel())
     reply = b.log_readings_direct("telegram", "42", {"ammonia_mg_l": 0.5})
     assert "live twin needs" in reply.lower() or "logged" in reply.lower()
+
+
+def _twin_profile(mem, uid):
+    """A complete live-twin profile, sited so the mirror has coordinates."""
+    mem.set_facts(uid, {
+        "fish_species": "tilapia", "crop": "basil", "grow_area_m2": 15,
+        "tank_volume_l": 2000, "fish_count": 60, "fish_avg_weight_g": 200,
+        "climate_site": "taichung_2025", "site_lat": 24.15, "site_lon": 120.68},
+        source="user_stated")
+
+
+def _offline_weather(monkeypatch):
+    """Stub the one network boundary the mirror crosses (Open-Meteo), so twin tests are
+    deterministic. Everything downstream — the model, the nudge, the drift — stays real."""
+    from datetime import date, timedelta
+
+    from aqua_model.climate import DailyClimate
+    from agronaut_agent import tools as T
+
+    def fake(lat, lon, past_days, forecast_days):
+        n = min(92, max(0, past_days)) + min(16, max(1, forecast_days))
+        start = date.today() - timedelta(days=min(92, max(0, past_days)))
+        dates = [(start + timedelta(days=i)).isoformat() for i in range(n)]
+        days = tuple(DailyClimate(t_mean_c=26.0, t_min_c=22.0, t_max_c=30.0,
+                                  solar_mj_m2=18.0) for _ in range(n))
+        return dates, days
+
+    monkeypatch.setattr(T, "_live_weather", fake)
+
+
+def test_logging_a_reading_persists_it_beside_the_models_value(monkeypatch):
+    """The drift report is the twin's whole claim to being a twin. Speaking it once and
+    dropping it makes "is the model getting closer to MY pond?" unanswerable."""
+    from agronaut_agent.store import _Db, MemoryStore, ReadingStore
+    from agronaut_agent import runtime
+    from agronaut_agent.tools import log_my_readings
+
+    _offline_weather(monkeypatch)
+    db = _Db(":memory:")
+    mem, readings = MemoryStore(db), ReadingStore(db)
+    runtime.set_current(mem, "cli:t", readings=readings)
+    try:
+        _twin_profile(mem, "cli:t")
+        log_my_readings.func(nitrate_mg_l=40.0, water_temp_c=27.0, greenhouse="shade")
+    finally:
+        runtime.clear_current()
+
+    hist = readings.history("cli:t")
+    assert len(hist) == 1, "the logged reading was not persisted"
+    assert hist[0]["observed"] == {"nitrate_mg_l": 40.0, "water_temp_c": 27.0}
+    assert "nitrate_mg_l" in hist[0]["modelled"], "the model's own value was not kept"
+    assert hist[0]["greenhouse"] == "shade"
+
+
+def test_logging_without_a_reading_store_still_works(monkeypatch):
+    """Telegram and the CLI construct the agent differently; a missing store must not
+    turn a farmer's log into a traceback."""
+    from agronaut_agent.store import _Db, MemoryStore
+    from agronaut_agent import runtime
+    from agronaut_agent.tools import log_my_readings
+
+    _offline_weather(monkeypatch)
+    mem = MemoryStore(_Db(":memory:"))
+    runtime.set_current(mem, "cli:t")
+    try:
+        _twin_profile(mem, "cli:t")
+        text = log_my_readings.func(nitrate_mg_l=40.0)
+    finally:
+        runtime.clear_current()
+    assert "Logged." in text

--- a/agronaut_agent/tests/test_twin_dashboard.py
+++ b/agronaut_agent/tests/test_twin_dashboard.py
@@ -1,0 +1,103 @@
+"""The structured seam behind the twin dashboard.
+
+/log and /forecast return prose for Telegram. A dashboard needs the numbers that prose
+was rendered FROM — and the two must never disagree, so both are computed once here.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from aqua_model.climate import DailyClimate
+from agronaut_agent import runtime, tools as T
+from agronaut_agent.core import AgronautAgent
+from agronaut_agent.store import _Db, MemoryStore, ReadingStore
+
+
+@pytest.fixture
+def offline_weather(monkeypatch):
+    def fake(lat, lon, past_days, forecast_days):
+        n = min(92, max(0, past_days)) + min(16, max(1, forecast_days))
+        start = date.today() - timedelta(days=min(92, max(0, past_days)))
+        dates = [(start + timedelta(days=i)).isoformat() for i in range(n)]
+        days = tuple(DailyClimate(t_mean_c=26.0, t_min_c=22.0, t_max_c=30.0,
+                                  solar_mj_m2=18.0) for _ in range(n))
+        return dates, days
+    monkeypatch.setattr(T, "_live_weather", fake)
+
+
+@pytest.fixture
+def brain(tmp_path):
+    """A real agent with no LLM — the twin path never calls one."""
+    return AgronautAgent(db_path=tmp_path / "t.sqlite3", chat_model=_NoLLM())
+
+
+class _NoLLM:
+    def bind_tools(self, tools):
+        return self
+    def invoke(self, *a, **k):
+        raise AssertionError("the twin path must never call an LLM")
+
+
+def _profile(brain, channel="telegram", user="1"):
+    uid = brain._conv.get_or_create_user(channel, user)
+    brain._mem.set_facts(uid, {
+        "fish_species": "tilapia", "crop": "basil", "grow_area_m2": 15,
+        "tank_volume_l": 2000, "fish_count": 60, "fish_avg_weight_g": 200,
+        "climate_site": "taichung_2025", "site_lat": 24.15, "site_lon": 120.68},
+        source="user_stated")
+    return uid
+
+
+def test_twin_snapshot_returns_numbers_not_prose(brain, offline_weather):
+    _profile(brain)
+
+    snap = brain.twin_snapshot("telegram", "1", days=7, greenhouse="shade")
+
+    assert snap.ready is True
+    assert snap.state.fish.count == 60
+    assert len(snap.trajectory) >= 2, "a chartable per-day series"
+    assert snap.summary.days == len(snap.trajectory)
+    assert snap.summary.limiting_factor
+
+
+def test_twin_snapshot_reports_what_is_missing_instead_of_raising(brain, offline_weather):
+    """An incomplete profile is the normal first-run state, not an error."""
+    snap = brain.twin_snapshot("telegram", "nobody", days=7)
+
+    assert snap.ready is False
+    assert "tank_volume_l" in snap.missing
+    assert snap.state is None
+
+
+def test_dashboard_and_telegram_agree_on_the_numbers(brain, offline_weather):
+    """The prose /forecast and the dashboard must be one computation, not two. If these
+    ever diverge, the farmer is reading two different twins."""
+    _profile(brain)
+
+    snap = brain.twin_snapshot("telegram", "1", days=7, greenhouse="shade")
+    text = brain.forecast_direct("telegram", "1", 7, "shade")
+
+    assert f"{snap.summary.crop_harvested_kg:.1f} kg" in text
+    assert snap.summary.limiting_factor in text
+
+
+def test_logged_readings_reach_the_snapshot_history(brain, offline_weather):
+    _profile(brain)
+
+    brain.log_readings_direct("telegram", "1", {"nitrate_mg_l": 40.0, "water_temp_c": 27.0})
+    snap = brain.twin_snapshot("telegram", "1", days=7)
+
+    assert len(snap.history) == 1
+    assert snap.history[0]["observed"]["nitrate_mg_l"] == 40.0
+
+
+def test_twin_readings_are_exported_and_erasable(brain, offline_weather):
+    """DPG data rights: anything we store about a user is exportable and erasable."""
+    _profile(brain)
+    brain.log_readings_direct("telegram", "1", {"nitrate_mg_l": 40.0})
+
+    assert len(brain.export_user_data("telegram", "1")["twin_readings"]) == 1
+
+    brain.delete_me("telegram", "1")
+    assert brain.export_user_data("telegram", "1")["twin_readings"] == []

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -27,7 +27,7 @@ from aqua_model.species import SPECIES, get_species
 from aqua_model.crops import CROPS
 from aqua_model import datasets, report
 
-from . import profile as profile_mod, rag, runtime, serialize
+from . import profile as profile_mod, rag, runtime, serialize, twin_view
 
 log = logging.getLogger(__name__)
 
@@ -1184,6 +1184,47 @@ def _advance_mirror(mem, user_id, facts: dict, forecast_days: int = 1,
     return stored, fc_run, notes
 
 
+_READING_TO_STATE = {
+    "water_temp_c": lambda st: st.water_temp_c,
+    "ammonia_mg_l": lambda st: st.nitrogen.tan_mg_l,
+    "nitrite_mg_l": lambda st: st.nitrogen.no2_mg_l,
+    "nitrate_mg_l": lambda st: st.nitrogen.no3_mg_l,
+    "fish_avg_weight_g": lambda st: st.fish.mean_weight_g,
+    "fish_count": lambda st: float(st.fish.count),
+}
+
+
+def _modelled_for(state, observed: dict) -> dict:
+    """What the twin held for exactly the fields the user measured — the other half of the
+    drift report, captured BEFORE the nudge pulls the state toward the reading."""
+    out = {}
+    for key, value in observed.items():
+        if value is None:
+            continue
+        read = _READING_TO_STATE.get(key)
+        if read is None:
+            continue
+        try:
+            out[key] = float(read(state))
+        except (AttributeError, TypeError, ValueError):
+            continue
+    return out
+
+
+def _record_reading(user_id: str, observed: dict, modelled: dict, greenhouse: str) -> None:
+    """Append the reading to the twin's history. Best-effort: a farmer's log must never
+    fail because history storage is unavailable (the CLI wires no ReadingStore)."""
+    store = runtime.get_readings()
+    if store is None:
+        return
+    from datetime import date
+    try:
+        store.record(user_id, observed, modelled, greenhouse=greenhouse,
+                     recorded_at=date.today().isoformat())
+    except Exception:  # noqa: BLE001 — history is an extra, never the farmer's problem
+        log.warning("could not persist twin reading", exc_info=True)
+
+
 @tool
 def log_my_readings(
     greenhouse: str = "poly",
@@ -1218,12 +1259,17 @@ def log_my_readings(
         state, _fc, notes = _advance_mirror(mem, user_id, facts, greenhouse=greenhouse)
     except Exception as err:  # noqa: BLE001 — a weather hiccup must become words
         return f"Could not advance the twin ({err}) — try again shortly."
+    observed = {"water_temp_c": water_temp_c, "ammonia_mg_l": ammonia_mg_l,
+                "nitrite_mg_l": nitrite_mg_l, "nitrate_mg_l": nitrate_mg_l,
+                "fish_avg_weight_g": fish_avg_weight_g, "fish_count": fish_count}
+    modelled = _modelled_for(state, observed)
     state, innovation = mirror.nudge(state, {
         "water_temp_c": water_temp_c, "tan_mg_l": ammonia_mg_l,
         "no2_mg_l": nitrite_mg_l, "no3_mg_l": nitrate_mg_l,
         "fish_avg_weight_g": fish_avg_weight_g, "fish_count": fish_count})
     from datetime import date
     _save_mirror(mem, user_id, state, date.today().isoformat())
+    _record_reading(user_id, observed, modelled, greenhouse)
     if fish_count is not None or fish_avg_weight_g is not None:
         upd = {}
         if fish_count is not None:
@@ -1236,6 +1282,25 @@ def log_my_readings(
             + "\nNow: " + mirror.snapshot_line(state))
 
 
+def render(snap) -> str:
+    """Format a TwinSnapshot as the Telegram/CLI reply. The dashboard reads the same
+    snapshot object instead — one computation, two renderings."""
+    from aqua_model import mirror
+    from aqua_model.production import ProductionRun, format_summary
+
+    if not snap.ready:
+        return ("The live twin needs: " + ", ".join(snap.missing) +
+                ". Ask, save with update_profile (and fetch_site_climate), then call again.")
+    out = ["LIVE twin — " + " ".join(snap.notes) if snap.notes else "LIVE twin",
+           "Now: " + mirror.snapshot_line(snap.state)]
+    if snap.summary is not None:
+        out.append("")
+        out.append(format_summary(ProductionRun(trajectory=snap.trajectory,
+                                                summary=snap.summary),
+                                  site_label=f"next {snap.summary.days} days (forecast)"))
+    return "\n".join(out)
+
+
 @tool
 def my_system_forecast(days_ahead: int = 7, greenhouse: str = "poly") -> str:
     """The LIVE twin's answer to "how is my system doing, and what happens next?" —
@@ -1246,30 +1311,15 @@ def my_system_forecast(days_ahead: int = 7, greenhouse: str = "poly") -> str:
     this heatwave do", "check my system". The state persists between conversations —
     logged readings (log_my_readings) keep it honest.
     greenhouse: the envelope they actually run — 'poly', 'shade', or 'heated'."""
-    from aqua_model import mirror
-    from aqua_model.production import format_summary
-
     cur = runtime.get_current()
     if cur is None:
         return "No session — cannot keep a live twin here."
     mem, user_id = cur
-    facts = mem.get_facts(user_id) or {}
-    missing = _mirror_context(facts)
-    if missing:
-        return ("The live twin needs: " + ", ".join(missing) +
-                ". Ask, save with update_profile (and fetch_site_climate), then call again.")
     try:
-        state, fc_run, notes = _advance_mirror(mem, user_id, facts, greenhouse=greenhouse,
-                                               forecast_days=max(2, min(int(days_ahead), 15)))
+        snap = twin_view.compute(mem, user_id, days=days_ahead, greenhouse=greenhouse)
     except Exception as err:  # noqa: BLE001
         return f"Could not advance the twin ({err}) — try again shortly."
-    out = ["LIVE twin — " + " ".join(notes) if notes else "LIVE twin",
-           "Now: " + mirror.snapshot_line(state)]
-    if fc_run is not None:
-        out.append("")
-        out.append(format_summary(fc_run,
-                                  site_label=f"next {fc_run.summary.days} days (forecast)"))
-    return "\n".join(out)
+    return render(snap)
 
 
 @tool

--- a/agronaut_agent/twin_view.py
+++ b/agronaut_agent/twin_view.py
@@ -1,0 +1,52 @@
+"""One computation behind both the Telegram prose and the dashboard.
+
+`/forecast` renders words; the dashboard renders charts. They must never be two
+computations — a farmer reading a chart and a farmer reading the bot are looking at the
+same pond. Everything either surface needs is produced here once, structured, and
+formatted downstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TwinSnapshot:
+    """The live twin as numbers. `ready` is False for the normal first-run state where the
+    profile is still incomplete — `missing` then names exactly what to collect."""
+
+    ready: bool
+    missing: list[str] = field(default_factory=list)
+    state: object | None = None            # ProductionState as of today
+    trajectory: list = field(default_factory=list)   # list[ProductionDay], the forecast
+    summary: object | None = None          # ProductionSummary over the forecast
+    notes: list[str] = field(default_factory=list)
+    history: list[dict] = field(default_factory=list)  # past logged readings vs model
+
+
+def compute(mem, user_id: str, days: int = 7, greenhouse: str = "poly",
+            readings=None) -> TwinSnapshot:
+    """Advance the stored twin to today and project forward, returning structure.
+
+    Raises nothing for an incomplete profile — that is a state, not an error.
+    """
+    from agronaut_agent import tools as T
+
+    facts = mem.get_facts(user_id) or {}
+    missing = T._mirror_context(facts)
+    if missing:
+        return TwinSnapshot(ready=False, missing=list(missing))
+
+    state, fc_run, notes = T._advance_mirror(
+        mem, user_id, facts, greenhouse=greenhouse,
+        forecast_days=max(2, min(int(days), 15)))
+
+    return TwinSnapshot(
+        ready=True,
+        state=state,
+        trajectory=list(fc_run.trajectory) if fc_run is not None else [],
+        summary=fc_run.summary if fc_run is not None else None,
+        notes=list(notes),
+        history=readings.history(user_id) if readings is not None else [],
+    )

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ import streamlit as st
 
 from agent.calculator_ui import render_calculator
 from agent.optimizer_ui import render_optimizer
+from agent.twin_ui import render_twin
 
 
 APP_TITLE = "🌱 Agronaut"
@@ -160,9 +161,10 @@ def main() -> None:
     # on a fresh install. Chat needs the agent stack + a tool-calling LLM provider.
     mode = st.sidebar.radio(
         "Mode",
-        ("Design Calculator", "Optimize Ratio", "Assistant (chat)"),
+        ("Design Calculator", "Optimize Ratio", "My Twin", "Assistant (chat)"),
         help="Calculator sizes one system. Optimizer finds the best fish/crop ratio for "
-             "your constraint. Chat runs a consultation with the full agent (needs an LLM).",
+             "your constraint. My Twin mirrors the system you actually run (deterministic, "
+             "no LLM). Chat runs a consultation with the full agent (needs an LLM).",
     )
 
     if mode == "Design Calculator":
@@ -170,6 +172,16 @@ def main() -> None:
         return
     if mode == "Optimize Ratio":
         render_optimizer()
+        return
+
+    # My Twin is deterministic — it must render even when no LLM is configured, because
+    # surviving model weather is the entire promise of the twin's command layer.
+    if mode == "My Twin":
+        reason = _agent_error()
+        if reason and "agent" not in st.session_state:
+            st.warning(reason)
+            return
+        render_twin(brain=st.session_state.agent, user=_web_user())
         return
 
     # Assistant (chat) — the real consultative agent, degrading gracefully when the

--- a/app.py
+++ b/app.py
@@ -36,7 +36,17 @@ def _agent_error() -> str | None:
         return st.session_state.agent_error
     try:
         from agronaut_agent.core import AgronautAgent
-        st.session_state.agent = AgronautAgent()
+        # require_tools=False: the agent still carries the stores and the deterministic
+        # twin when no tool-calling provider exists, so My Twin survives a missing key.
+        agent = AgronautAgent(require_tools=False)
+        st.session_state.agent = agent
+        if agent.chat_error:
+            reason = ("Chat needs a tool-calling LLM provider (e.g. `LLM_PROVIDER=nvidia` "
+                      f"with `NVIDIA_API_KEY`) — couldn't start one: {agent.chat_error}. "
+                      "**My Twin**, **Design Calculator** and **Optimize Ratio** are fully "
+                      "deterministic and keep working.")
+            st.session_state.agent_error = reason
+            return reason
         return None
     except ModuleNotFoundError as exc:
         reason = (f"Chat mode needs the optional chat stack (`{exc.name}` isn't installed). "
@@ -178,8 +188,8 @@ def main() -> None:
     # surviving model weather is the entire promise of the twin's command layer.
     if mode == "My Twin":
         reason = _agent_error()
-        if reason and "agent" not in st.session_state:
-            st.warning(reason)
+        if "agent" not in st.session_state:
+            st.warning(reason or "The twin is unavailable in this install.")
             return
         render_twin(brain=st.session_state.agent, user=_web_user())
         return


### PR DESCRIPTION
## What this changes

The live twin shipped in #97-99 as text over Telegram. It was already computing a rich per-day trajectory and a drift report, then flattening both to prose and dropping the rest. Three things followed from that, and this PR fixes all three.

**The numbers had nowhere to go.** `twin_view.compute()` now returns the twin as structure — today's state, the per-day trajectory, the summary, the reading history. `tools.render()` formats that for Telegram; the new dashboard reads the same object. One computation, two renderings, with a test asserting they agree: if they ever drift, a farmer reading the chart and a farmer reading the bot are looking at two different ponds.

**The twin could not remember being wrong.** `log_my_readings` measured how far the model was off, said so once, and discarded it — twin state is a single overwritten snapshot by design, so *"is the model getting closer to MY pond?"* was unanswerable. A new append-only `twin_readings` table stores each reading beside the value the twin held at that moment, captured **before** the nudge pulls state toward the observation. Written where `/log` already runs, so Telegram and the dashboard populate one history.

**The profile gate spoke to a robot.** It answered `"call fetch_site_climate ... save with update_profile"` — instructions addressed to a model, which no operator can act on, and which stranded anyone whose model declined to call the tool. On the current NVIDIA free tier that is not hypothetical: a validation run this week missed `update_profile` and `log_my_readings`, 2 of 6 flows. The tab now offers the three numbers as a form writing the profile directly, so the twin can be started with **no LLM in the path at all**.

## How it was verified

```
938 passed, 2 skipped in 104.97s
Advice-safety golden set: 373/373 passed (score 1.000)
  honesty 331/331 · sizing 4/4 · trust_gate 6/6 · vision_guard 23/23 · visual_triage 9/9
```

- [x] `pytest` is green — 938 passed, 2 skipped
- [x] `python -m scripts.safety_eval` exits 0 — 373/373
- [x] New behaviour has a test that would have failed before this change

11 new tests, written first and watched fail. Two are worth naming:

- `test_dashboard_and_telegram_agree_on_the_numbers` — the anti-divergence guard on the shared seam.
- `test_the_form_starts_the_twin_without_an_llm` — the UI suite injects a chat model that **raises** if anything calls it, so the no-LLM claim is checked rather than asserted.

Twin tests stub exactly one thing, `_live_weather` (the Open-Meteo call), leaving the model, the nudge and the drift computation real.

Data rights: `twin_readings` is exported by `export_user_data` and erased by `delete_me`, with a test covering both.

## What this does NOT do

- **No calibration feedback.** Accumulated drift is stored and charted but does not yet refit per-user coefficients. That touches the calibration path and deserves its own PR and validation.
- **No `aqua_model/` changes.** The trust zone is untouched, hence no trust-zone checklist above — this is all `agronaut_agent/`, `agent/`, `app.py`.
- **No screenshot in this PR.** Chromium will not sandbox on the dev machine (Ubuntu AppArmor blocks unprivileged user namespaces), so verification is Streamlit `AppTest` driving the real app plus a clean HTTP 200, not pixels.
- **History starts now.** Nothing backfills readings logged before this lands; there were none to backfill (`measurements` was empty and readings were never stored).
- **The forecast is still a projection** from a model calibrated on literature seeds, not on your system. The dashboard carries that honesty line and the not-modelled list through verbatim rather than burying them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtS7eo1dwY9f3h3RQEfgEw
