### PR TITLE
feat(rag): close the course gaps, and find that two constants had already expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ Parametric, not machine-learned — buildable today from published equations:
 ## The advice layer (retrieval), and how it was tuned
 
 Sizing is computed. Troubleshooting advice is *retrieved*, from a corpus of 22 hand-written
-operator guides plus openly licensed publications — currently **1354 chunks**, led by FAO 589.
+operator guides plus openly licensed publications — currently **CHUNKS_TBD chunks**, led by
+Goddek et al. (2019) and FAO 589.
 
 Retrieval is measured, not assumed. `docs/dpg/retrieval_eval/golden_set.json` holds queries in
 real operator voice ("my tilapia are gasping at the surface", not "dissolved oxygen") plus
@@ -160,20 +161,57 @@ off-topic controls that must be **refused**:
 
 ```bash
 python -m scripts.retrieval_eval     # recall@k, precision@k, MRR, MAP@k + floor separation
+python -m scripts.retrieval_sweep --all   # re-pick floor / per-source cap / hybrid β
 python -m scripts.corpus_report      # what each declared source actually contributes
 ```
 
-Eight techniques were implemented and measured. **Four ship; four lose** — and the losses are
-recorded in `docs/dpg/retrieval_eval/techniques.json` with the conditions that would reverse them,
-which is how hybrid search went from rejected to shipped when the corpus grew:
+Nine techniques were implemented and measured. **Four ship, four lose, one is available but
+unused** — and the losses are recorded in `docs/dpg/retrieval_eval/techniques.json` with the
+conditions that would reverse them, which is how hybrid search went from rejected to shipped when
+the corpus grew:
 
 | | ships | why |
 |---|---|---|
-| Relevance floor | **on** | refuses 8/10 off-topic queries, silences 0/33 real ones |
-| Hybrid BM25 + RRF | **on** (β=0.90) | lost at 362 chunks, won at 1354: recall/MAP +0.091 |
-| Per-source cap | **on** (2) | one 992-chunk book was taking all 3 slots on 10 of 33 queries |
+| Relevance floor | **on** (1.50) | refuses 8/10 off-topic queries, silences 0/33 real ones, keeps 0.117 headroom |
+| Hybrid BM25 + RRF | **on** (β=0.90) | lost at 362 chunks, won at 1354, re-confirmed at 3935 |
+| Per-source cap | **on** (1) | two books now hold 98% of the corpus; at cap=2 they take 2 of 3 slots |
 | PDF cleaning | **on** | drops contents pages; running header removed from 111 chunks → 4 |
+| Metadata filtering | available, off | the third leg of hybrid search. Filters `source_type`, `kb_tag`, `chapter`, `page`, `url_category` on **both** pools before fusion. A capability, not a ranking change — no golden-set number moves, and none is claimed |
 | Header chunking · context prefix · PDF chapter labels · cross-encoder rerank | off | each measured *worse* on this corpus |
+
+**Current: hit 0.879 · recall 0.833 · MAP 0.624 · 8/10 off-topic refused · 0/33 real silenced.**
+
+### A decision expiring, caught in the act
+
+`techniques.json` was written 2026-08-25. The next day, commit `70b2d00` added a second book and
+took the corpus from 1354 to 3935 chunks. Nothing was re-measured, and every constant silently
+became wrong for the corpus that actually shipped:
+
+| | at 1354 (recorded) | at 3935 (untouched) | at 3935 (re-tuned) |
+|---|---|---|---|
+| hit_rate | 0.939 | 0.848 | **0.879** |
+| recall@k | 0.894 | 0.758 | **0.833** |
+| MAP@k | 0.697 | 0.578 | **0.624** |
+| off-topic refused | 8/10 | 4/10 | **8/10** |
+
+Two constants moved, one did not. The **floor** tightened 1.65 → 1.50, because the distance bands
+*separated* as the corpus grew (on-topic worst 1.383, closest off-topic 1.411, where at 1354
+chunks they overlapped and no floor could work). The **cap** tightened 2 → 1, because cap=2 was
+calibrated against *one* oversized source and there are now two. **β stayed at 0.90** — it
+describes the relationship between two ranking signals, which is a property of the query language,
+not of how much text sits behind it.
+
+The floor was *not* tightened to 1.40, though that refuses all 10 controls: it clears the worst
+real query by 0.017, and this project had already rejected a 0.032 margin as too thin. 33 golden
+queries say nothing about the 34th; headroom is the only thing that does.
+
+```bash
+python -m scripts.retrieval_sweep --all      # re-pick all three, with the evidence table
+```
+
+That command exists because the drift was not carelessness. Re-measuring three constants was an
+afternoon of ad-hoc scripting, so it did not happen. Now it is one command — run it after any
+corpus or embedding-model change.
 
 Three of the four failures share one mechanism: they add topic words to chunks in a corpus where
 every document already shares a vocabulary domain, which dilutes rather than disambiguates. What
@@ -191,6 +229,63 @@ python -m scripts.corpus_report --candidate "<url>" --label "<expected topic>"
 It checks four things, because a source can fail in four ways: unreachable, empty, **wrong
 subject** (a guessed publication ID once resolved to *"Sharks for the Aquarium"* — 28k characters
 that pass every check except being about aquaponics), or not openly licensed.
+
+---
+
+## Observability: what a turn actually did
+
+Retrieval quality is measured offline against a golden set. Production behaviour is a different
+question, and needs a different instrument.
+
+**Every turn is one trace.** All the events a turn produces — the message, each model call, each
+tool call, the retrieval, the turn summary — carry the same random per-turn id, so the log reads
+as a path rather than as counters:
+
+```bash
+agronaut traces          # recent turns: which tools ran, what retrieval returned, where the ms went
+agronaut analytics       # p50/p95/max latency for turn / model / retrieval, tokens, thumbs up-down
+```
+
+**The trace holds shape, never content.** No prompt, no reply, no passage text, no query is
+recorded, and that is enforced by an allowlist that drops unknown fields rather than by callers
+remembering not to pass them (`agronaut_agent/tests/test_turn_tracing.py` asserts it). The trace
+id is minted fresh per turn and is never derived from the user, so it groups a turn without
+following anyone between turns.
+
+**What gets measured, and why those things.** Turn latency and model latency separately, because
+the course is blunt that the transformer is the bottleneck and this project previously timed only
+retrieval — the fast, cheap stage. Token counts in and out, omitted entirely rather than recorded
+as `0` when a provider reports no usage, so a quiet provider cannot drag every cost aggregate
+toward zero. And a failed turn is still written, because dropping the turns that broke is how a
+p95 comes to look healthier than the service is.
+
+### Does the answer actually use what was retrieved?
+
+`retrieval_eval` scores whether the right documents were found. It cannot score whether the reply
+used them, and a system can hit recall 0.894 while inventing every number in its answer.
+
+```bash
+AGRONAUT_FAITHFULNESS_EVAL=1 python -m scripts.faithfulness_eval
+```
+
+Three metrics of three deliberately different kinds:
+
+| | judged by | what it catches |
+|---|---|---|
+| `faithfulness` | an LLM, per atomic claim | claims the retrieved context does not support — the grounding measure |
+| `response_relevancy` | an LLM + embeddings | an answer that is true but does not address the question |
+| `citation_accuracy` | **code, no model** | `[source: ...]` labels that were never retrieved — a fabricated citation |
+
+The judge is treated as a witness, not an oracle: rubrics are binary with named labels, an
+unparseable verdict counts as **unjudged** rather than being folded into either side, and
+`n_unjudged` is printed beside every score. It calls the network, so it is opt-in and never runs
+in CI; the scoring arithmetic is pure and unit-tested without a model.
+
+### Human feedback
+
+`/good` and `/bad` on Telegram record a bare rating, 1 or -1. There is no comment field on
+purpose — it is the one place message content could enter the analytics log, and the allowlist
+would drop it anyway. `agronaut analytics` prints the positive share.
 
 ---
 
@@ -284,7 +379,8 @@ agronaut web                     # the Streamlit app (trailing flags go to strea
                                  #   e.g. agronaut web --server.port=9000)
 agronaut bot                     # the Telegram bot
 agronaut review                  # approve/reject pending community insights
-agronaut analytics               # usage summary
+agronaut analytics               # usage summary: latency p50/p95, tokens, feedback
+agronaut traces                  # recent turns as pipeline traces (no message text)
 ```
 
 **Where it keeps things.** In a checkout, the knowledge base, the fetched-page cache and the
@@ -312,7 +408,7 @@ The consultative agent is reachable over Telegram. Set these (in `.env` or the e
 |---|---|
 | `TELEGRAM_BOT_TOKEN` | from [@BotFather](https://t.me/BotFather) |
 | `AGRONAUT_ALLOWED_IDS` | comma-separated Telegram user IDs allowed to use the bot (empty = open to anyone, discouraged) |
-| `AGRONAUT_RELEVANCE_MAX_DISTANCE` | how far a passage may be and still be used as context (default 1.65, `off` disables). Calibrated against the golden set; **not portable** — re-read `python -m scripts.retrieval_eval` after any corpus or embedding-model change |
+| `AGRONAUT_RELEVANCE_MAX_DISTANCE` | how far a passage may be and still be used as context (default 1.50, `off` disables). Calibrated against the golden set; **not portable** — re-run `python -m scripts.retrieval_sweep --all` after any corpus or embedding-model change |
 | `AGRONAUT_HYBRID` / `AGRONAUT_HYBRID_BETA` | keyword+semantic fusion, on by default at β=0.90 (β is the semantic weight) |
 | `AGRONAUT_MAX_PER_SOURCE` | how many passages one source may contribute to a single answer (default 2; `1` favours breadth, `0` disables) |
 | `AGRONAUT_INDEX_CACHE` | the built index is cached under `data/.index_cache/`, keyed by a corpus fingerprint; `off` rebuilds every time |
@@ -427,8 +523,10 @@ agronaut_agent/        # the channel-agnostic brain
   channels/            #   telegram_adapter.py, whatsapp_adapter.py, base.py
 
 scripts/               # safety_eval.py (hermetic golden set, runs in CI), vision_eval.py
+                       # faithfulness_eval.py (faithfulness / relevancy / citation accuracy)
                        # corpus_report.py (what each source contributes; --candidate vets one)
                        # retrieval_eval.py (recall/precision/MRR/MAP over the retrieval golden set)
+                       # retrieval_sweep.py (re-calibrates floor / cap / beta on the live corpus)
 skills/                # the deterministic core as a portable agentskills.io skill + CLI
 knowledge/ urls.txt    # the curated, cited knowledge base (urls.txt: CATEGORY|URL|LABEL|LICENCE)
 docs/dpg/              # DPG compliance pack: privacy, AI transparency, safety eval

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Parametric, not machine-learned — buildable today from published equations:
 ## The advice layer (retrieval), and how it was tuned
 
 Sizing is computed. Troubleshooting advice is *retrieved*, from a corpus of 22 hand-written
-operator guides plus openly licensed publications — currently **CHUNKS_TBD chunks**, led by
+operator guides plus openly licensed publications — currently **3941 chunks**, led by
 Goddek et al. (2019) and FAO 589.
 
 Retrieval is measured, not assumed. `docs/dpg/retrieval_eval/golden_set.json` holds queries in
@@ -173,13 +173,13 @@ the corpus grew:
 | | ships | why |
 |---|---|---|
 | Relevance floor | **on** (1.50) | refuses 8/10 off-topic queries, silences 0/33 real ones, keeps 0.117 headroom |
-| Hybrid BM25 + RRF | **on** (β=0.90) | lost at 362 chunks, won at 1354, re-confirmed at 3935 |
-| Per-source cap | **on** (1) | two books now hold 98% of the corpus; at cap=2 they take 2 of 3 slots |
+| Hybrid BM25 + RRF | **on** (β=0.90) | lost at 362 chunks, won at 1354, re-confirmed at 3941 |
+| Per-source cap | **on** (1) | two books hold 97% of the corpus; at cap=2 they take 2 of 3 slots |
 | PDF cleaning | **on** | drops contents pages; running header removed from 111 chunks → 4 |
 | Metadata filtering | available, off | the third leg of hybrid search. Filters `source_type`, `kb_tag`, `chapter`, `page`, `url_category` on **both** pools before fusion. A capability, not a ranking change — no golden-set number moves, and none is claimed |
 | Header chunking · context prefix · PDF chapter labels · cross-encoder rerank | off | each measured *worse* on this corpus |
 
-**Current: hit 0.879 · recall 0.833 · MAP 0.624 · 8/10 off-topic refused · 0/33 real silenced.**
+**Current: hit 0.879 · recall 0.833 · MAP 0.604 · 8/10 off-topic refused · 0/33 real silenced.**
 
 ### A decision expiring, caught in the act
 
@@ -187,11 +187,11 @@ the corpus grew:
 took the corpus from 1354 to 3935 chunks. Nothing was re-measured, and every constant silently
 became wrong for the corpus that actually shipped:
 
-| | at 1354 (recorded) | at 3935 (untouched) | at 3935 (re-tuned) |
+| | at 1354 (recorded) | at 3941, old constants | at 3941, re-tuned |
 |---|---|---|---|
-| hit_rate | 0.939 | 0.848 | **0.879** |
-| recall@k | 0.894 | 0.758 | **0.833** |
-| MAP@k | 0.697 | 0.578 | **0.624** |
+| hit_rate | 0.939 | 0.818 | **0.879** |
+| recall@k | 0.894 | 0.727 | **0.833** |
+| MAP@k | 0.697 | 0.548 | **0.604** |
 | off-topic refused | 8/10 | 4/10 | **8/10** |
 
 Two constants moved, one did not. The **floor** tightened 1.65 → 1.50, because the distance bands
@@ -200,6 +200,12 @@ chunks they overlapped and no floor could work). The **cap** tightened 2 → 1, 
 calibrated against *one* oversized source and there are now two. **β stayed at 0.90** — it
 describes the relationship between two ranking signals, which is a property of the query language,
 not of how much text sits behind it.
+
+Worth being precise about which change did what, because they pull opposite ways. **The floor
+costs retrieval quality**: at cap=1, staying at 1.65 would score hit 0.909 and MAP 0.624 against
+1.50's 0.879 and 0.604. That is bought deliberately, to double off-topic refusal from 4/10 to
+8/10. **The cap is what pays for it**: at floor 1.50, cap=1 gives 0.879/0.833/0.604 against
+cap=2's 0.788/0.697/0.538.
 
 The floor was *not* tightened to 1.40, though that refuses all 10 controls: it clears the worst
 real query by 0.017, and this project had already rejected a 0.032 margin as too thin. 33 golden
@@ -210,8 +216,10 @@ python -m scripts.retrieval_sweep --all      # re-pick all three, with the evide
 ```
 
 That command exists because the drift was not carelessness. Re-measuring three constants was an
-afternoon of ad-hoc scripting, so it did not happen. Now it is one command — run it after any
-corpus or embedding-model change.
+afternoon of ad-hoc scripting, so it did not happen. It also earned its keep immediately: while
+this work was in review the corpus moved *again* (a 22nd knowledge file, 3935 → 3941 chunks) and
+re-running was one command rather than an afternoon. Run it after any corpus or embedding-model
+change.
 
 Three of the four failures share one mechanism: they add topic words to chunks in a corpus where
 every document already shares a vocabulary domain, which dilutes rather than disambiguates. What

--- a/agronaut_agent/analytics.py
+++ b/agronaut_agent/analytics.py
@@ -6,6 +6,11 @@ counted without knowing who they are), a coarse date, and a small allowlist of n
 metadata (e.g. which tool was called). Free-text kwargs are silently dropped — content
 cannot leak even if a caller passes it.
 
+Every row also carries the current TURN TRACE id (see runtime.start_turn), so the rows a
+single turn produced can be read back as one path through the pipeline instead of as
+unrelated counters. The id is a fresh random token per turn, never derived from the user and
+never reused, so it groups events without identifying anyone.
+
 Local-only: appends to a JSONL file on the operator's machine; nothing is sent anywhere.
 Disable entirely with AGRONAUT_ANALYTICS=off. Consistent with docs/dpg/PRIVACY.md.
 """
@@ -29,12 +34,38 @@ from . import paths as _paths
 # keys are dropped rather than stored. That is what keeps this consistent with docs/dpg/PRIVACY.md
 # while still answering the production question the golden set cannot: is the retriever, on real
 # traffic, still behaving the way it did when its threshold was calibrated?
+#
+# The timing and cost fields describe the SHAPE and PRICE of a turn, never its subject.
+# They exist because the course-standard breakdown (system latency vs component latency,
+# tokens in vs out) was previously unmeasurable here: only retrieval was timed, which is the
+# fast, cheap stage. The bottleneck is the transformer, and it was invisible.
+#
+# `rating` is a thumbs up/down and nothing else: an integer 1 or -1, with no free-text
+# comment field, so the human-feedback signal cannot become a content leak.
 _ALLOWED_FIELDS = {"tool", "goal", "channel", "ok",
-                   "outcome", "n_results", "k", "latency_ms", "top_score", "hybrid"}
+                   "outcome", "n_results", "k", "latency_ms", "top_score", "hybrid",
+                   "filtered", "stage", "llm_ms", "llm_calls", "tokens_in", "tokens_out",
+                   "tool_calls", "rating"}
 
 _SIZING_TOOLS = {"size_aquaponics_system", "size_hydroponic_system_tool"}
 
 _DEFAULT_PATH = _paths.data_dir() / "analytics.jsonl"
+
+
+def _percentiles(values: list[int]) -> dict:
+    """p50/p95/max over a list of latencies, plus the sample size.
+
+    The sample size is returned alongside because a p95 over four turns is not a p95, and a
+    reader who cannot see n will treat it as one anyway.
+    """
+    if not values:
+        return {"n": 0, "p50": None, "p95": None, "max": None}
+    xs = sorted(values)
+    def _at(q: float) -> int:
+        # Nearest-rank: no interpolation between two real measurements, so every number
+        # printed is a latency that actually happened.
+        return xs[min(int(q * len(xs)), len(xs) - 1)]
+    return {"n": len(xs), "p50": _at(0.50), "p95": _at(0.95), "max": xs[-1]}
 
 
 def _hash_uid(user_id: str) -> str:
@@ -57,6 +88,15 @@ class Analytics:
             "uid": _hash_uid(user_id) if user_id is not None else None,
             "date": datetime.now(timezone.utc).date().isoformat(),  # date only — no fine tracking
         }
+        # Read rather than passed: a trace that depends on every callsite remembering to
+        # forward it is a trace with holes in exactly the paths nobody thought about.
+        try:
+            from .runtime import trace_id
+            tid = trace_id()
+            if tid:
+                row["trace"] = tid
+        except Exception:  # noqa: BLE001 — telemetry must never break a live turn
+            pass
         for k, v in fields.items():
             if k in _ALLOWED_FIELDS:
                 row[k] = v
@@ -67,25 +107,86 @@ class Analytics:
         except Exception:  # analytics must never break a live turn
             pass
 
+    def rows(self) -> list[dict]:
+        """Every recorded event, oldest first. Malformed lines are skipped, never raised:
+        a half-written final line (the process died mid-append) must not make the whole
+        log unreadable."""
+        out: list[dict] = []
+        if not self.path.exists():
+            return out
+        for line in self.path.read_text().splitlines():
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return out
+
+    def traces(self, limit: int = 20) -> list[dict]:
+        """The most recent turns, each as its ordered list of events.
+
+        This is the course's "detailed logs: trace individual prompts through your pipeline",
+        with the one substitution this project requires: the prompt itself is never stored, so
+        a trace shows the SHAPE of the path (which tools ran, what retrieval returned, where
+        the milliseconds went) rather than the text that travelled it. That is enough to
+        answer the questions traces are for, and it keeps the privacy guarantee intact.
+        """
+        grouped: dict[str, list[dict]] = {}
+        for r in self.rows():
+            tid = r.get("trace")
+            if tid:
+                grouped.setdefault(tid, []).append(r)
+        out = []
+        for tid, events in list(grouped.items())[-limit:]:
+            turn = next((e for e in events if e["event"] == "turn"), {})
+            out.append({
+                "trace": tid,
+                "date": events[0].get("date"),
+                "channel": next((e.get("channel") for e in events if e.get("channel")), None),
+                "latency_ms": turn.get("latency_ms"),
+                "llm_ms": turn.get("llm_ms"),
+                "tokens_in": turn.get("tokens_in"),
+                "tokens_out": turn.get("tokens_out"),
+                "events": events,
+            })
+        return out
+
     def summarize(self) -> dict:
         events: dict[str, int] = {}
         users: set[str] = set()
         sized_users: set[str] = set()
-        if self.path.exists():
-            for line in self.path.read_text().splitlines():
-                try:
-                    r = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                events[r["event"]] = events.get(r["event"], 0) + 1
-                if r.get("uid"):
-                    users.add(r["uid"])
-                    if r["event"] == "tool_call" and r.get("tool") in _SIZING_TOOLS:
-                        sized_users.add(r["uid"])
+        turn_ms: list[int] = []
+        llm_ms: list[int] = []
+        retrieval_ms: list[int] = []
+        tokens_in = tokens_out = 0
+        ratings: dict[str, int] = {"up": 0, "down": 0}
+        for r in self.rows():
+            events[r["event"]] = events.get(r["event"], 0) + 1
+            if r.get("uid"):
+                users.add(r["uid"])
+                if r["event"] == "tool_call" and r.get("tool") in _SIZING_TOOLS:
+                    sized_users.add(r["uid"])
+            if r["event"] == "turn":
+                if r.get("latency_ms") is not None:
+                    turn_ms.append(r["latency_ms"])
+                if r.get("llm_ms") is not None:
+                    llm_ms.append(r["llm_ms"])
+                tokens_in += r.get("tokens_in") or 0
+                tokens_out += r.get("tokens_out") or 0
+            elif r["event"] == "retrieval" and r.get("latency_ms") is not None:
+                retrieval_ms.append(r["latency_ms"])
+            elif r["event"] == "feedback":
+                ratings["up" if (r.get("rating") or 0) > 0 else "down"] += 1
         return {
             "events": events,
             "distinct_users": len(users),
             "users_who_sized": len(sized_users),
+            "latency": {
+                "turn": _percentiles(turn_ms),
+                "llm": _percentiles(llm_ms),
+                "retrieval": _percentiles(retrieval_ms),
+            },
+            "tokens": {"in": tokens_in, "out": tokens_out},
+            "feedback": ratings,
         }
 
 
@@ -93,6 +194,17 @@ def main() -> int:  # pragma: no cover - CLI convenience
     s = Analytics().summarize()
     print(f"Distinct users: {s['distinct_users']}")
     print(f"Users who sized a system: {s['users_who_sized']}")
+    fb = s["feedback"]
+    if fb["up"] or fb["down"]:
+        total = fb["up"] + fb["down"]
+        print(f"Feedback: {fb['up']} up / {fb['down']} down ({fb['up'] / total:.0%} positive)")
+    print("Latency (ms, p50/p95/max over n):")
+    for stage, p in s["latency"].items():
+        if p["n"]:
+            print(f"  {stage:10s} {p['p50']:>6} {p['p95']:>6} {p['max']:>6}   n={p['n']}")
+    tok = s["tokens"]
+    if tok["in"] or tok["out"]:
+        print(f"Tokens: {tok['in']} in / {tok['out']} out")
     print("Events:")
     for ev, n in sorted(s["events"].items(), key=lambda kv: -kv[1]):
         print(f"  {ev:16s} {n}")

--- a/agronaut_agent/channels/telegram_adapter.py
+++ b/agronaut_agent/channels/telegram_adapter.py
@@ -123,6 +123,7 @@ class TelegramAdapter(ChannelAdapter):
             "/design — size a new system\n"
             "/optimize — best fish/crop ratio\n"
             "/troubleshoot — diagnose a problem\n"
+            "/good, /bad — tell me if an answer helped (it's how I improve)\n"
             "/whoami — what I remember about you\n"
             "/export — download all your data (open JSON)\n"
             "/reset — clear this conversation (keeps long-term memory)\n"
@@ -162,6 +163,22 @@ class TelegramAdapter(ChannelAdapter):
             days, greenhouse)
         for part in chunk(reply):
             await update.message.reply_text(part)
+
+    async def _on_feedback(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        """/good and /bad — the human-feedback signal, as two commands rather than inline
+        buttons.
+
+        Buttons would read better, but they require a CallbackQueryHandler and a message id to
+        attach to, and a rating that only exists while the keyboard is still on screen is a
+        rating most people never give. A command works on every client, works late, and works
+        after the message has scrolled away.
+        """
+        positive = (update.message.text or "").lstrip("/").lower().startswith("good")
+        if not self._allowed(update):
+            return await self._deny(update)
+        reply = await asyncio.to_thread(
+            self.agent.record_feedback, self.channel_name, self._identity(update), positive)
+        await update.message.reply_text(reply)
 
     async def _on_whoami(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         if not self._allowed(update):
@@ -352,6 +369,8 @@ class TelegramAdapter(ChannelAdapter):
             ("troubleshoot", self._on_troubleshoot, "Mode: diagnose a problem"),
             ("log", self._on_log, "Log readings into your LIVE twin"),
             ("forecast", self._on_forecast, "Your live twin: now + the week ahead"),
+            ("good", self._on_feedback, "That last answer helped"),
+            ("bad", self._on_feedback, "That last answer missed"),
             ("whoami", self._on_whoami, "What I remember about you"),
             ("export", self._on_export, "Download all my data (JSON)"),
             ("reset", self._on_reset, "Clear this conversation"),

--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -62,6 +62,41 @@ def _cmd_analytics(args) -> int:
     return analytics.main()
 
 
+def _cmd_traces(args) -> int:
+    """Print recent turns as traces: what each one did and where its time went.
+
+    The course's "follow a prompt's path through the entire RAG pipeline", minus the prompt.
+    Text is never recorded here, so a trace shows the SHAPE of the path — which tools ran,
+    what retrieval returned, how the milliseconds split between model and retriever. That is
+    what answers "why was this turn slow" and "why did this answer have no sources", and it
+    stays inside the privacy guarantee.
+    """
+    from .analytics import Analytics
+
+    traces = Analytics().traces(limit=args.limit)
+    if not traces:
+        print("No traces recorded yet. Traces appear once the agent handles a turn "
+              "(and are off entirely with AGRONAUT_ANALYTICS=off).")
+        return 0
+    for t in traces:
+        head = f"trace {t['trace']}  {t['date']}  {t['channel'] or '-'}"
+        if t["latency_ms"] is not None:
+            head += f"  {t['latency_ms']} ms total"
+            if t["llm_ms"] is not None:
+                share = f" ({t['llm_ms'] / t['latency_ms']:.0%})" if t["latency_ms"] else ""
+                head += f", {t['llm_ms']} ms model{share}"
+        if t["tokens_in"] or t["tokens_out"]:
+            head += f", {t['tokens_in'] or 0}/{t['tokens_out'] or 0} tok"
+        print(head)
+        for e in t["events"]:
+            detail = {k: v for k, v in e.items()
+                      if k not in {"event", "uid", "date", "trace", "channel"} and v is not None}
+            bits = " ".join(f"{k}={v}" for k, v in detail.items())
+            print(f"    {e['event']:14s} {bits}")
+        print()
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="agronaut",
@@ -89,6 +124,9 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("review", help="approve/reject pending community insights").set_defaults(
         func=_cmd_review)
     sub.add_parser("analytics", help="summarise recorded usage").set_defaults(func=_cmd_analytics)
+    tr = sub.add_parser("traces", help="show recent turns as pipeline traces")
+    tr.add_argument("--limit", type=int, default=10, help="how many recent turns to show")
+    tr.set_defaults(func=_cmd_traces)
     return p
 
 

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import re
 import threading
+import time
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
@@ -381,12 +382,51 @@ class AgronautAgent:
                     return {"name": obj["name"], "args": args, "id": "rescued-leaked-call"}
         return None
 
+    # --- model instrumentation -------------------------------------------
+    @staticmethod
+    def _usage(ai) -> tuple:
+        """(input_tokens, output_tokens) from a model reply, or (None, None).
+
+        Two shapes because providers disagree: LangChain normalises modern chat models into
+        `usage_metadata`, while others only pass through the raw OpenAI-style
+        `response_metadata['token_usage']`. Anything else yields None rather than a zero —
+        an absent count and a genuine zero must not aggregate into the same number.
+        """
+        meta = getattr(ai, "usage_metadata", None)
+        if isinstance(meta, dict) and ("input_tokens" in meta or "output_tokens" in meta):
+            return meta.get("input_tokens"), meta.get("output_tokens")
+        raw = getattr(ai, "response_metadata", None) or {}
+        tu = raw.get("token_usage") or raw.get("usage") or {}
+        if isinstance(tu, dict) and tu:
+            return (tu.get("prompt_tokens") or tu.get("input_tokens"),
+                    tu.get("completion_tokens") or tu.get("output_tokens"))
+        return None, None
+
+    def _invoke_model(self, model, messages: list, stage: str):
+        """Call a chat model, timing it and accumulating its cost into the turn.
+
+        Every model call in the turn goes through here. The course is explicit that the
+        transformer is the latency and the cost, and this project measured only retrieval —
+        the fast stage — until now. Instrumenting the call site rather than the turn also
+        separates the two questions a slow turn raises: was it one slow call, or six.
+        """
+        t0 = time.perf_counter()
+        try:
+            ai = model.invoke(messages)
+        finally:
+            elapsed = int((time.perf_counter() - t0) * 1000)
+        tin, tout = self._usage(ai)
+        runtime.record_llm_call(elapsed, tin, tout)
+        self._analytics.record("llm_call", stage=stage, latency_ms=elapsed,
+                               tokens_in=tin, tokens_out=tout)
+        return ai
+
     # --- the tool-calling loop -------------------------------------------
     def _run_tool_loop(self, messages: list, user_id: str) -> str:
         fabrication_nudged = False
         promise_nudged = False
         for _ in range(_MAX_ITERS):
-            ai = self._bound.invoke(messages)
+            ai = self._invoke_model(self._bound, messages, "agent")
             messages.append(ai)
             tool_calls = getattr(ai, "tool_calls", None)
             if not tool_calls:
@@ -442,6 +482,7 @@ class AgronautAgent:
                         result = tool.invoke(call["args"])
                     except Exception as exc:  # fed back so the model can correct; never hidden
                         result = f"TOOL_ERROR: {exc}"
+                runtime.record_tool_call()
                 self._analytics.record("tool_call", user_id=user_id, tool=call["name"],
                                        ok=not str(result).startswith("TOOL_ERROR"))
                 self._conv.append_message(user_id, "tool", result, tool_name=call["name"])
@@ -454,7 +495,7 @@ class AgronautAgent:
         try:
             messages.append(SystemMessage(content="Now reply to the user in plain text using what "
                                                    "you have. Do not call any more tools."))
-            final = self._base.invoke(messages)
+            final = self._invoke_model(self._base, messages, "final")
             text = (getattr(final, "content", "") or "").strip()
             if text:
                 return text
@@ -475,9 +516,48 @@ class AgronautAgent:
         actually wrote); voice turns pass nothing, because a transcript IS the user's words.
         """
         if self._bound is None:
+            # Refused BEFORE the trace opens, deliberately. A turn is a run through the
+            # pipeline; this never reaches it, and recording it as one would drop a ~0 ms row
+            # into the latency distribution and flatter the p50 of turns that really ran. The
+            # event is still counted, so an operator can see a missing model rather than infer
+            # it from an absence of turns.
+            self._analytics.record("no_model", channel=channel)
             return ("I can't hold a conversation right now — no tool-calling model is "
                     f"configured ({self._chat_error}). Your live twin still works: "
                     "/log and /forecast never touch a model.")
+        owns_turn = runtime.start_turn()
+        t_turn = time.perf_counter()
+        try:
+            return self._handle_message_inner(channel, channel_user, text, display_name, fact_text)
+        finally:
+            if owns_turn:
+                self._record_turn(channel, t_turn)
+                runtime.end_turn()
+
+    def _record_turn(self, channel: str, t0: float) -> None:
+        """Close the turn out with its end-to-end shape: total wall clock, how much of it
+        was the model, how many calls it took, and what it cost in tokens.
+
+        Written in a `finally`, so a turn that raised is still measured. A failed turn is
+        the one whose latency you most want in the distribution, and dropping it is how a
+        p95 comes to look healthier than the service actually is.
+        """
+        m = runtime.turn_metrics()
+        fields = {
+            "channel": channel,
+            "latency_ms": int((time.perf_counter() - t0) * 1000),
+            "llm_ms": m.get("llm_ms"),
+            "llm_calls": m.get("llm_calls"),
+            "tool_calls": m.get("tool_calls"),
+        }
+        if m.get("usage_seen"):     # omit entirely when the provider reported no usage
+            fields["tokens_in"] = m.get("tokens_in")
+            fields["tokens_out"] = m.get("tokens_out")
+        self._analytics.record("turn", **fields)
+
+    def _handle_message_inner(self, channel: str, channel_user: str, text: str,
+                              display_name: str | None = None,
+                              fact_text: str | None = None) -> str:
         user_id = self._conv.get_or_create_user(channel, channel_user, display_name)
         self._analytics.record("message", user_id=user_id, channel=channel)
         source_text = text if fact_text is None else fact_text
@@ -516,6 +596,21 @@ class AgronautAgent:
         self._schedule_summary(user_id)
         return reply
 
+    def record_feedback(self, channel: str, channel_user: str, positive: bool) -> str:
+        """Record a thumbs up/down on the last reply and acknowledge it.
+
+        The course's cheapest quality signal and the only one that measures what the other
+        evaluators cannot: whether the person actually asked was helped. Deliberately a bare
+        rating with no comment field — a free-text box here would be the one place message
+        content could enter the analytics log, and the allowlist would drop it anyway.
+        """
+        user_id = self._conv.get_or_create_user(channel, channel_user)
+        self._analytics.record("feedback", user_id=user_id, channel=channel,
+                               rating=1 if positive else -1)
+        return ("Noted, thank you — that helps me get better."
+                if positive else
+                "Thanks for telling me. What was wrong with it? I'll use that to do better.")
+
     def take_attachments(self, channel: str, channel_user: str) -> list:
         """Files the last turn produced for this user, to be sent by the channel adapter.
         Draining is idempotent — returns [] once taken."""
@@ -527,6 +622,17 @@ class AgronautAgent:
         """A photo arrives: the VLM produces a plain-language visual observation, which is
         then run through the NORMAL text turn — so memory, the trust-gated tools, and cited
         knowledge all still apply. The vision model never calls tools or emits numbers."""
+        owns_turn = runtime.start_turn()
+        t_turn = time.perf_counter()
+        try:
+            return self._handle_image_inner(channel, channel_user, image_bytes, caption, display_name)
+        finally:
+            if owns_turn:
+                self._record_turn(channel, t_turn)
+                runtime.end_turn()
+
+    def _handle_image_inner(self, channel: str, channel_user: str, image_bytes: bytes,
+                            caption: str | None = None, display_name: str | None = None) -> str:
         self._analytics.record("image", user_id=self._conv.get_or_create_user(channel, channel_user),
                                channel=channel)
         if self._describe is None:
@@ -608,6 +714,17 @@ class AgronautAgent:
         """A voice note arrives: transcribe it, then run the transcript through the NORMAL
         text turn. The transcript IS the user's message, so everything (memory, tools, cited
         knowledge, reply-in-user-language) applies unchanged."""
+        owns_turn = runtime.start_turn()
+        t_turn = time.perf_counter()
+        try:
+            return self._handle_voice_inner(channel, channel_user, audio_bytes, mime, display_name)
+        finally:
+            if owns_turn:
+                self._record_turn(channel, t_turn)
+                runtime.end_turn()
+
+    def _handle_voice_inner(self, channel: str, channel_user: str, audio_bytes: bytes,
+                            mime: str | None = None, display_name: str | None = None) -> str:
         self._analytics.record("voice", user_id=self._conv.get_or_create_user(channel, channel_user),
                                channel=channel)
         if self._transcribe is None:

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -14,27 +14,38 @@ import re
 # Maximum FAISS L2 distance a passage may have and still be offered to the model as context.
 # LOWER is closer; anything above this is treated as "nothing relevant matched".
 #
-# Measured on docs/dpg/retrieval_eval/golden_set.json (33 operator queries, 10 off-topic controls),
-# corpus of 1354 chunks: rejects 8/10 off-topic queries, silences 0/33 real ones.
+# RE-CALIBRATED 2026-09-01 on the 3935-chunk corpus (was 1.65 at 1354 chunks).
+# `python -m scripts.retrieval_sweep --floor ...`, saved to retrieval_eval/sweep_2026_09.json:
 #
-# THE BANDS OVERLAP AND CANNOT BE SEPARATED. Worst on-topic distance is 1.548; the CLOSEST
-# off-topic match is 1.426 ("best way to remove red wine from a carpet", which lands near
-# algae_control.md's advice on removing growth from surfaces). Adding FAO 589 widened this gap in
-# the wrong direction — a 275-page book covering everything from plumbing to food safety is
-# semantically near almost any question. No single global threshold can catch that query without
-# also silencing real ones.
+#     floor  hit    recall  prec    MRR     MAP     silenced  rejected  headroom
+#     1.30   0.758  0.682   0.409   0.591   0.538   4         10/10     -0.083
+#     1.35   0.818  0.727   0.429   0.621   0.553   2         10/10     -0.033
+#     1.40   0.818  0.727   0.429   0.621   0.553   0         10/10      0.017
+#     1.45   0.818  0.727   0.434   0.636   0.568   0          8/10      0.067
+#     1.50   0.818  0.727   0.434   0.636   0.568   0          8/10      0.117   <- ships
+#     1.65   0.848  0.758   0.444   0.646   0.578   0          4/10      0.267
 #
-# 1.65 rather than a tighter 1.58: the tighter value would reject one more control (neg-06, at
-# 1.616) but leaves only 0.032 of headroom above the worst real query, versus 0.10 at 1.65. On a
-# 33-query sample that trades a threefold cut in safety margin for one extra rejection, and
-# "silences 0 real queries" is the property that must not break. A real question is refused
-# service; an off-topic one merely gets an honest "no matching passages".
+# THE BANDS HAVE SEPARATED, which is new and is what makes a tighter floor possible at all. At
+# 1354 chunks the worst on-topic distance (1.548) sat ABOVE the closest off-topic match (1.426)
+# and no single threshold could work. Adding Goddek et al. (2019) pulled the on-topic band in —
+# more corpus means a closer match for every real question — so the worst real query is now 1.383
+# and the nearest off-topic one is 1.411. The eval prints "separable" instead of "OVERLAPPING".
+#
+# NOT 1.40, though it rejects all ten controls. It sits 0.017 above the worst real query. This
+# project already rejected a 0.032 margin as too thin ("a threefold cut in safety margin for one
+# extra rejection"), and 0.017 is half of that. The golden set has 33 queries; the 34th is the one
+# that matters, and headroom is all that protects it. 1.50 keeps 0.117, comparable to the 0.10
+# that reasoning accepted, and still doubles refusal from 4/10 to 8/10.
+#
+# The cost is real and is the honest half of this: hit_rate 0.848 -> 0.818 and MAP 0.578 -> 0.568
+# at this stage. The per-source cap below more than repays it (final: hit 0.879, MAP 0.624).
 #
 # This number is a property of THIS embedding model over THIS corpus and does not port.
 # `python -m scripts.retrieval_eval` reprints the separation on every run and says outright when
-# the bands overlap. Re-read it after any corpus change. Override with
-# AGRONAUT_RELEVANCE_MAX_DISTANCE (or "off" to disable).
-_DEFAULT_MAX_DISTANCE = 1.65
+# the bands overlap; `python -m scripts.retrieval_sweep --all` re-picks all three constants.
+# Re-run after any corpus change — the value above expired in one day the last time nobody did.
+# Override with AGRONAUT_RELEVANCE_MAX_DISTANCE (or "off" to disable).
+_DEFAULT_MAX_DISTANCE = 1.50
 
 _INDEX = None          # cached FAISS index (or None if unavailable)
 _TRIED = False         # don't retry a failed/slow build every call
@@ -52,15 +63,27 @@ _RRF_K = 60
 # disabled. Adding FAO 589 grew the corpus to 1354 chunks, and re-running the sweep — which the
 # recorded evidence explicitly said to do after substantial corpus growth — flipped the result:
 #
-#     beta   hit    recall  prec    MRR     MAP
+#     beta   hit    recall  prec    MRR     MAP      (1354 chunks)
 #     0.50   0.758  0.727   0.444   0.561   0.543
 #     0.70   0.818  0.773   0.475   0.646   0.606
-#     0.90   0.848  0.788   0.495   0.692   0.636   <- ships
+#     0.90   0.848  0.788   0.495   0.692   0.636   <- shipped then
 #     dense  0.848  0.697   0.490   0.682   0.545
 #
-# Note how LITTLE keyword weight is right: 10%. Enough to break ties a 992-chunk book would
-# otherwise win on volume, not enough to let common aquaponics vocabulary dominate the ranking.
-# At 0.5 — the intuitive "balanced" setting — hybrid is still clearly worse than dense.
+# RE-CONFIRMED 2026-09-01 at 3935 chunks, under floor 1.50 and cap 1 — the one constant the corpus
+# growth did NOT move:
+#
+#     beta   hit    recall  prec    MRR     MAP      (3935 chunks)
+#     0.50   0.879  0.788   0.333   0.601   0.558
+#     0.70   0.879  0.803   0.343   0.606   0.571
+#     0.90   0.879  0.833   0.364   0.657   0.624   <- ships
+#     1.00   0.848  0.803   0.354   0.662   0.621    (dense-only)
+#
+# Note how LITTLE keyword weight is right: 10%. Enough to break ties a book would otherwise win on
+# volume, not enough to let common aquaponics vocabulary dominate the ranking. At 0.5 — the
+# intuitive "balanced" setting — hybrid is still clearly worse. That beta held steady across a
+# 3x corpus growth while the floor and the cap both moved is itself informative: beta describes
+# the relationship between two RANKING SIGNALS, which is a property of the query language and the
+# embedding model, not of how much text sits behind them.
 _DEFAULT_BETA = 0.90
 
 
@@ -142,7 +165,10 @@ def hybrid_enabled() -> bool:
 
     Nothing about the technique changed. The corpus did. A 992-chunk book competing with 82 chunks
     of targeted operator guidance is precisely the situation a keyword signal is for: it breaks
-    ties that dense similarity resolves by volume. Disable with AGRONAUT_HYBRID=off.
+    ties that dense similarity resolves by volume.
+
+    RE-CONFIRMED 2026-09-01 at 3935 chunks: still on, still beta=0.90, and now measurably ahead of
+    dense-only on hit_rate as well (0.879 vs 0.848). Disable with AGRONAUT_HYBRID=off.
     """
     return os.getenv("AGRONAUT_HYBRID", "").lower() not in {"off", "0", "false"}
 
@@ -189,29 +215,37 @@ _POOL = 20      # candidates drawn from each retriever before fusion
 
 # At most this many passages from any ONE source in a single result set.
 #
-# The observed failure when a 992-chunk book joined an 82-chunk curated corpus was not subtle:
-# FAO 589 took all three slots on 10 of 33 queries, so a targeted operator answer that existed in
-# knowledge/ never reached the model. Ranking alone cannot fix that — the book genuinely IS
-# similar, and has twelve times as many chances to be. A per-source cap spends one slot on breadth
-# instead, which is what a researcher does by reflex: read two sources, not three pages of one.
+# CHANGED 2026-09-01 from 2 to 1. The reason the old choice expired is worth keeping, because the
+# technique did not change — the corpus did, for the second time.
 #
-# Measured (1354-chunk corpus, hybrid on):
+# At 1354 chunks there was ONE oversized source (FAO 589, 992 chunks) against 82 chunks of curated
+# operator guidance, and cap=2 was the right call: it kept most of cap=1's recall while returning
+# materially less irrelevant context (precision 0.540 vs 0.404), and still let a source with real
+# depth contribute twice.
+#
+# There are now TWO. Goddek et al. (2019) added 2576 chunks, so 3853 of 3935 chunks are books and
+# the curated files are 2% of the corpus. cap=2 lets books take two of three slots, which is the
+# same failure the cap was built to stop, arriving through a door the cap left open.
+#
+# Measured (3935-chunk corpus, floor 1.50, hybrid on) — retrieval_eval/sweep_2026_09.json:
 #
 #     cap    hit    recall  prec    MRR     MAP
-#     1      0.970  0.919   0.404   0.747   0.710
-#     2      0.939  0.894   0.540   0.737   0.697   <- ships
-#     none   0.848  0.788   0.495   0.692   0.636
+#     1      0.879  0.833   0.364   0.657   0.624   <- ships
+#     2      0.818  0.727   0.434   0.636   0.568
+#     3      0.697  0.621   0.374   0.576   0.515
+#     none   0.697  0.621   0.374   0.576   0.515
 #
-# cap=1 restores the pre-FAO hit_rate exactly and wins MRR/MAP, so it is a defensible choice and
-# is one env var away. It ships at 2 because part of cap=1's advantage is an artefact of the
-# metric rather than a real gain: `relevant` is labelled at DOCUMENT granularity, so one FAO
-# passage scores identically to three, and the metric cannot see that some queries (feeding rates,
-# pest treatments) are genuinely best answered by several passages from the same chapter. cap=2
-# keeps most of the recall while returning materially less irrelevant context to the model
-# (precision 0.540 vs 0.404), and still allows a source with real depth to contribute twice.
+# The gap that decided it widened by roughly four times. At 1354 chunks cap=1 bought +0.031 hit
+# and +0.025 recall over cap=2; here it buys +0.061 hit and +0.106 recall, and +0.056 MAP.
 #
-# Set AGRONAUT_MAX_PER_SOURCE=1 to prioritise coverage, or 0 to disable the cap entirely.
-_MAX_PER_SOURCE = 2
+# Precision still falls (0.434 -> 0.364) and that is still partly a metric artefact: `relevant` is
+# labelled at DOCUMENT granularity, so cap=1 caps precision@3 at 0.333 for any query with one
+# relevant document however good the answer is. What is NOT an artefact is recall and MAP, which
+# both move decisively the other way. When the honest and the artefactual disagree this sharply,
+# follow the metric that is not structurally bounded.
+#
+# Set AGRONAUT_MAX_PER_SOURCE=2 to restore the old behaviour, or 0 to disable the cap entirely.
+_MAX_PER_SOURCE = 1
 
 # Cross-encoder reranker. A bi-encoder embeds query and passage SEPARATELY, so it can only
 # compare two summaries of meaning; a cross-encoder reads the pair together and scores their
@@ -222,8 +256,59 @@ _RERANKER = None
 _RERANK_TRIED = False
 
 
+# Metadata keys a caller may filter on. Restricted deliberately: an open-ended predicate over
+# arbitrary metadata would let a caller filter on fields that only some chunks carry, silently
+# excluding every document that predates the field rather than the ones it meant to exclude.
+#
+# What each key holds (assigned in srcs/chatbot.py):
+#   source_type    "local_file" | "web"    — curated operator guidance vs a fetched page
+#   kb_tag         markdown filename stem  — "ph_and_alkalinity", "fish_disease_and_treatment"
+#   url_category   the curated category from urls.txt
+#   chapter        FAO 589 chapter, forward-filled to ~95% page coverage
+#   page           page number within a PDF source
+_FILTERABLE = {"source_type", "kb_tag", "url_category", "chapter", "page"}
+
+
+def _matches(metadata: dict, filters: dict) -> bool:
+    """Whether one chunk satisfies every filter clause.
+
+    A clause value may be a scalar or a collection, so {"source_type": "local_file"} and
+    {"kb_tag": ["ph_and_alkalinity", "water_quality_ranges"]} both read naturally. Every
+    clause must match: filters narrow, they never widen. A chunk MISSING the key fails,
+    which is the safe direction — "give me only FAO chapter 8" must not return the whole
+    markdown corpus on the grounds that it has no chapter to disagree with.
+    """
+    for key, want in filters.items():
+        got = metadata.get(key)
+        if got is None:
+            return False
+        if isinstance(want, (list, tuple, set, frozenset)):
+            if got not in want and str(got) not in {str(w) for w in want}:
+                return False
+        elif got != want and str(got) != str(want):
+            return False
+    return True
+
+
+def normalize_filters(filters: dict | None) -> dict | None:
+    """Validate a filter dict, dropping unknown keys with a warning. None/empty -> None.
+
+    Unknown keys are dropped rather than raising: a filter is a retrieval REFINEMENT, and a
+    typo in one should cost precision, never the whole answer to an operator's question.
+    """
+    if not filters:
+        return None
+    clean = {k: v for k, v in filters.items() if k in _FILTERABLE}
+    unknown = set(filters) - set(clean)
+    if unknown:
+        logging.warning("Ignoring unfilterable metadata keys %s (filterable: %s)",
+                        sorted(unknown), sorted(_FILTERABLE))
+    return clean or None
+
+
 def retrieve(query: str, k: int = 3, max_dist: float | None = None,
-             hybrid: bool | None = None) -> list[dict]:
+             hybrid: bool | None = None, filters: dict | None = None,
+             max_per_source: int | None = None) -> list[dict]:
     """Structured retrieval: the ranked passages for `query`, each as
     {"text", "source", "score"}.
 
@@ -243,17 +328,49 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
     fusion only decides the order of what it returns. If nothing clears the floor, nothing is
     returned, whatever the keyword scores say.
 
+    METADATA FILTERING (`filters`) is the third leg of hybrid retrieval and works differently
+    from the other two: it does not rank anything. It excludes, on rigid criteria, before
+    ranking happens — and so it is applied to BOTH pools, not to the fused result. Filtering
+    after fusion would let excluded chunks consume pool slots first and silently shrink the
+    candidate set; filtering before means each retriever spends its whole pool inside the
+    permitted subset. See `_FILTERABLE` for the keys and `_matches` for the semantics.
+
+    It is OFF unless a caller passes it, and passing nothing leaves behaviour byte-identical
+    to before it existed. That is deliberate. A filter encodes something the CALLER knows and
+    the query text does not say ("only my own curated docs", "only chapter 8"); inferring one
+    from the query would be query rewriting wearing a different hat, and that technique is
+    recorded as measured-and-lost for this corpus.
+
+    `max_per_source` overrides the diversity cap for this call (0 disables it). It exists for
+    MEASUREMENT: the calibration of the relevance floor depends on the closest distance in the
+    raw candidate pool, and the cap can drop precisely that chunk when it is the second passage
+    from a source. Measuring the band edge through a capped result set therefore reports a
+    distance that is too high — on this corpus, 1.416 instead of the true 1.383 — which would
+    quietly overstate how tight a floor can safely be. Evaluators pass 0 here to see the pool the
+    floor actually gates.
+
     Returns [] both when the index is unavailable and when nothing survives filtering; callers
     that must tell those apart should check `index_available()`.
     """
     limit = max_distance() if max_dist is None else max_dist
+    filters = normalize_filters(filters)
     index = _get_index()
     if index is None:
         return []
     import srcs.chatbot as core
 
     try:
-        pairs = index.similarity_search_with_score(query, k=max(_POOL, k * 2))
+        if filters:
+            # fetch_k over-fetches BEFORE filtering, so it must be generous: FAISS takes the
+            # nearest fetch_k, drops those the filter rejects, and only then keeps k. Left at
+            # its default of 20, a narrow filter over a 3935-chunk corpus would usually find
+            # nothing in the top 20 and return empty for a query the corpus can answer well.
+            pairs = index.similarity_search_with_score(
+                query, k=max(_POOL, k * 2),
+                filter=lambda md: _matches(md, filters),
+                fetch_k=max(_POOL * 20, 400))
+        else:
+            pairs = index.similarity_search_with_score(query, k=max(_POOL, k * 2))
     except Exception as exc:
         logging.warning("knowledge search failed: %s", exc)
         return []
@@ -291,6 +408,8 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
                 doc = docs[i]
                 if core._is_boilerplate_text(doc.page_content):
                     continue
+                if filters and not _matches(doc.metadata, filters):
+                    continue
                 key = (_source_label(doc.metadata), doc.page_content[:120])
                 if key not in by_key:
                     # A keyword-only hit carries no L2 distance. Record it as exactly that
@@ -307,7 +426,7 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
         # Rerank the shortlist BEFORE the diversity cap: the cap should displace the least
         # relevant duplicate, which requires relevance to already be correct.
         fused = _rerank(query, fused[:_POOL], by_key)
-    return [by_key[key] for key in _diversify(fused, by_key, k)]
+    return [by_key[key] for key in _diversify(fused, by_key, k, max_per_source)]
 
 
 def rerank_enabled() -> bool:
@@ -327,7 +446,13 @@ def rerank_enabled() -> bool:
     This is a statement about THIS model on THIS domain, not about reranking. A cross-encoder
     fine-tuned on agronomy text, or simply a stronger general one, could plausibly win — the
     machinery is here and AGRONAUT_RERANK=on turns it on, with AGRONAUT_RERANK_MODEL selecting
-    the model. Re-measure before trusting it.
+    the model.
+
+    THE TABLE ABOVE WAS MEASURED AT 1354 CHUNKS and has NOT been re-run since the corpus reached
+    3935. Unlike the floor and the cap, this decision was not re-measured on 2026-09-01, because
+    a technique that lost on every metric and tripled latency does not become the priority when
+    the corpus grows. It is recorded as stale rather than quietly presented as current — re-run
+    `AGRONAUT_RERANK=on python -m scripts.retrieval_eval` before trusting either verdict.
     """
     return os.getenv("AGRONAUT_RERANK", "").lower() in {"on", "1", "true"}
 
@@ -415,7 +540,7 @@ def index_available() -> bool:
     return _get_index() is not None
 
 
-def search_with_stats(query: str, k: int = 3) -> tuple[str, dict]:
+def search_with_stats(query: str, k: int = 3, filters: dict | None = None) -> tuple[str, dict]:
     """search(), plus non-identifying telemetry about how the retrieval went.
 
     The stats deliberately contain NO query text and NO passage text — only shape and timing. The
@@ -429,7 +554,7 @@ def search_with_stats(query: str, k: int = 3) -> tuple[str, dict]:
     if not index_available():
         return _UNAVAILABLE, {"outcome": "unavailable", "n_results": 0,
                               "latency_ms": int((time.perf_counter() - t0) * 1000)}
-    hits = retrieve(query, k=k)
+    hits = retrieve(query, k=k, filters=filters)
     latency_ms = int((time.perf_counter() - t0) * 1000)
     scored = [h["score"] for h in hits if h.get("score") is not None]
     stats = {
@@ -439,13 +564,17 @@ def search_with_stats(query: str, k: int = 3) -> tuple[str, dict]:
         "latency_ms": latency_ms,
         "top_score": round(min(scored), 3) if scored else None,
         "hybrid": hybrid_enabled(),
+        # WHICH keys were filtered on, never their values: a value can be as specific as a
+        # single kb_tag, and "this user filtered to fish_disease_and_treatment" is closer to
+        # the subject of their question than the shape of it.
+        "filtered": sorted(normalize_filters(filters) or {}) or None,
     }
     if not hits:
         return _NO_MATCH, stats
     return "\n\n".join(f"[source: {h['source']}]\n{h['text']}" for h in hits), stats
 
 
-def search(query: str, k: int = 3) -> str:
+def search(query: str, k: int = 3, filters: dict | None = None) -> str:
     """Return retrieved knowledge passages for `query`, each labeled with its source —
     citation is enforced here, not left to the model — or a clear 'no context' note."""
-    return search_with_stats(query, k=k)[0]
+    return search_with_stats(query, k=k, filters=filters)[0]

--- a/agronaut_agent/rag.py
+++ b/agronaut_agent/rag.py
@@ -14,16 +14,21 @@ import re
 # Maximum FAISS L2 distance a passage may have and still be offered to the model as context.
 # LOWER is closer; anything above this is treated as "nothing relevant matched".
 #
-# RE-CALIBRATED 2026-09-01 on the 3935-chunk corpus (was 1.65 at 1354 chunks).
-# `python -m scripts.retrieval_sweep --floor ...`, saved to retrieval_eval/sweep_2026_09.json:
+# RE-CALIBRATED 2026-09-01 on the 3941-chunk corpus (was 1.65 at 1354 chunks).
+# `python -m scripts.retrieval_sweep --all`, saved to retrieval_eval/sweep_2026_09.json:
 #
 #     floor  hit    recall  prec    MRR     MAP     silenced  rejected  headroom
-#     1.30   0.758  0.682   0.409   0.591   0.538   4         10/10     -0.083
-#     1.35   0.818  0.727   0.429   0.621   0.553   2         10/10     -0.033
-#     1.40   0.818  0.727   0.429   0.621   0.553   0         10/10      0.017
-#     1.45   0.818  0.727   0.434   0.636   0.568   0          8/10      0.067
-#     1.50   0.818  0.727   0.434   0.636   0.568   0          8/10      0.117   <- ships
-#     1.65   0.848  0.758   0.444   0.646   0.578   0          4/10      0.267
+#     1.30   0.788  0.773   0.333   0.581   0.568   4         10/10     -0.083
+#     1.35   0.848  0.818   0.354   0.611   0.583   2         10/10     -0.033
+#     1.40   0.848  0.818   0.354   0.611   0.583   0         10/10      0.017
+#     1.45   0.848  0.818   0.354   0.626   0.598   0          8/10      0.067
+#     1.50   0.879  0.833   0.364   0.636   0.604   0          8/10      0.117   <- ships
+#     1.65   0.909  0.879   0.384   0.646   0.624   0          4/10      0.267
+#
+# READ THAT TABLE HONESTLY: a LOOSER floor scores BETTER on every retrieval metric. 1.65 gets
+# hit 0.909 and MAP 0.624 against 1.50's 0.879 and 0.604. This change costs retrieval quality
+# and buys refusal, doubling 4/10 to 8/10. It is a safety trade, not an improvement, and the
+# per-source cap below is what pays for it (net, old config to new: hit 0.818 -> 0.879).
 #
 # THE BANDS HAVE SEPARATED, which is new and is what makes a tighter floor possible at all. At
 # 1354 chunks the worst on-topic distance (1.548) sat ABOVE the closest off-topic match (1.426)
@@ -35,10 +40,7 @@ import re
 # project already rejected a 0.032 margin as too thin ("a threefold cut in safety margin for one
 # extra rejection"), and 0.017 is half of that. The golden set has 33 queries; the 34th is the one
 # that matters, and headroom is all that protects it. 1.50 keeps 0.117, comparable to the 0.10
-# that reasoning accepted, and still doubles refusal from 4/10 to 8/10.
-#
-# The cost is real and is the honest half of this: hit_rate 0.848 -> 0.818 and MAP 0.578 -> 0.568
-# at this stage. The per-source cap below more than repays it (final: hit 0.879, MAP 0.624).
+# that reasoning accepted.
 #
 # This number is a property of THIS embedding model over THIS corpus and does not port.
 # `python -m scripts.retrieval_eval` reprints the separation on every run and says outright when
@@ -69,14 +71,20 @@ _RRF_K = 60
 #     0.90   0.848  0.788   0.495   0.692   0.636   <- shipped then
 #     dense  0.848  0.697   0.490   0.682   0.545
 #
-# RE-CONFIRMED 2026-09-01 at 3935 chunks, under floor 1.50 and cap 1 — the one constant the corpus
-# growth did NOT move:
+# RE-CONFIRMED 2026-09-01 at 3941 chunks, under floor 1.50 and cap 1 — the one constant the
+# corpus growth did NOT move:
 #
-#     beta   hit    recall  prec    MRR     MAP      (3935 chunks)
-#     0.50   0.879  0.788   0.333   0.601   0.558
-#     0.70   0.879  0.803   0.343   0.606   0.571
-#     0.90   0.879  0.833   0.364   0.657   0.624   <- ships
-#     1.00   0.848  0.803   0.354   0.662   0.621    (dense-only)
+#     beta   hit    recall  prec    MRR     MAP      (3941 chunks)
+#     0.50   0.879  0.788   0.333   0.591   0.548
+#     0.70   0.879  0.803   0.343   0.601   0.566
+#     0.90   0.879  0.833   0.364   0.636   0.604   <- ships
+#     1.00   0.848  0.803   0.354   0.646   0.606    (dense-only, hybrid OFF)
+#
+# NOTE THE TRAP IN THAT LAST ROW. Dense-only shows the highest MAP, by 0.002. A strict argmax
+# would turn hybrid search off on that, while hit_rate and recall each fall by ~0.030 — fifteen
+# times the size of the "win". With 33 queries, one flipping moves hit_rate by 0.030, so 0.002 is
+# noise with a decimal point. scripts/retrieval_sweep.py now re-ranks inside a 0.01 noise band on
+# hit_rate for exactly this reason.
 #
 # Note how LITTLE keyword weight is right: 10%. Enough to break ties a book would otherwise win on
 # volume, not enough to let common aquaponics vocabulary dominate the ranking. At 0.5 — the
@@ -167,7 +175,7 @@ def hybrid_enabled() -> bool:
     of targeted operator guidance is precisely the situation a keyword signal is for: it breaks
     ties that dense similarity resolves by volume.
 
-    RE-CONFIRMED 2026-09-01 at 3935 chunks: still on, still beta=0.90, and now measurably ahead of
+    RE-CONFIRMED 2026-09-01 at 3941 chunks: still on, still beta=0.90, and now measurably ahead of
     dense-only on hit_rate as well (0.879 vs 0.848). Disable with AGRONAUT_HYBRID=off.
     """
     return os.getenv("AGRONAUT_HYBRID", "").lower() not in {"off", "0", "false"}
@@ -223,22 +231,23 @@ _POOL = 20      # candidates drawn from each retriever before fusion
 # materially less irrelevant context (precision 0.540 vs 0.404), and still let a source with real
 # depth contribute twice.
 #
-# There are now TWO. Goddek et al. (2019) added 2576 chunks, so 3853 of 3935 chunks are books and
-# the curated files are 2% of the corpus. cap=2 lets books take two of three slots, which is the
+# There are now TWO. Goddek et al. (2019) added 2576 chunks, so 3848 of 3941 chunks are books and
+# the curated files are 2.4% of the corpus. cap=2 lets books take two of three slots, which is the
 # same failure the cap was built to stop, arriving through a door the cap left open.
 #
-# Measured (3935-chunk corpus, floor 1.50, hybrid on) — retrieval_eval/sweep_2026_09.json:
+# Measured (3941-chunk corpus, floor 1.50, hybrid on) — retrieval_eval/sweep_2026_09.json:
 #
 #     cap    hit    recall  prec    MRR     MAP
-#     1      0.879  0.833   0.364   0.657   0.624   <- ships
-#     2      0.818  0.727   0.434   0.636   0.568
-#     3      0.697  0.621   0.374   0.576   0.515
-#     none   0.697  0.621   0.374   0.576   0.515
+#     1      0.879  0.833   0.364   0.636   0.604   <- ships
+#     2      0.788  0.697   0.419   0.606   0.538
+#     3      0.667  0.591   0.359   0.545   0.485
+#     none   0.667  0.591   0.359   0.545   0.485
 #
-# The gap that decided it widened by roughly four times. At 1354 chunks cap=1 bought +0.031 hit
-# and +0.025 recall over cap=2; here it buys +0.061 hit and +0.106 recall, and +0.056 MAP.
+# THIS is the change that carries the re-calibration. The deciding gap widened roughly fourfold:
+# at 1354 chunks cap=1 bought +0.031 hit and +0.025 recall over cap=2; here it buys +0.091 hit
+# and +0.136 recall, and +0.066 MAP.
 #
-# Precision still falls (0.434 -> 0.364) and that is still partly a metric artefact: `relevant` is
+# Precision still falls (0.419 -> 0.364) and that is still partly a metric artefact: `relevant` is
 # labelled at DOCUMENT granularity, so cap=1 caps precision@3 at 0.333 for any query with one
 # relevant document however good the answer is. What is NOT an artefact is recall and MAP, which
 # both move decisively the other way. When the honest and the artefactual disagree this sharply,
@@ -363,7 +372,7 @@ def retrieve(query: str, k: int = 3, max_dist: float | None = None,
         if filters:
             # fetch_k over-fetches BEFORE filtering, so it must be generous: FAISS takes the
             # nearest fetch_k, drops those the filter rejects, and only then keeps k. Left at
-            # its default of 20, a narrow filter over a 3935-chunk corpus would usually find
+            # its default of 20, a narrow filter over a 3941-chunk corpus would usually find
             # nothing in the top 20 and return empty for a query the corpus can answer well.
             pairs = index.similarity_search_with_score(
                 query, k=max(_POOL, k * 2),
@@ -449,7 +458,7 @@ def rerank_enabled() -> bool:
     the model.
 
     THE TABLE ABOVE WAS MEASURED AT 1354 CHUNKS and has NOT been re-run since the corpus reached
-    3935. Unlike the floor and the cap, this decision was not re-measured on 2026-09-01, because
+    3941. Unlike the floor and the cap, this decision was not re-measured on 2026-09-01, because
     a technique that lost on every metric and tripled latency does not become the priority when
     the corpus grows. It is recorded as stale rather than quietly presented as current — re-run
     `AGRONAUT_RERANK=on python -m scripts.retrieval_eval` before trusting either verdict.

--- a/agronaut_agent/runtime.py
+++ b/agronaut_agent/runtime.py
@@ -3,11 +3,22 @@
 handle_message() sets the current (MemoryStore, user_id) before running the tool loop; the
 memory tools read it. A ContextVar keeps this correct under the bot's worker-thread model
 (one in-flight message per thread) without threading user_id through every tool signature.
+
+The same mechanism carries the TURN TRACE. Analytics events were previously independent
+counter rows: a `message`, a `retrieval` and three `tool_call` rows landed in the log with
+nothing tying them to each other, so "this answer was slow" could never be resolved into
+"because retrieval returned nothing and the model then called four tools". A per-turn id
+that every event in the turn carries is the whole difference between counting and tracing.
+
+The id is minted per TURN, not per user: a fresh random token each time, never derived from
+the user id and never persisted alongside anything identifying. It links rows within one
+turn and says nothing about who produced them.
 """
 
 from __future__ import annotations
 
 import contextvars
+import uuid
 
 _current = contextvars.ContextVar("agronaut_current", default=None)
 _followups = contextvars.ContextVar("agronaut_followups", default=None)
@@ -15,6 +26,8 @@ _community = contextvars.ContextVar("agronaut_community", default=None)
 _calibration = contextvars.ContextVar("agronaut_calibration", default=None)
 _readings = contextvars.ContextVar("agronaut_readings", default=None)
 _attachments = contextvars.ContextVar("agronaut_attachments", default=None)
+_trace = contextvars.ContextVar("agronaut_trace", default=None)
+_metrics = contextvars.ContextVar("agronaut_metrics", default=None)
 
 
 def set_current(memory_store, user_id: str, followups=None, community=None,
@@ -71,3 +84,65 @@ def get_calibration():
 def get_readings():
     """Return the ReadingStore for the in-flight message, or None if unset."""
     return _readings.get()
+
+
+# --- turn tracing -------------------------------------------------------------
+
+def start_turn() -> bool:
+    """Open a traced turn. Returns True if THIS call opened it, meaning the caller owns
+    ending it; False if a turn was already in flight and this call joins it.
+
+    The join case is not an edge case. A photo turn calls handle_message() internally, and
+    a voice turn does too. Without joining, the inner call would mint a second id and one
+    photo would appear in the log as two unrelated turns, which is precisely the confusion
+    tracing exists to remove.
+    """
+    if _trace.get():
+        return False
+    _trace.set(uuid.uuid4().hex[:12])
+    _metrics.set({"llm_calls": 0, "llm_ms": 0, "tokens_in": 0, "tokens_out": 0,
+                  "tool_calls": 0, "usage_seen": False})
+    return True
+
+
+def end_turn() -> None:
+    """Close the traced turn. Only the caller that opened it should call this."""
+    _trace.set(None)
+    _metrics.set(None)
+
+
+def trace_id() -> str | None:
+    """The current turn's trace id, or None outside a turn."""
+    return _trace.get()
+
+
+def record_llm_call(latency_ms: int, tokens_in=None, tokens_out=None) -> None:
+    """Accumulate one model call into the turn's totals.
+
+    Token counts are optional because they are genuinely optional: not every provider
+    returns usage metadata, and a missing count must stay missing rather than be recorded
+    as a zero that would quietly understate real cost in every aggregate.
+    """
+    m = _metrics.get()
+    if m is None:
+        return
+    m["llm_calls"] += 1
+    m["llm_ms"] += int(latency_ms)
+    if tokens_in is not None:
+        m["tokens_in"] += int(tokens_in)
+        m["usage_seen"] = True
+    if tokens_out is not None:
+        m["tokens_out"] += int(tokens_out)
+        m["usage_seen"] = True
+
+
+def record_tool_call() -> None:
+    """Count one tool invocation into the turn's totals."""
+    m = _metrics.get()
+    if m is not None:
+        m["tool_calls"] += 1
+
+
+def turn_metrics() -> dict:
+    """Totals accumulated during the current turn; {} outside a turn."""
+    return dict(_metrics.get() or {})

--- a/agronaut_agent/tests/test_faithfulness_eval.py
+++ b/agronaut_agent/tests/test_faithfulness_eval.py
@@ -1,0 +1,173 @@
+"""Generation-quality metrics — the arithmetic, hermetically.
+
+scripts/faithfulness_eval.py needs a model to produce judgements, but the scoring built on top
+of those judgements must not. These tests pin the parts that decide what a score MEANS, with
+fake judges standing in for the real one, so a regression in the accounting is caught in CI even
+though the eval itself never runs there.
+
+The recurring theme is refusing to average unlike things:
+  - an unparseable verdict is UNJUDGED, not a failure,
+  - an uncited answer has NO citation accuracy, not a zero,
+  - a metric that could not be computed for a query is absent from its mean, not counted.
+
+Each of those, done the other way, produces a number that looks like a measurement and is not.
+"""
+
+from scripts import faithfulness_eval as fe
+
+# --- claim extraction --------------------------------------------------------
+
+def test_claims_parse_from_the_three_list_shapes_models_emit():
+    text = "Here are the claims:\n1. pH should sit near 6.8\n- Nitrite must read zero\n* DO above 5"
+    assert fe.parse_claims(text) == ["pH should sit near 6.8", "Nitrite must read zero",
+                                     "DO above 5"]
+
+
+def test_preamble_and_blank_lines_are_not_claims():
+    assert fe.parse_claims("Sure! Here you go:\n\n1. one claim\n\n") == ["one claim"]
+
+
+def test_no_list_yields_no_claims():
+    assert fe.parse_claims("I could not identify any claims.") == []
+
+
+# --- verdict parsing ---------------------------------------------------------
+
+def test_unsupported_is_read_before_supported():
+    """UNSUPPORTED contains SUPPORTED. Testing the positive label first would turn every
+    rejection into an acceptance and silently invert the whole metric."""
+    assert fe.parse_verdict("UNSUPPORTED") is False
+    assert fe.parse_verdict("SUPPORTED") is True
+
+
+def test_a_judge_that_explains_itself_still_parses():
+    assert fe.parse_verdict("UNSUPPORTED - the context never mentions nitrite") is False
+    assert fe.parse_verdict("supported, the passage states it directly") is True
+
+
+def test_an_unparseable_verdict_is_unjudged_not_a_failure():
+    for junk in ("maybe?", "", "I'm not sure", None):
+        assert fe.parse_verdict(junk) is None
+
+
+def test_unjudged_claims_are_excluded_from_the_score_and_counted():
+    out = fe.faithfulness_score([True, True, False, None])
+    assert out["score"] == 2 / 3           # over the JUDGED claims only
+    assert out["n_claims"] == 4 and out["n_judged"] == 3 and out["n_unjudged"] == 1
+
+
+def test_no_judgeable_claims_scores_none_not_zero():
+    """A judge that failed entirely must report 'no measurement'. A confident 0.0 would read
+    as a system that hallucinates everything."""
+    assert fe.faithfulness_score([None, None])["score"] is None
+    assert fe.faithfulness_score([])["score"] is None
+
+
+# --- citations ---------------------------------------------------------------
+
+def test_cited_sources_are_deduplicated_in_order():
+    ans = "Shade it [source: knowledge/algae_control.md]. Also [source: knowledge/algae_control.md]."
+    assert fe.cited_sources(ans) == ["knowledge/algae_control.md"]
+
+
+def test_a_fabricated_citation_is_detected_and_named():
+    ans = "[source: knowledge/algae_control.md] and [source: knowledge/invented.md]"
+    score, bogus = fe.citation_accuracy(ans, ["knowledge/algae_control.md"])
+    assert score == 0.5 and bogus == ["knowledge/invented.md"]
+
+
+def test_an_uncited_answer_has_no_score_rather_than_zero():
+    """Uncited and miscited are different failures. Averaging 'no citations' in as 0.0 makes an
+    under-citing system indistinguishable from a lying one."""
+    score, bogus = fe.citation_accuracy("Just shade the tank.", ["knowledge/algae_control.md"])
+    assert score is None and bogus == []
+
+
+def test_all_citations_real_scores_one():
+    score, bogus = fe.citation_accuracy("[source: a] [source: b]", ["a", "b", "c"])
+    assert score == 1.0 and bogus == []
+
+
+# --- similarity --------------------------------------------------------------
+
+def test_cosine_is_one_for_identical_and_zero_for_orthogonal():
+    assert fe.cosine([1, 0], [1, 0]) == 1.0
+    assert fe.cosine([1, 0], [0, 1]) == 0.0
+
+
+def test_cosine_of_a_zero_vector_is_zero_not_an_exception():
+    assert fe.cosine([0, 0], [1, 1]) == 0.0
+
+
+# --- aggregation -------------------------------------------------------------
+
+def test_each_metric_averages_only_over_the_queries_that_produced_it():
+    per_query = [
+        {"faithfulness": 1.0, "response_relevancy": 0.9, "citation_accuracy": 1.0,
+         "n_unjudged": 0, "fabricated": []},
+        {"faithfulness": 0.5, "response_relevancy": None, "citation_accuracy": None,
+         "n_unjudged": 2, "fabricated": ["knowledge/ghost.md"]},
+    ]
+    s = fe.aggregate(per_query)
+    assert s["queries"] == 2
+    assert s["faithfulness"] == {"mean": 0.75, "n": 2}
+    assert s["response_relevancy"] == {"mean": 0.9, "n": 1}   # the None is not a zero
+    assert s["citation_accuracy"] == {"mean": 1.0, "n": 1}
+    assert s["claims_unjudged"] == 2 and s["fabricated_citations"] == 1
+
+
+def test_aggregate_of_nothing_reports_none_not_zero():
+    s = fe.aggregate([])
+    assert s["queries"] == 0 and s["faithfulness"]["mean"] is None
+
+
+# --- the scoring path, end to end with fakes ---------------------------------
+
+def _fake_ask(prompt: str) -> str:
+    """A judge that supports the algae claim and rejects the invented nitrite one.
+
+    It reads the CLAIM section rather than the whole prompt: the context also says "algae
+    bloom", so a substring test over the full prompt would mark BOTH claims supported and the
+    fake would quietly agree with whatever it was given.
+    """
+    if prompt.startswith("Break the ANSWER"):
+        return "1. Green water is an algae bloom\n2. Tilapia need 30 mg/l of nitrite"
+    if prompt.startswith("Decide whether"):
+        claim = prompt.split("CLAIM:", 1)[1]
+        return "SUPPORTED" if "algae bloom" in claim else "UNSUPPORTED"
+    return "1. What is green water?\n2. Why is my water green?"
+
+
+def _fake_embed(text: str):
+    return [1.0, 0.0] if "green" in text.lower() else [0.0, 1.0]
+
+
+def test_score_query_catches_the_claim_the_context_does_not_support():
+    """The metric's whole purpose: an answer whose second sentence is invented scores 0.5, even
+    though retrieval succeeded and the answer reads fluently."""
+    row = fe.score_query(
+        query="why is my water green",
+        answer="Green water is an algae bloom [source: knowledge/algae_control.md]. "
+               "Tilapia need 30 mg/l of nitrite [source: knowledge/ghost.md].",
+        context="[source: knowledge/algae_control.md]\nGreen water is an algae bloom.",
+        retrieved=["knowledge/algae_control.md"],
+        ask=_fake_ask, embed=_fake_embed)
+    assert row["faithfulness"] == 0.5
+    assert row["n_claims"] == 2 and row["n_unjudged"] == 0
+    assert row["citation_accuracy"] == 0.5
+    assert row["fabricated"] == ["knowledge/ghost.md"]
+    assert row["response_relevancy"] == 1.0
+
+
+def test_a_failing_relevancy_judge_does_not_void_the_other_metrics(capsys):
+    def _ask(prompt: str) -> str:
+        if prompt.startswith("Read the ANSWER"):
+            raise RuntimeError("judge unavailable")
+        return _fake_ask(prompt)
+
+    row = fe.score_query("why is my water green",
+                         "Green water is an algae bloom [source: knowledge/algae_control.md].",
+                         "Green water is an algae bloom.", ["knowledge/algae_control.md"],
+                         ask=_ask, embed=_fake_embed)
+    assert row["response_relevancy"] is None
+    assert row["faithfulness"] == 0.5 and row["citation_accuracy"] == 1.0

--- a/agronaut_agent/tests/test_feedback.py
+++ b/agronaut_agent/tests/test_feedback.py
@@ -35,7 +35,7 @@ def agent(tmp_path, monkeypatch):
 
 def _rows(agent):
     p = agent._analytics.path
-    return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+    return [json.loads(line) for line in p.read_text().splitlines()] if p.exists() else []
 
 
 def test_thumbs_up_and_down_record_opposite_ratings(agent):

--- a/agronaut_agent/tests/test_feedback.py
+++ b/agronaut_agent/tests/test_feedback.py
@@ -1,0 +1,80 @@
+"""Thumbs up/down — the one quality signal that comes from the person who was actually helped.
+
+Code-based evaluators say the retriever found the right file. An LLM judge says the answer used
+it. Neither can say the operator got what they needed, and the course puts human feedback in its
+own row for exactly that reason.
+
+The design constraint is that this is the closest analytics ever comes to an opinion, so it must
+stay a bare rating: no comment field, no free text, nothing that could carry what was said.
+"""
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from agronaut_agent.analytics import Analytics
+from agronaut_agent.core import AgronautAgent
+
+
+class _Chatty:
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        return AIMessage(content="Shade the tank and cut the photoperiod.")
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGRONAUT_ANALYTICS_PATH", str(tmp_path / "a.jsonl"))
+    a = AgronautAgent(chat_model=_Chatty(), db_path=str(tmp_path / "db.sqlite"))
+    a._analytics = Analytics(path=tmp_path / "a.jsonl")
+    return a
+
+
+def _rows(agent):
+    p = agent._analytics.path
+    return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+
+def test_thumbs_up_and_down_record_opposite_ratings(agent):
+    agent.record_feedback("test", "u1", True)
+    agent.record_feedback("test", "u1", False)
+    ratings = [r["rating"] for r in _rows(agent) if r["event"] == "feedback"]
+    assert ratings == [1, -1]
+
+
+def test_feedback_acknowledges_the_person(agent):
+    assert "thank you" in agent.record_feedback("test", "u1", True).lower()
+    assert agent.record_feedback("test", "u1", False) != agent.record_feedback("test", "u1", True)
+
+
+def test_feedback_is_attributed_to_the_user_only_as_a_hash(agent):
+    agent.record_feedback("test", "telegram:123456789", True)
+    row = [r for r in _rows(agent) if r["event"] == "feedback"][0]
+    assert row["uid"] and "123456789" not in json.dumps(row)
+
+
+def test_feedback_cannot_carry_a_written_comment(agent):
+    """The allowlist is the guarantee, not the calling convention. Even a caller that invents a
+    comment field must not be able to persist it."""
+    agent._analytics.record("feedback", user_id="u1", rating=-1,
+                            comment="the numbers for my tank in Bobo were wrong")
+    row = [r for r in _rows(agent) if r["event"] == "feedback"][0]
+    assert "comment" not in row and "Bobo" not in json.dumps(row)
+
+
+def test_summary_reports_the_positive_share(agent):
+    for positive in (True, True, True, False):
+        agent.record_feedback("test", "u1", positive)
+    assert agent._analytics.summarize()["feedback"] == {"up": 3, "down": 1}
+
+
+def test_feedback_is_not_a_turn_and_does_not_pollute_latency(agent):
+    """A rating is not a pipeline run. Counting it as a turn would put a ~0 ms row into the
+    latency distribution and quietly drag the p50 down."""
+    agent.handle_message("test", "u1", "why is my water green")
+    agent.record_feedback("test", "u1", True)
+    s = agent._analytics.summarize()
+    assert s["latency"]["turn"]["n"] == 1

--- a/agronaut_agent/tests/test_metadata_filtering.py
+++ b/agronaut_agent/tests/test_metadata_filtering.py
@@ -1,0 +1,168 @@
+"""Metadata filtering — the third leg of hybrid retrieval.
+
+The course (M2) is precise about what this is and is not: it "doesn't perform retrieval, it
+narrows down results from other techniques", it is rigid rather than ranked, and it is useless
+alone. So the tests are about EXCLUSION being exact and being applied in the right place, not
+about relevance.
+
+Two properties matter more than the rest:
+
+  - passing no filter must leave behaviour byte-identical to before filtering existed, because
+    every retrieval number this project has recorded was measured without one,
+  - a chunk that LACKS the filtered key must be excluded, not admitted. Admitting it is how
+    "only FAO chapter 8" quietly returns the entire markdown corpus.
+"""
+
+import pytest
+
+from agronaut_agent import rag
+
+# --- the predicate -----------------------------------------------------------
+
+def test_scalar_clause_matches_exactly():
+    assert rag._matches({"kb_tag": "ph_and_alkalinity"}, {"kb_tag": "ph_and_alkalinity"})
+    assert not rag._matches({"kb_tag": "algae_control"}, {"kb_tag": "ph_and_alkalinity"})
+
+
+def test_collection_clause_is_membership():
+    md = {"kb_tag": "algae_control"}
+    assert rag._matches(md, {"kb_tag": ["algae_control", "water_source_and_treatment"]})
+    assert not rag._matches(md, {"kb_tag": ["ph_and_alkalinity"]})
+
+
+def test_clauses_are_conjunctive():
+    """Filters narrow. Two clauses must both hold, or the filter would widen as it grew."""
+    md = {"source_type": "local_file", "kb_tag": "algae_control"}
+    assert rag._matches(md, {"source_type": "local_file", "kb_tag": "algae_control"})
+    assert not rag._matches(md, {"source_type": "local_file", "kb_tag": "feed_and_feeding"})
+
+
+def test_missing_key_is_excluded_not_admitted():
+    """The direction that matters. A markdown chunk has no `chapter`; filtering on chapter must
+    drop it rather than pass it through for having nothing to disagree with."""
+    assert not rag._matches({"source_type": "local_file"}, {"chapter": "8"})
+
+
+def test_values_compare_across_str_and_int():
+    """`page` arrives as an int from the PDF loader and as a string from a CLI or JSON caller.
+    A filter that silently matched neither would look like an empty corpus."""
+    assert rag._matches({"page": 51}, {"page": "51"})
+    assert rag._matches({"page": "51"}, {"page": 51})
+
+
+# --- validation --------------------------------------------------------------
+
+def test_unknown_keys_are_dropped_with_a_warning(caplog):
+    """A typo costs precision, never the answer: an operator's question must not fail because
+    a caller wrote `kb_tags`."""
+    out = rag.normalize_filters({"kb_tag": "algae_control", "kb_tags": "oops"})
+    assert out == {"kb_tag": "algae_control"}
+    assert "kb_tags" in caplog.text
+
+
+def test_empty_and_all_unknown_normalize_to_none():
+    assert rag.normalize_filters(None) is None
+    assert rag.normalize_filters({}) is None
+    assert rag.normalize_filters({"nonsense": 1}) is None
+
+
+# --- placement in the pipeline ----------------------------------------------
+
+class _Doc:
+    def __init__(self, text, meta):
+        self.page_content = text
+        self.metadata = meta
+
+
+class _FakeIndex:
+    """A FAISS stand-in with the two behaviours retrieve() depends on: a callable metadata
+    filter applied before the top-k cut, and a docstore BM25 can be built over."""
+
+    def __init__(self, docs_scores):
+        self._docs_scores = docs_scores
+        self.docstore = type("D", (), {"_dict": {i: d for i, (d, _s) in enumerate(docs_scores)}})()
+
+    def similarity_search_with_score(self, query, k=4, filter=None, fetch_k=20):
+        pairs = [(d, s) for d, s in self._docs_scores if filter is None or filter(d.metadata)]
+        return sorted(pairs, key=lambda p: p[1])[:k]
+
+
+@pytest.fixture
+def index(monkeypatch):
+    # Passages run past 200 characters on purpose: srcs.chatbot._is_boilerplate_text treats
+    # anything shorter as furniture, and retrieve() applies that filter before this one. A
+    # fixture of one-liners would test the boilerplate rule rather than the metadata rule.
+    docs = [
+        (_Doc("Green water is a suspended algae bloom and it is fed by light plus dissolved "
+              "nutrient. Shade the fish tank and any exposed sump, cut the photoperiod on "
+              "supplementary lighting, and keep the beds planted so the crop competes for the "
+              "nitrate the algae are living on.",
+              {"source_type": "local_file", "source_path": "knowledge/algae_control.md",
+               "kb_tag": "algae_control"}), 0.5),
+        (_Doc("Alkalinity is the buffer that holds pH against the acid load nitrification "
+              "produces. When carbonate hardness falls the pH stops drifting down slowly and "
+              "starts crashing between checks, so top up with a carbonate or hydroxide base "
+              "rather than chasing the pH number itself.",
+              {"source_type": "local_file", "source_path": "knowledge/ph_and_alkalinity.md",
+               "kb_tag": "ph_and_alkalinity"}), 0.7),
+        (_Doc("Design of aquaponic units. Algae growth on exposed water surfaces reduces the "
+              "oxygen available overnight and competes with the crop for nutrient. Unit design "
+              "should therefore minimise open, illuminated water between the fish tank and the "
+              "grow beds wherever the climate allows it.",
+              {"source_type": "web", "url_label": "FAO 589", "chapter": "Design of aquaponic units",
+               "page": 51}), 0.9),
+    ]
+    idx = _FakeIndex(docs)
+    monkeypatch.setattr(rag, "_get_index", lambda: idx)
+    monkeypatch.setattr(rag, "_get_bm25", lambda: None)   # dense-only: isolate the filter
+    return idx
+
+
+def test_no_filter_returns_everything_as_before(index):
+    hits = rag.retrieve("algae", k=3)
+    assert len(hits) == 3
+
+
+def test_filter_restricts_to_the_named_source_type(index):
+    hits = rag.retrieve("algae", k=3, filters={"source_type": "local_file"})
+    assert {h["source"] for h in hits} == {"knowledge/algae_control.md",
+                                           "knowledge/ph_and_alkalinity.md"}
+
+
+def test_filter_can_isolate_a_single_topic_file(index):
+    hits = rag.retrieve("algae", k=3, filters={"kb_tag": "algae_control"})
+    assert [h["source"] for h in hits] == ["knowledge/algae_control.md"]
+
+
+def test_filter_on_a_pdf_chapter_excludes_markdown(index):
+    hits = rag.retrieve("algae", k=3, filters={"chapter": "Design of aquaponic units"})
+    assert [h["source"] for h in hits] == ["FAO 589"]
+
+
+def test_filter_that_matches_nothing_returns_empty_not_everything(index):
+    """The failure mode worth a test of its own: a filter with no matches must return nothing,
+    never fall back to the unfiltered ranking."""
+    assert rag.retrieve("algae", k=3, filters={"kb_tag": "no_such_file"}) == []
+
+
+def test_filter_is_applied_to_the_keyword_pool_too(monkeypatch, index):
+    """Filtering only the dense pool would let BM25 reintroduce excluded chunks through fusion,
+    which is exactly the leak the course's per-list filter diagram avoids."""
+    docs = [d for d, _s in index._docs_scores]
+
+    class _BM25:
+        def get_scores(self, tokens):
+            return [0.0, 0.0, 9.9]        # the FAO chunk wins on keywords
+
+    monkeypatch.setattr(rag, "_get_bm25", lambda: (_BM25(), docs))
+    hits = rag.retrieve("algae", k=3, hybrid=True, filters={"source_type": "local_file"})
+    assert "FAO 589" not in {h["source"] for h in hits}
+
+
+def test_stats_record_which_keys_were_filtered_never_their_values(index):
+    """A filter VALUE can be as specific as one topic file, which is closer to the subject of
+    the question than to its shape. Only the key names may be recorded."""
+    _text, stats = rag.search_with_stats("algae", k=3,
+                                         filters={"kb_tag": "algae_control"})
+    assert stats["filtered"] == ["kb_tag"]
+    assert "algae_control" not in str(stats)

--- a/agronaut_agent/tests/test_relevance_floor.py
+++ b/agronaut_agent/tests/test_relevance_floor.py
@@ -78,9 +78,35 @@ def test_env_override_and_off_switch(monkeypatch):
     assert rag.max_distance() == rag._DEFAULT_MAX_DISTANCE
 
 
-def test_floor_default_sits_between_the_measured_bands():
-    """The default is only meaningful if it lies inside the gap measured on the golden set:
-    worst on-topic 1.554, closest off-topic 1.717."""
-    assert 1.554 < rag._DEFAULT_MAX_DISTANCE < 1.717
+# Band edges measured on the 3935-chunk corpus, 2026-09-01 (retrieval_eval/sweep_2026_09.json).
+# At 1354 chunks these were 1.548 and 1.426 — OVERLAPPING, so no floor could separate them. More
+# corpus pulled the on-topic band in: every real question now has a closer match than it did.
+_WORST_ON_TOPIC = 1.383
+_CLOSEST_OFF_TOPIC = 1.411
+_MIN_HEADROOM = 0.10       # the margin this project accepted when it rejected a 0.032 one
+
+
+def test_floor_default_keeps_the_measured_safety_margin():
+    """The default must clear the worst REAL query by the margin this project settled on.
+
+    Deliberately not "sits inside the gap between the bands". The bands are now separable
+    (1.383 < 1.411) and a floor of 1.40 would sit in that gap and reject all ten controls — but it
+    would clear the worst real query by 0.017, half the margin that was already judged too thin.
+    The property that must hold is headroom above real queries, not tightness against off-topic
+    ones, so that is what this asserts.
+    """
+    assert rag._DEFAULT_MAX_DISTANCE >= _WORST_ON_TOPIC + _MIN_HEADROOM
+
+
+def test_floor_default_is_tighter_than_the_pre_drift_value():
+    """The bands separated when the corpus grew, so the floor could be tightened from 1.65. If
+    this ever fails upward again, the corpus moved and the sweep needs re-running."""
+    assert rag._DEFAULT_MAX_DISTANCE < 1.65
+
+
+def test_the_bands_are_recorded_as_separable():
+    """A guard on the premise. If these two ever cross again the floor's whole justification
+    changes, and `scripts/retrieval_eval` prints OVERLAPPING instead of separable."""
+    assert _WORST_ON_TOPIC < _CLOSEST_OFF_TOPIC
 
 

--- a/agronaut_agent/tests/test_retrieval_sweep.py
+++ b/agronaut_agent/tests/test_retrieval_sweep.py
@@ -1,0 +1,106 @@
+"""The sweep's decision rules, hermetically.
+
+`scripts/retrieval_sweep.py` needs an index and an embedding model to produce a table, but the
+rules that turn a table into a shipped constant must not. Those rules are the whole point of the
+script: a sweep that only prints numbers leaves the judgement call to whoever reads it, and the
+judgement call is where this project has twice gone wrong.
+
+The rule under test is the floor picker, and its non-obvious half is the headroom constraint.
+Maximising off-topic rejections alone picks 1.40 on the real corpus — a value that clears the
+worst of 33 real queries by 0.017 and would refuse the 34th. These tests pin the rule that
+rejects it.
+"""
+
+import pytest
+
+from scripts import retrieval_sweep as sw
+
+
+def _row(value, silenced=0, rejected=8, hit=0.879, headroom=0.117, **kw):
+    row = {"value": value, "silenced_on_topic": silenced, "rejected_off_topic": rejected,
+           "negative_controls": 10, "hit_rate": hit, "recall@k": 0.833, "precision@k": 0.364,
+           "MRR": 0.657, "MAP@k": 0.624, "headroom": headroom}
+    row.update(kw)
+    return row
+
+
+# --- the floor picker --------------------------------------------------------
+
+def test_a_floor_that_silences_a_real_query_is_never_chosen():
+    """The hard constraint. A refused real question is a worse failure than an answered
+    off-topic one, so no rejection count can buy its way past this."""
+    rows = [_row(1.30, silenced=4, rejected=10, headroom=0.5),
+            _row(1.50, silenced=0, rejected=8)]
+    assert sw.pick_floor(rows)["value"] == 1.50
+
+
+def test_thin_headroom_is_rejected_even_when_it_refuses_every_control():
+    """The real case, and the one a metric-maximising picker gets wrong. 1.40 silences nothing
+    across all 33 golden queries and refuses 10/10 off-topic — and is still the wrong answer,
+    because 0.017 of margin is half of what this project already called too thin."""
+    rows = [_row(1.40, rejected=10, headroom=0.017),
+            _row(1.50, rejected=8, headroom=0.117)]
+    assert sw.pick_floor(rows)["value"] == 1.50
+
+
+def test_among_safe_floors_the_one_refusing_most_off_topic_wins():
+    rows = [_row(1.50, rejected=8, headroom=0.117),
+            _row(1.65, rejected=4, headroom=0.267)]
+    assert sw.pick_floor(rows)["value"] == 1.50
+
+
+def test_ties_break_toward_more_headroom_not_tighter():
+    """1.45 and 1.50 score identically on every metric on the real corpus. The looser one is
+    strictly safer and costs nothing, so a tie must never be broken toward tightness."""
+    rows = [_row(1.45, rejected=8, headroom=0.107),
+            _row(1.50, rejected=8, headroom=0.117)]
+    assert sw.pick_floor(rows)["value"] == 1.50
+
+
+def test_no_viable_floor_returns_none_rather_than_the_least_bad():
+    """When nothing satisfies both constraints the caller must keep the shipped value. Returning
+    a best-of-a-bad-set would ship a floor that silences real questions."""
+    rows = [_row(1.30, silenced=2, headroom=0.4), _row(1.35, silenced=1, headroom=0.02)]
+    assert sw.pick_floor(rows) is None
+
+
+def test_a_missing_headroom_field_is_treated_as_unsafe():
+    """Absent evidence is not evidence of safety. A row without a measured headroom must not
+    satisfy the headroom constraint by default."""
+    rows = [{"value": 1.4, "silenced_on_topic": 0, "rejected_off_topic": 10,
+             "negative_controls": 10, "hit_rate": 0.9}]
+    assert sw.pick_floor(rows) is None
+
+
+def test_hit_rate_breaks_a_rejection_tie_before_headroom_does():
+    rows = [_row(1.50, rejected=8, hit=0.879, headroom=0.117),
+            _row(1.55, rejected=8, hit=0.700, headroom=0.167)]
+    assert sw.pick_floor(rows)["value"] == 1.50
+
+
+# --- the cap / beta picker ---------------------------------------------------
+
+def test_metric_picker_maximises_the_named_metric():
+    rows = [_row(1, **{"MAP@k": 0.624}), _row(2, **{"MAP@k": 0.568})]
+    assert sw.pick_by(rows, "MAP@k")["value"] == 1
+
+
+def test_metric_picker_breaks_ties_on_hit_rate():
+    rows = [_row(1, hit=0.818, **{"MAP@k": 0.6}), _row(2, hit=0.879, **{"MAP@k": 0.6})]
+    assert sw.pick_by(rows, "MAP@k")["value"] == 2
+
+
+# --- the constant the rules depend on ----------------------------------------
+
+def test_min_headroom_matches_the_margin_the_project_accepted():
+    """0.10 is not a taste. It is the margin the original floor calibration chose when it
+    rejected a 0.032 alternative as 'a threefold cut in safety margin'. If this constant is ever
+    lowered, that recorded reasoning is being overruled and should be re-argued in writing."""
+    assert sw._MIN_HEADROOM == 0.10
+
+
+@pytest.mark.parametrize("kind", ["floor", "cap", "beta"])
+def test_every_swept_constant_has_a_default_ladder(kind):
+    """A sweep with no candidates silently succeeds and reports nothing, which reads exactly like
+    a sweep that found no change."""
+    assert len(getattr(sw, f"_{kind.upper()}S")) >= 3

--- a/agronaut_agent/tests/test_retrieval_sweep.py
+++ b/agronaut_agent/tests/test_retrieval_sweep.py
@@ -104,3 +104,33 @@ def test_every_swept_constant_has_a_default_ladder(kind):
     """A sweep with no candidates silently succeeds and reports nothing, which reads exactly like
     a sweep that found no change."""
     assert len(getattr(sw, f"_{kind.upper()}S")) >= 3
+
+
+# --- the noise band ----------------------------------------------------------
+
+def test_a_sub_noise_metric_win_does_not_decide():
+    """The real case this constant was added for. On the shipped corpus beta=1.0 (hybrid OFF)
+    beat beta=0.9 by 0.002 MAP while losing 0.031 hit_rate and 0.030 recall. A strict argmax
+    turns a whole retrieval technique off on a rounding difference."""
+    rows = [_row(0.9, hit=0.879, **{"MAP@k": 0.604, "recall@k": 0.833}),
+            _row(1.0, hit=0.848, **{"MAP@k": 0.606, "recall@k": 0.803})]
+    assert sw.pick_by(rows, "MAP@k")["value"] == 0.9
+
+
+def test_a_real_metric_win_still_decides():
+    """The noise band must not flatten genuine differences: cap=1 beats cap=2 by 0.066 MAP,
+    far outside it, and must win even though its hit_rate advantage is smaller."""
+    rows = [_row(1, hit=0.879, **{"MAP@k": 0.604}), _row(2, hit=0.788, **{"MAP@k": 0.538})]
+    assert sw.pick_by(rows, "MAP@k")["value"] == 1
+
+
+def test_recall_breaks_a_tie_when_hit_rate_also_ties():
+    rows = [_row("a", hit=0.879, **{"MAP@k": 0.600, "recall@k": 0.803}),
+            _row("b", hit=0.879, **{"MAP@k": 0.604, "recall@k": 0.833})]
+    assert sw.pick_by(rows, "MAP@k")["value"] == "b"
+
+
+def test_noise_band_is_smaller_than_one_query_flipping():
+    """33 golden queries, so one flip moves hit_rate by 1/33 = 0.030. The band must sit under
+    that or it would swallow real single-query differences."""
+    assert 0 < sw._NOISE < 1 / 33

--- a/agronaut_agent/tests/test_source_diversity.py
+++ b/agronaut_agent/tests/test_source_diversity.py
@@ -5,8 +5,13 @@ golden-set queries — so a targeted operator answer that existed in knowledge/ 
 model at all. Ranking cannot fix that on its own: the book genuinely is similar, and it has twelve
 times as many chances to be. Capping per-source occupancy spends one slot on breadth.
 
-Measured effect (1354 chunks, hybrid on): hit_rate 0.848 -> 0.939, recall 0.788 -> 0.894,
-precision 0.495 -> 0.540. Every metric improved — the largest single gain in this work.
+Measured effect at 1354 chunks (hybrid on): hit_rate 0.848 -> 0.939, recall 0.788 -> 0.894,
+precision 0.495 -> 0.540. Every metric improved — the largest single gain in that round.
+
+The cap SHIPS AT 1 as of 2026-09-01, not 2. A second book (Goddek et al. 2019, 2576 chunks) took
+the corpus to 3935, and at cap=2 two books can still take two of three slots. Re-measured under
+floor 1.50: cap=1 gives hit 0.879 / recall 0.833 / MAP 0.624 against cap=2's 0.818 / 0.727 /
+0.568. The mechanism did not change; the number of oversized sources did.
 """
 
 
@@ -75,13 +80,13 @@ def test_empty_ranking_is_safe():
 
 def test_default_cap_and_env_override(monkeypatch):
     monkeypatch.delenv("AGRONAUT_MAX_PER_SOURCE", raising=False)
-    assert rag.max_source_cap() == 2
-    monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "1")
-    assert rag.max_source_cap() == 1
+    assert rag.max_source_cap() == 1       # re-measured 2026-09-01 on the 3935-chunk corpus
+    monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "2")
+    assert rag.max_source_cap() == 2       # the previous default is still one env var away
     monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "0")
     assert rag.max_source_cap() == 0
     monkeypatch.setenv("AGRONAUT_MAX_PER_SOURCE", "nonsense")
-    assert rag.max_source_cap() == 2       # bad config must not break a turn
+    assert rag.max_source_cap() == 1       # bad config must not break a turn
 
 
 def test_citation_labels_are_what_the_cap_counts():

--- a/agronaut_agent/tests/test_turn_tracing.py
+++ b/agronaut_agent/tests/test_turn_tracing.py
@@ -63,7 +63,7 @@ def agent(tmp_path, monkeypatch):
 
 def _rows(agent):
     p = agent._analytics.path
-    return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+    return [json.loads(line) for line in p.read_text().splitlines()] if p.exists() else []
 
 
 # --- the trace ---------------------------------------------------------------

--- a/agronaut_agent/tests/test_turn_tracing.py
+++ b/agronaut_agent/tests/test_turn_tracing.py
@@ -1,0 +1,186 @@
+"""Turn tracing and cost telemetry.
+
+Before this, analytics rows were independent counters: a `message`, a `retrieval` and three
+`tool_call` rows landed in the log with nothing tying them together, so "that answer was slow"
+could never be resolved into "because the model was called four times". These tests assert the
+three properties that make the log a trace instead of a tally:
+
+  1. every event a turn produces carries the SAME trace id,
+  2. a nested turn (photo, voice) joins its parent's trace rather than minting a second one,
+  3. the turn is measured even when it raises, because a failed turn is exactly the one whose
+     latency you must not drop from the distribution.
+
+And the property that must survive all of it: still no content, ever.
+"""
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from agronaut_agent import runtime
+from agronaut_agent.analytics import Analytics
+from agronaut_agent.core import AgronautAgent
+
+
+class _FakeChat:
+    """One tool call, then a final answer. Reports token usage the way LangChain normalises it."""
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        if [m for m in messages if isinstance(m, ToolMessage)]:
+            return AIMessage(content="Sized it.",
+                             usage_metadata={"input_tokens": 700, "output_tokens": 40, "total_tokens": 740})
+        return AIMessage(
+            content="",
+            usage_metadata={"input_tokens": 500, "output_tokens": 20, "total_tokens": 520},
+            tool_calls=[{
+                "name": "size_aquaponics_system",
+                "id": "call_1",
+                "args": {"fish_species": "tilapia", "crop": "lettuce", "grow_area_m2": 12,
+                         "temperature_c": 27, "water_budget_lpd": 300},
+            }],
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_turn():
+    """No test may leak an open turn into the next one — a ContextVar left set would make the
+    next test's events join a trace it never opened."""
+    yield
+    runtime.end_turn()
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGRONAUT_ANALYTICS_PATH", str(tmp_path / "a.jsonl"))
+    a = AgronautAgent(chat_model=_FakeChat(), db_path=str(tmp_path / "db.sqlite"))
+    a._analytics = Analytics(path=tmp_path / "a.jsonl")
+    return a
+
+
+def _rows(agent):
+    p = agent._analytics.path
+    return [json.loads(l) for l in p.read_text().splitlines()] if p.exists() else []
+
+
+# --- the trace ---------------------------------------------------------------
+
+def test_every_event_in_a_turn_shares_one_trace_id(agent):
+    agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    rows = _rows(agent)
+    traces = {r.get("trace") for r in rows}
+    assert None not in traces, "an event escaped the trace"
+    assert len(traces) == 1, f"one turn produced {len(traces)} traces"
+    assert {"message", "llm_call", "tool_call", "turn"} <= {r["event"] for r in rows}
+
+
+def test_two_turns_get_two_trace_ids(agent):
+    agent.handle_message("test", "u1", "hello")
+    agent.handle_message("test", "u1", "hello again")
+    assert len({r["trace"] for r in _rows(agent)}) == 2
+
+
+def test_trace_id_is_not_derived_from_the_user(agent):
+    """It groups events within a turn and must not become a second user identifier: the same
+    user on two turns gets two different ids."""
+    agent.handle_message("test", "u1", "hello")
+    agent.handle_message("test", "u1", "hello")
+    rows = _rows(agent)
+    assert len({r["trace"] for r in rows}) == 2
+    uids = {r["uid"] for r in rows if r.get("uid")}
+    assert len(uids) == 1                      # same user...
+    assert not (uids & {r["trace"] for r in rows})   # ...but never the same token
+
+
+def test_nested_turn_joins_rather_than_minting_a_second_trace():
+    """A photo turn runs a text turn inside itself. One photo must read as one turn."""
+    assert runtime.start_turn() is True
+    outer = runtime.trace_id()
+    assert runtime.start_turn() is False, "inner turn wrongly claimed ownership"
+    assert runtime.trace_id() == outer
+    runtime.end_turn()
+
+
+# --- the numbers -------------------------------------------------------------
+
+def test_turn_records_end_to_end_latency_and_model_share(agent):
+    agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    turn = [r for r in _rows(agent) if r["event"] == "turn"][0]
+    assert turn["latency_ms"] >= 0
+    assert turn["llm_calls"] == 2 and turn["tool_calls"] == 1
+    assert turn["llm_ms"] <= turn["latency_ms"], "model time cannot exceed the turn"
+
+
+def test_token_usage_is_summed_across_the_turn(agent):
+    agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    turn = [r for r in _rows(agent) if r["event"] == "turn"][0]
+    assert turn["tokens_in"] == 1200 and turn["tokens_out"] == 60
+
+
+def test_missing_usage_is_omitted_not_zeroed(tmp_path, monkeypatch):
+    """A provider that reports no usage must leave the field ABSENT. Recording 0 would let a
+    provider with no usage metadata silently drag every cost aggregate toward zero."""
+    class _NoUsage(_FakeChat):
+        def invoke(self, messages):
+            return AIMessage(content="hi")
+
+    monkeypatch.setenv("AGRONAUT_ANALYTICS_PATH", str(tmp_path / "a.jsonl"))
+    a = AgronautAgent(chat_model=_NoUsage(), db_path=str(tmp_path / "db.sqlite"))
+    a._analytics = Analytics(path=tmp_path / "a.jsonl")
+    a.handle_message("test", "u1", "hello")
+    turn = [r for r in _rows(a) if r["event"] == "turn"][0]
+    assert "tokens_in" not in turn and "tokens_out" not in turn
+    assert turn["llm_calls"] == 1
+
+
+def test_a_failed_turn_is_still_measured(tmp_path, monkeypatch):
+    class _Explodes(_FakeChat):
+        def invoke(self, messages):
+            raise RuntimeError("provider down")
+
+    monkeypatch.setenv("AGRONAUT_ANALYTICS_PATH", str(tmp_path / "a.jsonl"))
+    a = AgronautAgent(chat_model=_Explodes(), db_path=str(tmp_path / "db.sqlite"))
+    a._analytics = Analytics(path=tmp_path / "a.jsonl")
+    with pytest.raises(RuntimeError):
+        a.handle_message("test", "u1", "hello")
+    turns = [r for r in _rows(a) if r["event"] == "turn"]
+    assert len(turns) == 1 and turns[0]["latency_ms"] >= 0
+
+
+def test_llm_call_events_carry_their_stage(agent):
+    agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    stages = [r["stage"] for r in _rows(agent) if r["event"] == "llm_call"]
+    assert stages == ["agent", "agent"]
+
+
+# --- the guarantee that must survive -----------------------------------------
+
+def test_tracing_records_no_message_content(agent):
+    agent.handle_message("test", "u1", "my tilapia in tank 3 are gasping at dawn")
+    blob = json.dumps(_rows(agent))
+    for word in ("tilapia", "gasping", "tank"):
+        assert word not in blob
+
+
+# --- reading traces back -----------------------------------------------------
+
+def test_traces_groups_a_turn_into_one_path(agent):
+    agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    traces = agent._analytics.traces()
+    assert len(traces) == 1
+    t = traces[0]
+    assert t["latency_ms"] is not None and t["tokens_in"] == 1200
+    assert [e["event"] for e in t["events"]][0] == "message"
+    assert [e["event"] for e in t["events"]][-1] == "turn"
+
+
+def test_summarize_reports_latency_percentiles_and_tokens(agent):
+    for _ in range(3):
+        agent.handle_message("test", "u1", "size me a 12 m2 tilapia system")
+    s = agent._analytics.summarize()
+    assert s["latency"]["turn"]["n"] == 3
+    assert s["latency"]["llm"]["p50"] is not None
+    assert s["tokens"]["in"] == 3600 and s["tokens"]["out"] == 180

--- a/docs/dpg/PRIVACY.md
+++ b/docs/dpg/PRIVACY.md
@@ -56,10 +56,18 @@ Reachable directly from chat at any time:
 
 - Data is stored in a single local SQLite database on the operator's own machine/server.
   There is no central Agronaut server and no third-party analytics on your content.
-- The operator may keep **local usage analytics** — event counts and funnels only (e.g. how
-  many messages, how many designs). These are content-free by construction: no message text
-  is recorded, and user ids are stored only as a truncated one-way hash, so distinct users
-  can be counted without identifying anyone. Disable with `AGRONAUT_ANALYTICS=off`.
+- The operator may keep **local usage analytics** — event counts, funnels and timings only
+  (e.g. how many messages, how many designs, how long a turn took, how many tokens it cost).
+  These are content-free by construction: no message text is recorded, and user ids are stored
+  only as a truncated one-way hash, so distinct users can be counted without identifying
+  anyone. Disable with `AGRONAUT_ANALYTICS=off`.
+- Each turn's events share a **trace id** so one turn can be read back as one path through the
+  pipeline (`agronaut traces`). The id is a fresh random token minted per turn: it is never
+  derived from your identity, never reused across turns, and links only the shape of a single
+  turn — which tools ran, how many passages came back, where the time went. It cannot be used
+  to follow you between turns.
+- A **thumbs up/down** (`/good`, `/bad`) is stored as a bare rating, 1 or -1. There is
+  deliberately no comment field, so this signal cannot carry anything you wrote.
 - Data is retained until you delete it. An operator deployment may set its own retention
   window; this reference build retains until erasure is requested.
 - Access control: on Telegram/WhatsApp an allowlist restricts who can use a given

--- a/docs/dpg/retrieval_eval/baseline_tuned_2026_09.json
+++ b/docs/dpg/retrieval_eval/baseline_tuned_2026_09.json
@@ -1,0 +1,768 @@
+{
+  "summary": {
+    "queries": 33,
+    "k": 3,
+    "hit_rate": 0.8787878787878788,
+    "precision@k": 0.36363636363636365,
+    "recall@k": 0.8333333333333334,
+    "MRR": 0.6565656565656566,
+    "MAP@k": 0.6237373737373737,
+    "latency_ms_mean": 252.1364115686579,
+    "floor_silenced_on_topic": 0,
+    "floor_rejected_off_topic": 8,
+    "negative_controls": 10
+  },
+  "per_query": [
+    {
+      "retrieved": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/common_system_failures.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "do-01",
+      "query": "my tilapia are all gasping at the surface early in the morning",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 0.8959376811981201,
+      "raw_top_score": 0.8959376811981201,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/fish_stress_diagnosis.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5833333333333333,
+      "id": "do-02",
+      "query": "fish crowding near the water inlet and breathing fast",
+      "relevant": [
+        "knowledge/dissolved_oxygen_and_aeration.md",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.8161635398864746,
+      "raw_top_score": 0.7474802136421204,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_stress_diagnosis.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "stress-01",
+      "query": "fish are moving slowly and barely touching their food",
+      "relevant": [
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "top_score": 0.6871860027313232,
+      "raw_top_score": 0.6871860027313232,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-01",
+      "query": "ammonia reading jumped to 4 ppm what do I do right now",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "top_score": 0.8181362152099609,
+      "raw_top_score": 0.8181362152099609,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "n-02",
+      "query": "brand new setup three weeks in and nitrite is climbing",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.0203709602355957,
+      "raw_top_score": 0.9735504388809204,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/nitrogen_cycle_and_cycling.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5833333333333333,
+      "id": "n-03",
+      "query": "how long before the bacteria establish themselves",
+      "relevant": [
+        "knowledge/nitrogen_cycle_and_cycling.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.0436968803405762,
+      "raw_top_score": 0.9312494993209839,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/ph_and_alkalinity.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "ph-01",
+      "query": "the pH keeps sliding down every week no matter what I add",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 0.8413991928100586,
+      "raw_top_score": 0.8036634922027588,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/ph_and_alkalinity.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "ph-02",
+      "query": "how do I bring up the buffering capacity safely",
+      "relevant": [
+        "knowledge/ph_and_alkalinity.md"
+      ],
+      "top_score": 1.3183010816574097,
+      "raw_top_score": 1.3183010816574097,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5833333333333333,
+      "id": "plant-01",
+      "query": "lettuce leaves going yellow between the veins but the veins stay green",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "knowledge/plant_deficiency_cheatsheet.md"
+      ],
+      "top_score": 0.5887277722358704,
+      "raw_top_score": 1.1596250534057617,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/plant_nutrient_deficiencies.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "plant-02",
+      "query": "the oldest leaves are turning pale first while new growth looks fine",
+      "relevant": [
+        "knowledge/plant_nutrient_deficiencies.md"
+      ],
+      "top_score": 0.8162521123886108,
+      "raw_top_score": 0.8162521123886108,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_nutrient_deficiencies.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "algae-01",
+      "query": "my water has gone bright green and cloudy",
+      "relevant": [
+        "knowledge/algae_control.md"
+      ],
+      "top_score": 1.0503398180007935,
+      "raw_top_score": 1.0503398180007935,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "knowledge/algae_control.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 0.8333333333333333,
+      "id": "algae-02",
+      "query": "stringy green growth clogging the pipes and screens",
+      "relevant": [
+        "knowledge/algae_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.1393007040023804,
+      "raw_top_score": 1.1393007040023804,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/fish_stress_diagnosis.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "fail-01",
+      "query": "we lost power for six hours overnight what should I check first",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/dissolved_oxygen_and_aeration.md"
+      ],
+      "top_score": 1.3383744955062866,
+      "raw_top_score": 1.3383744955062866,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "fail-02",
+      "query": "I think I have been giving them too much food and now the water is murky",
+      "relevant": [
+        "knowledge/common_system_failures.md",
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/feed_and_feeding.md"
+      ],
+      "top_score": 1.043809413909912,
+      "raw_top_score": 1.043809413909912,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/fish_disease_and_treatment.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "disease-01",
+      "query": "little white dots all over my fish like grains of salt",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 0.7301387786865234,
+      "raw_top_score": 0.7301387786865234,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Applications, technologies, and evaluation methods in smart aquaponics: a systematic literature review (Artif Intell Rev, 2024)"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "disease-02",
+      "query": "can I use a copper based treatment with plants in the loop",
+      "relevant": [
+        "knowledge/fish_disease_and_treatment.md"
+      ],
+      "top_score": 0.9744634628295898,
+      "raw_top_score": 0.7133116126060486,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/feed_and_feeding.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "feed-01",
+      "query": "how much should I be giving them each day",
+      "relevant": [
+        "knowledge/feed_and_feeding.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 1.1389631032943726,
+      "raw_top_score": 1.1389631032943726,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/pump_sizing_basics.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "pump-01",
+      "query": "the pump is rated for plenty but barely trickles at the top of the tower",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 1.0091389417648315,
+      "raw_top_score": 0.9135887026786804,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/pump_sizing_basics.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "pump-02",
+      "query": "how do I work out the flow I actually need",
+      "relevant": [
+        "knowledge/pump_sizing_basics.md"
+      ],
+      "top_score": 0.8910391926765442,
+      "raw_top_score": 0.8910391926765442,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/system_types_and_design.md",
+        "knowledge/solids_and_mineralization.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "type-01",
+      "query": "should I go with rafts or the thin channel setup",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.1507134437561035,
+      "raw_top_score": 1.1507134437561035,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/system_types_and_design.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "type-02",
+      "query": "I have almost no floor space what layout works",
+      "relevant": [
+        "knowledge/system_types_and_design.md"
+      ],
+      "top_score": 1.4159350395202637,
+      "raw_top_score": 1.2961180210113525,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "water-01",
+      "query": "our tap water smells strongly of chlorine can I top up with it",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 0.8689039349555969,
+      "raw_top_score": 0.8689039349555969,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/water_source_and_treatment.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "water-02",
+      "query": "the well water here is extremely hard",
+      "relevant": [
+        "knowledge/water_source_and_treatment.md"
+      ],
+      "top_score": 1.1220040321350098,
+      "raw_top_score": 1.0372190475463867,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/common_system_failures.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 0.5,
+      "rr": 1.0,
+      "ap": 0.5,
+      "id": "solids-01",
+      "query": "dark sludge piling up in the bottom of the tank",
+      "relevant": [
+        "knowledge/solids_and_mineralization.md",
+        "knowledge/common_system_failures.md"
+      ],
+      "top_score": 0.9865351915359497,
+      "raw_top_score": 0.9865351915359497,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/regulations_and_permits.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "reg-01",
+      "query": "do I need any kind of licence before I can sell the fish",
+      "relevant": [
+        "knowledge/regulations_and_permits.md"
+      ],
+      "top_score": 0.8532035946846008,
+      "raw_top_score": 0.8532035946846008,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.3333333333333333,
+      "ap": 0.3333333333333333,
+      "id": "safety-01",
+      "query": "is produce grown on fish waste actually safe to eat",
+      "relevant": [
+        "knowledge/food_safety_and_hygiene.md"
+      ],
+      "top_score": 0.6161458492279053,
+      "raw_top_score": 0.6161458492279053,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/plant_pests_and_ipm.md",
+        "knowledge/regulations_and_permits.md"
+      ],
+      "hit": true,
+      "precision": 0.6666666666666666,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "pest-01",
+      "query": "tiny green insects covering my basil what can I spray",
+      "relevant": [
+        "knowledge/plant_pests_and_ipm.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "top_score": 0.6313092708587646,
+      "raw_top_score": 0.6313092708587646,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/economics_and_costs.md",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "econ-01",
+      "query": "what are the running costs going to look like",
+      "relevant": [
+        "knowledge/economics_and_costs.md"
+      ],
+      "top_score": 1.0173242092132568,
+      "raw_top_score": 0.8659826517105103,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "knowledge/economics_and_costs.md"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 0.5,
+      "rr": 0.3333333333333333,
+      "ap": 0.16666666666666666,
+      "id": "econ-02",
+      "query": "is this ever going to break even",
+      "relevant": [
+        "knowledge/economics_and_costs.md",
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.371431827545166,
+      "raw_top_score": 1.371431827545166,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "knowledge/feasibility_and_business_case.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 0.5,
+      "ap": 0.5,
+      "id": "econ-03",
+      "query": "putting together a funding proposal what should it cover",
+      "relevant": [
+        "knowledge/feasibility_and_business_case.md"
+      ],
+      "top_score": 1.1042566299438477,
+      "raw_top_score": 1.1042566299438477,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-01",
+      "query": "water hits 34 degrees in the afternoon here",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.1499556303024292,
+      "raw_top_score": 1.1499556303024292,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "knowledge/temperature_and_climate_control.md",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "hit": true,
+      "precision": 0.3333333333333333,
+      "recall": 1.0,
+      "rr": 1.0,
+      "ap": 1.0,
+      "id": "temp-02",
+      "query": "which species suits a cold winter",
+      "relevant": [
+        "knowledge/temperature_and_climate_control.md"
+      ],
+      "top_score": 1.0294992923736572,
+      "raw_top_score": 1.0294992923736572,
+      "floor_returned_nothing": false
+    },
+    {
+      "retrieved": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
+      ],
+      "hit": false,
+      "precision": 0.0,
+      "recall": 0.0,
+      "rr": 0.0,
+      "ap": 0.0,
+      "id": "range-01",
+      "query": "what levels should I be aiming for overall",
+      "relevant": [
+        "knowledge/water_quality_ranges.md"
+      ],
+      "top_score": 1.3826854228973389,
+      "raw_top_score": 1.3826854228973389,
+      "floor_returned_nothing": false
+    }
+  ],
+  "negative_controls": [
+    {
+      "id": "neg-01",
+      "query": "how do I fix a slipping bicycle chain",
+      "top_score": 1.6716821193695068,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-02",
+      "query": "what is the capital of Canada",
+      "top_score": 1.5543473958969116,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-03",
+      "query": "write me a python function to reverse a linked list",
+      "top_score": 1.4111902713775635,
+      "returned": [
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Applications, technologies, and evaluation methods in smart aquaponics: a systematic literature review (Artif Intell Rev, 2024)"
+      ],
+      "rejected_by_floor": false
+    },
+    {
+      "id": "neg-04",
+      "query": "what time does the pharmacy close today",
+      "top_score": 1.613491177558899,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-05",
+      "query": "recommend a good science fiction novel",
+      "top_score": 1.538677453994751,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-06",
+      "query": "how do I change a flat car tyre",
+      "top_score": 1.616103172302246,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-07",
+      "query": "explain the offside rule in football",
+      "top_score": 1.6666005849838257,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-08",
+      "query": "best way to remove red wine from a carpet",
+      "top_score": 1.425750732421875,
+      "returned": [
+        "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
+        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+      ],
+      "rejected_by_floor": false
+    },
+    {
+      "id": "neg-09",
+      "query": "convert 500 euros to yen",
+      "top_score": 1.6639702320098877,
+      "returned": [],
+      "rejected_by_floor": true
+    },
+    {
+      "id": "neg-10",
+      "query": "who won the world cup in 1998",
+      "top_score": 1.750444769859314,
+      "returned": [],
+      "rejected_by_floor": true
+    }
+  ]
+}

--- a/docs/dpg/retrieval_eval/baseline_tuned_2026_09.json
+++ b/docs/dpg/retrieval_eval/baseline_tuned_2026_09.json
@@ -5,9 +5,9 @@
     "hit_rate": 0.8787878787878788,
     "precision@k": 0.36363636363636365,
     "recall@k": 0.8333333333333334,
-    "MRR": 0.6565656565656566,
-    "MAP@k": 0.6237373737373737,
-    "latency_ms_mean": 252.1364115686579,
+    "MRR": 0.6363636363636364,
+    "MAP@k": 0.6035353535353536,
+    "latency_ms_mean": 253.1206956217912,
     "floor_silenced_on_topic": 0,
     "floor_rejected_off_topic": 8,
     "negative_controls": 10
@@ -111,7 +111,7 @@
         "knowledge/nitrogen_cycle_and_cycling.md",
         "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
       ],
-      "top_score": 1.0203709602355957,
+      "top_score": 1.0203710794448853,
       "raw_top_score": 0.9735504388809204,
       "floor_returned_nothing": false
     },
@@ -560,8 +560,8 @@
         "knowledge/plant_pests_and_ipm.md",
         "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)"
       ],
-      "top_score": 0.6313092708587646,
-      "raw_top_score": 0.6313092708587646,
+      "top_score": 0.6313093304634094,
+      "raw_top_score": 0.6313093304634094,
       "floor_returned_nothing": false
     },
     {
@@ -647,22 +647,22 @@
     },
     {
       "retrieved": [
-        "knowledge/temperature_and_climate_control.md",
+        "knowledge/winter_cold_season_operation.md",
         "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
-        "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open"
+        "knowledge/temperature_and_climate_control.md"
       ],
       "hit": true,
       "precision": 0.3333333333333333,
       "recall": 1.0,
-      "rr": 1.0,
-      "ap": 1.0,
+      "rr": 0.3333333333333333,
+      "ap": 0.3333333333333333,
       "id": "temp-02",
       "query": "which species suits a cold winter",
       "relevant": [
         "knowledge/temperature_and_climate_control.md"
       ],
-      "top_score": 1.0294992923736572,
-      "raw_top_score": 1.0294992923736572,
+      "top_score": 0.9586202502250671,
+      "raw_top_score": 0.9586202502250671,
       "floor_returned_nothing": false
     },
     {
@@ -680,8 +680,8 @@
       "relevant": [
         "knowledge/water_quality_ranges.md"
       ],
-      "top_score": 1.3826854228973389,
-      "raw_top_score": 1.3826854228973389,
+      "top_score": 1.3826850652694702,
+      "raw_top_score": 1.3826850652694702,
       "floor_returned_nothing": false
     }
   ],
@@ -689,7 +689,7 @@
     {
       "id": "neg-01",
       "query": "how do I fix a slipping bicycle chain",
-      "top_score": 1.6716821193695068,
+      "top_score": 1.6716817617416382,
       "returned": [],
       "rejected_by_floor": true
     },
@@ -742,7 +742,7 @@
     {
       "id": "neg-08",
       "query": "best way to remove red wine from a carpet",
-      "top_score": 1.425750732421875,
+      "top_score": 1.425750494003296,
       "returned": [
         "FAO 589 Small-scale aquaponic food production (Somerville et al., 2014)",
         "Goddek, Joyce, Kotzen & Burnell eds. (2019), Aquaponics Food Production Systems, Springer Open",
@@ -760,7 +760,7 @@
     {
       "id": "neg-10",
       "query": "who won the world cup in 1998",
-      "top_score": 1.750444769859314,
+      "top_score": 1.7504446506500244,
       "returned": [],
       "rejected_by_floor": true
     }

--- a/docs/dpg/retrieval_eval/sweep_2026_09.json
+++ b/docs/dpg/retrieval_eval/sweep_2026_09.json
@@ -1,0 +1,255 @@
+{
+  "description": "Re-measurement of the tunable retrieval constants against the corpus as it stands at run time.",
+  "floor": {
+    "rows": [
+      {
+        "value": 1.3,
+        "hit_rate": 0.7576,
+        "recall@k": 0.6818,
+        "precision@k": 0.4091,
+        "MRR": 0.5909,
+        "MAP@k": 0.5379,
+        "silenced_on_topic": 4,
+        "rejected_off_topic": 10,
+        "negative_controls": 10,
+        "latency_ms": 280,
+        "worst_on_topic": 1.3827,
+        "headroom": -0.0827
+      },
+      {
+        "value": 1.35,
+        "hit_rate": 0.8182,
+        "recall@k": 0.7273,
+        "precision@k": 0.4293,
+        "MRR": 0.6212,
+        "MAP@k": 0.553,
+        "silenced_on_topic": 2,
+        "rejected_off_topic": 10,
+        "negative_controls": 10,
+        "latency_ms": 14,
+        "worst_on_topic": 1.3827,
+        "headroom": -0.0327
+      },
+      {
+        "value": 1.4,
+        "hit_rate": 0.8182,
+        "recall@k": 0.7273,
+        "precision@k": 0.4293,
+        "MRR": 0.6212,
+        "MAP@k": 0.553,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 10,
+        "negative_controls": 10,
+        "latency_ms": 14,
+        "worst_on_topic": 1.3827,
+        "headroom": 0.0173
+      },
+      {
+        "value": 1.45,
+        "hit_rate": 0.8182,
+        "recall@k": 0.7273,
+        "precision@k": 0.4343,
+        "MRR": 0.6364,
+        "MAP@k": 0.5682,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15,
+        "worst_on_topic": 1.3827,
+        "headroom": 0.0673
+      },
+      {
+        "value": 1.5,
+        "hit_rate": 0.8182,
+        "recall@k": 0.7273,
+        "precision@k": 0.4343,
+        "MRR": 0.6364,
+        "MAP@k": 0.5682,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15,
+        "worst_on_topic": 1.3827,
+        "headroom": 0.1173
+      },
+      {
+        "value": 1.65,
+        "hit_rate": 0.8485,
+        "recall@k": 0.7576,
+        "precision@k": 0.4444,
+        "MRR": 0.6465,
+        "MAP@k": 0.5783,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 4,
+        "negative_controls": 10,
+        "latency_ms": 15,
+        "worst_on_topic": 1.3827,
+        "headroom": 0.2673
+      }
+    ],
+    "chosen": {
+      "value": 1.5,
+      "hit_rate": 0.8182,
+      "recall@k": 0.7273,
+      "precision@k": 0.4343,
+      "MRR": 0.6364,
+      "MAP@k": 0.5682,
+      "silenced_on_topic": 0,
+      "rejected_off_topic": 8,
+      "negative_controls": 10,
+      "latency_ms": 15,
+      "worst_on_topic": 1.3827,
+      "headroom": 0.1173
+    }
+  },
+  "cap": {
+    "rows": [
+      {
+        "value": 1,
+        "hit_rate": 0.8788,
+        "recall@k": 0.8333,
+        "precision@k": 0.3636,
+        "MRR": 0.6566,
+        "MAP@k": 0.6237,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 2,
+        "hit_rate": 0.8182,
+        "recall@k": 0.7273,
+        "precision@k": 0.4343,
+        "MRR": 0.6364,
+        "MAP@k": 0.5682,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 3,
+        "hit_rate": 0.697,
+        "recall@k": 0.6212,
+        "precision@k": 0.3737,
+        "MRR": 0.5758,
+        "MAP@k": 0.5152,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 0,
+        "hit_rate": 0.697,
+        "recall@k": 0.6212,
+        "precision@k": 0.3737,
+        "MRR": 0.5758,
+        "MAP@k": 0.5152,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      }
+    ],
+    "chosen": {
+      "value": 1,
+      "hit_rate": 0.8788,
+      "recall@k": 0.8333,
+      "precision@k": 0.3636,
+      "MRR": 0.6566,
+      "MAP@k": 0.6237,
+      "silenced_on_topic": 0,
+      "rejected_off_topic": 8,
+      "negative_controls": 10,
+      "latency_ms": 15
+    },
+    "held": {
+      "floor": 1.5
+    }
+  },
+  "beta": {
+    "rows": [
+      {
+        "value": 0.5,
+        "hit_rate": 0.8788,
+        "recall@k": 0.7879,
+        "precision@k": 0.3333,
+        "MRR": 0.601,
+        "MAP@k": 0.5581,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 0.7,
+        "hit_rate": 0.8788,
+        "recall@k": 0.803,
+        "precision@k": 0.3434,
+        "MRR": 0.6061,
+        "MAP@k": 0.5707,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 0.9,
+        "hit_rate": 0.8788,
+        "recall@k": 0.8333,
+        "precision@k": 0.3636,
+        "MRR": 0.6566,
+        "MAP@k": 0.6237,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      },
+      {
+        "value": 1.0,
+        "hit_rate": 0.8485,
+        "recall@k": 0.803,
+        "precision@k": 0.3535,
+        "MRR": 0.6616,
+        "MAP@k": 0.6212,
+        "silenced_on_topic": 0,
+        "rejected_off_topic": 8,
+        "negative_controls": 10,
+        "latency_ms": 15
+      }
+    ],
+    "chosen": {
+      "value": 0.9,
+      "hit_rate": 0.8788,
+      "recall@k": 0.8333,
+      "precision@k": 0.3636,
+      "MRR": 0.6566,
+      "MAP@k": 0.6237,
+      "silenced_on_topic": 0,
+      "rejected_off_topic": 8,
+      "negative_controls": 10,
+      "latency_ms": 15
+    },
+    "held": {
+      "floor": 1.5,
+      "cap": 1
+    }
+  },
+  "verified": {
+    "config": {
+      "floor": 1.5,
+      "cap": 1,
+      "beta": 0.9
+    },
+    "hit_rate": 0.8788,
+    "recall@k": 0.8333,
+    "precision@k": 0.3636,
+    "MRR": 0.6566,
+    "MAP@k": 0.6237,
+    "silenced_on_topic": 0,
+    "rejected_off_topic": 8,
+    "latency_ms": 15
+  }
+}

--- a/docs/dpg/retrieval_eval/sweep_2026_09.json
+++ b/docs/dpg/retrieval_eval/sweep_2026_09.json
@@ -1,103 +1,103 @@
 {
-  "description": "Re-measurement of the tunable retrieval constants against the corpus as it stands at run time.",
+  "description": "Re-measurement of the tunable retrieval constants against the corpus as it stands (3941 chunks, 22 curated files, 4 publications). The `rows` are the measurement; `chosen` is the decision rule applied to them.",
   "floor": {
     "rows": [
       {
         "value": 1.3,
-        "hit_rate": 0.7576,
-        "recall@k": 0.6818,
-        "precision@k": 0.4091,
-        "MRR": 0.5909,
-        "MAP@k": 0.5379,
+        "hit_rate": 0.7879,
+        "recall@k": 0.7727,
+        "precision@k": 0.3333,
+        "MRR": 0.5808,
+        "MAP@k": 0.5682,
         "silenced_on_topic": 4,
         "rejected_off_topic": 10,
         "negative_controls": 10,
-        "latency_ms": 280,
+        "latency_ms": 289,
         "worst_on_topic": 1.3827,
         "headroom": -0.0827
       },
       {
         "value": 1.35,
-        "hit_rate": 0.8182,
-        "recall@k": 0.7273,
-        "precision@k": 0.4293,
-        "MRR": 0.6212,
-        "MAP@k": 0.553,
+        "hit_rate": 0.8485,
+        "recall@k": 0.8182,
+        "precision@k": 0.3535,
+        "MRR": 0.6111,
+        "MAP@k": 0.5833,
         "silenced_on_topic": 2,
         "rejected_off_topic": 10,
         "negative_controls": 10,
-        "latency_ms": 14,
+        "latency_ms": 17,
         "worst_on_topic": 1.3827,
         "headroom": -0.0327
       },
       {
         "value": 1.4,
-        "hit_rate": 0.8182,
-        "recall@k": 0.7273,
-        "precision@k": 0.4293,
-        "MRR": 0.6212,
-        "MAP@k": 0.553,
+        "hit_rate": 0.8485,
+        "recall@k": 0.8182,
+        "precision@k": 0.3535,
+        "MRR": 0.6111,
+        "MAP@k": 0.5833,
         "silenced_on_topic": 0,
         "rejected_off_topic": 10,
         "negative_controls": 10,
-        "latency_ms": 14,
+        "latency_ms": 16,
         "worst_on_topic": 1.3827,
         "headroom": 0.0173
       },
       {
         "value": 1.45,
-        "hit_rate": 0.8182,
-        "recall@k": 0.7273,
-        "precision@k": 0.4343,
-        "MRR": 0.6364,
-        "MAP@k": 0.5682,
+        "hit_rate": 0.8485,
+        "recall@k": 0.8182,
+        "precision@k": 0.3535,
+        "MRR": 0.6263,
+        "MAP@k": 0.5985,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15,
+        "latency_ms": 16,
         "worst_on_topic": 1.3827,
         "headroom": 0.0673
       },
       {
         "value": 1.5,
-        "hit_rate": 0.8182,
-        "recall@k": 0.7273,
-        "precision@k": 0.4343,
+        "hit_rate": 0.8788,
+        "recall@k": 0.8333,
+        "precision@k": 0.3636,
         "MRR": 0.6364,
-        "MAP@k": 0.5682,
+        "MAP@k": 0.6035,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15,
+        "latency_ms": 16,
         "worst_on_topic": 1.3827,
         "headroom": 0.1173
       },
       {
         "value": 1.65,
-        "hit_rate": 0.8485,
-        "recall@k": 0.7576,
-        "precision@k": 0.4444,
+        "hit_rate": 0.9091,
+        "recall@k": 0.8788,
+        "precision@k": 0.3838,
         "MRR": 0.6465,
-        "MAP@k": 0.5783,
+        "MAP@k": 0.6237,
         "silenced_on_topic": 0,
         "rejected_off_topic": 4,
         "negative_controls": 10,
-        "latency_ms": 15,
+        "latency_ms": 16,
         "worst_on_topic": 1.3827,
         "headroom": 0.2673
       }
     ],
     "chosen": {
       "value": 1.5,
-      "hit_rate": 0.8182,
-      "recall@k": 0.7273,
-      "precision@k": 0.4343,
+      "hit_rate": 0.8788,
+      "recall@k": 0.8333,
+      "precision@k": 0.3636,
       "MRR": 0.6364,
-      "MAP@k": 0.5682,
+      "MAP@k": 0.6035,
       "silenced_on_topic": 0,
       "rejected_off_topic": 8,
       "negative_controls": 10,
-      "latency_ms": 15,
+      "latency_ms": 16,
       "worst_on_topic": 1.3827,
       "headroom": 0.1173
     }
@@ -109,48 +109,48 @@
         "hit_rate": 0.8788,
         "recall@k": 0.8333,
         "precision@k": 0.3636,
-        "MRR": 0.6566,
-        "MAP@k": 0.6237,
+        "MRR": 0.6364,
+        "MAP@k": 0.6035,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       },
       {
         "value": 2,
-        "hit_rate": 0.8182,
-        "recall@k": 0.7273,
-        "precision@k": 0.4343,
-        "MRR": 0.6364,
-        "MAP@k": 0.5682,
+        "hit_rate": 0.7879,
+        "recall@k": 0.697,
+        "precision@k": 0.4192,
+        "MRR": 0.6061,
+        "MAP@k": 0.5379,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       },
       {
         "value": 3,
-        "hit_rate": 0.697,
-        "recall@k": 0.6212,
-        "precision@k": 0.3737,
-        "MRR": 0.5758,
-        "MAP@k": 0.5152,
+        "hit_rate": 0.6667,
+        "recall@k": 0.5909,
+        "precision@k": 0.3586,
+        "MRR": 0.5455,
+        "MAP@k": 0.4848,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       },
       {
         "value": 0,
-        "hit_rate": 0.697,
-        "recall@k": 0.6212,
-        "precision@k": 0.3737,
-        "MRR": 0.5758,
-        "MAP@k": 0.5152,
+        "hit_rate": 0.6667,
+        "recall@k": 0.5909,
+        "precision@k": 0.3586,
+        "MRR": 0.5455,
+        "MAP@k": 0.4848,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       }
     ],
     "chosen": {
@@ -158,12 +158,12 @@
       "hit_rate": 0.8788,
       "recall@k": 0.8333,
       "precision@k": 0.3636,
-      "MRR": 0.6566,
-      "MAP@k": 0.6237,
+      "MRR": 0.6364,
+      "MAP@k": 0.6035,
       "silenced_on_topic": 0,
       "rejected_off_topic": 8,
       "negative_controls": 10,
-      "latency_ms": 15
+      "latency_ms": 16
     },
     "held": {
       "floor": 1.5
@@ -176,8 +176,8 @@
         "hit_rate": 0.8788,
         "recall@k": 0.7879,
         "precision@k": 0.3333,
-        "MRR": 0.601,
-        "MAP@k": 0.5581,
+        "MRR": 0.5909,
+        "MAP@k": 0.548,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
@@ -188,36 +188,36 @@
         "hit_rate": 0.8788,
         "recall@k": 0.803,
         "precision@k": 0.3434,
-        "MRR": 0.6061,
-        "MAP@k": 0.5707,
+        "MRR": 0.601,
+        "MAP@k": 0.5657,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       },
       {
         "value": 0.9,
         "hit_rate": 0.8788,
         "recall@k": 0.8333,
         "precision@k": 0.3636,
-        "MRR": 0.6566,
-        "MAP@k": 0.6237,
+        "MRR": 0.6364,
+        "MAP@k": 0.6035,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       },
       {
         "value": 1.0,
         "hit_rate": 0.8485,
         "recall@k": 0.803,
         "precision@k": 0.3535,
-        "MRR": 0.6616,
-        "MAP@k": 0.6212,
+        "MRR": 0.6465,
+        "MAP@k": 0.6061,
         "silenced_on_topic": 0,
         "rejected_off_topic": 8,
         "negative_controls": 10,
-        "latency_ms": 15
+        "latency_ms": 16
       }
     ],
     "chosen": {
@@ -225,17 +225,18 @@
       "hit_rate": 0.8788,
       "recall@k": 0.8333,
       "precision@k": 0.3636,
-      "MRR": 0.6566,
-      "MAP@k": 0.6237,
+      "MRR": 0.6364,
+      "MAP@k": 0.6035,
       "silenced_on_topic": 0,
       "rejected_off_topic": 8,
       "negative_controls": 10,
-      "latency_ms": 15
+      "latency_ms": 16
     },
     "held": {
       "floor": 1.5,
       "cap": 1
-    }
+    },
+    "note": "beta=1.0 (hybrid OFF) shows MAP 0.606 against 0.90's 0.604. That 0.002 is below the noise band: one query flipping moves hit_rate by 1/33 = 0.030, and hit_rate and recall both fall by ~0.030 at beta=1.0. The picker re-ranks inside the noise band on hit_rate, so 0.90 holds."
   },
   "verified": {
     "config": {
@@ -243,13 +244,28 @@
       "cap": 1,
       "beta": 0.9
     },
-    "hit_rate": 0.8788,
-    "recall@k": 0.8333,
-    "precision@k": 0.3636,
-    "MRR": 0.6566,
-    "MAP@k": 0.6237,
+    "hit_rate": 0.879,
+    "recall@k": 0.833,
+    "precision@k": 0.364,
+    "MRR": 0.636,
+    "MAP@k": 0.604,
     "silenced_on_topic": 0,
-    "rejected_off_topic": 8,
-    "latency_ms": 15
+    "rejected_off_topic": 8
+  },
+  "vs_previous_config": {
+    "previous": {
+      "config": {
+        "floor": 1.65,
+        "cap": 2,
+        "beta": 0.9
+      },
+      "hit_rate": 0.818,
+      "recall@k": 0.727,
+      "precision@k": 0.429,
+      "MRR": 0.616,
+      "MAP@k": 0.548,
+      "rejected_off_topic": 4
+    },
+    "note": "Both measured on the SAME corpus, so the delta isolates the constants."
   }
 }

--- a/docs/dpg/retrieval_eval/techniques.json
+++ b/docs/dpg/retrieval_eval/techniques.json
@@ -1,9 +1,10 @@
 {
-  "description": "Every retrieval technique implemented in this work, what it measured, and whether it ships. Recorded so each decision is reproducible and so a decision can EXPIRE \u2014 hybrid search was rejected, then adopted when the corpus grew.",
+  "description": "Every retrieval technique implemented in this work, what it measured, and whether it ships. Recorded so each decision is reproducible and so a decision can EXPIRE — hybrid search was rejected, then adopted when the corpus grew.",
   "corpus_at_final_measurement": {
     "chunks": 1354,
     "local_files": 21,
-    "web_sources": 3
+    "web_sources": 3,
+    "note": "SUPERSEDED — see corpus_now / final_2026_09"
   },
   "final": {
     "hit_rate": 0.939,
@@ -11,26 +12,27 @@
     "precision@k": 0.54,
     "MRR": 0.737,
     "MAP@k": 0.697,
-    "latency_ms": 244
+    "latency_ms": 244,
+    "note": "SUPERSEDED by final_2026_09. Kept because the reversal is the point: these numbers were correct for a 1354-chunk corpus and expired one day later."
   },
   "techniques": [
     {
       "name": "Relevance floor",
-      "ships": "ON",
-      "evidence": "rejects 8/10 off-topic, silences 0/33 real",
-      "note": "Bands overlap (on-topic worst 1.548, off-topic best 1.426) so it cannot be tightened."
+      "ships": "ON (1.50, was 1.65)",
+      "evidence": "3935 chunks: rejects 8/10 off-topic, silences 0/33 real, 0.117 headroom above the worst real query (1.383). At 1354 chunks: 1.65, 8/10, 0/33.",
+      "note": "REVERSED PREMISE. The bands OVERLAPPED at 1354 chunks (on-topic worst 1.548 above off-topic best 1.426) and no floor could separate them. At 3935 they SEPARATE (1.383 < 1.411), because more corpus means a closer match for every real question. Not tightened to 1.40 despite that rejecting 10/10: it clears the worst real query by 0.017, and this project already rejected a 0.032 margin as too thin. The golden set has 33 queries; headroom is what protects the 34th."
     },
     {
       "name": "Hybrid BM25 + RRF",
       "ships": "ON (beta=0.90)",
-      "evidence": "362 chunks: lost at every beta. 1354 chunks: recall +0.091, MAP +0.091",
-      "note": "REVERSED. The technique did not change; the corpus did. Only 10% keyword weight is correct."
+      "evidence": "362 chunks: lost at every beta. 1354 chunks: recall +0.091, MAP +0.091 3935 chunks: re-confirmed at beta=0.90, and now ahead of dense-only on hit_rate too (0.879 vs 0.848).",
+      "note": "REVERSED. The technique did not change; the corpus did. Only 10% keyword weight is correct. Beta is the ONE constant a 3x corpus growth did not move."
     },
     {
       "name": "Per-source cap",
-      "ships": "ON (2)",
-      "evidence": "hit 0.848->0.939, recall 0.788->0.894, precision 0.495->0.540",
-      "note": "Largest single gain. FAO 589 was taking all 3 slots on 10 of 33 queries."
+      "ships": "ON (1, was 2)",
+      "evidence": "3935 chunks, floor 1.50: cap=1 hit 0.879 / recall 0.833 / MAP 0.624 vs cap=2's 0.818 / 0.727 / 0.568. At 1354 chunks cap=2 won on precision.",
+      "note": "REVERSED. cap=2 was right against ONE oversized source; there are now TWO (3853 of 3935 chunks are books, curated files are 2%), so cap=2 lets books take two of three slots — the same failure the cap exists to stop, through a door it left open. The deciding gap widened roughly fourfold: cap=1 bought +0.031 hit at 1354 chunks and buys +0.061 here."
     },
     {
       "name": "PDF cleaning",
@@ -60,13 +62,97 @@
       "name": "Cross-encoder reranking",
       "ships": "OFF",
       "evidence": "hit 0.939->0.879, latency 274->761 ms",
-      "note": "ms-marco model is out of domain for operator phrasing against agronomy prose."
+      "note": "ms-marco model is out of domain for operator phrasing against agronomy prose. NOT re-measured at 3935 chunks — recorded as stale rather than presented as current. A technique that lost on every metric and tripled latency does not become the priority when the corpus grows."
     },
     {
       "name": "Query rewriting",
       "ships": "NOT BUILT",
       "note": "Three prefix/expansion techniques already lost for the same reason; adding vocabulary to a corpus that shares one vocabulary domain dilutes rather than disambiguates."
+    },
+    {
+      "name": "Metadata filtering",
+      "ships": "AVAILABLE, off by default",
+      "evidence": "Default path unchanged: with no filter passed, the golden-set scorecard is identical before and after (0.848 / 0.758 / 0.444 / 0.646 / 0.578 on the 3935-chunk corpus), verified by re-running the eval against a stash of the change.",
+      "note": "The third leg of M2 hybrid search, and the only one this system lacked. Applied to BOTH pools before fusion, never after, so an excluded chunk cannot consume a pool slot. Filterable keys: source_type, kb_tag, url_category, chapter, page — all already carried by every chunk. It is a CAPABILITY, not a ranking change: it encodes something the caller knows that the query text does not say, so there is no golden-set number for it to move and none is claimed. Nothing calls it with a filter yet."
+    },
+    {
+      "name": "Sweep harness (scripts/retrieval_sweep.py)",
+      "ships": "N/A — tooling",
+      "evidence": "Reproduces the floor/cap/beta tables above in one command.",
+      "note": "Built because the drift above was not a carelessness problem. Re-measuring three constants was an afternoon of ad-hoc scripting, so it did not happen when the corpus changed. The floor picker encodes the project's ACTUAL decision rule — zero real queries silenced, then a minimum 0.10 headroom, then maximum rejections — rather than maximising a metric, because a naive picker chose 1.40 here and 1.40 is the wrong answer for a reason no metric in the table can see."
     }
   ],
-  "the_pattern": "Four of the eight measured techniques LOST, and three of those four share one mechanism: they add topic words (a section crumb, a chapter name, a heading) to chunks in a corpus where every document already shares a vocabulary domain. Words that appear in every chunk about a topic carry no discriminating information \u2014 they only dilute the distinctive content already in the vector. What DID work was structural instead of lexical: refusing irrelevant passages, refusing error pages, and refusing to let one source occupy every slot."
+  "the_pattern": "Four of the eight measured techniques LOST, and three of those four share one mechanism: they add topic words (a section crumb, a chapter name, a heading) to chunks in a corpus where every document already shares a vocabulary domain. Words that appear in every chunk about a topic carry no discriminating information — they only dilute the distinctive content already in the vector. What DID work was structural instead of lexical: refusing irrelevant passages, refusing error pages, and refusing to let one source occupy every slot. A ninth technique has since been added and a corpus drift recorded: see `corpus_drift_warning`. The lesson the hybrid reversal taught — a measurement is a property of a corpus and expires when the corpus moves — has now applied to the per-source cap and the relevance floor as well.",
+  "corpus_drift_warning": {
+    "status": "RESOLVED 2026-09-01 by re-calibration; kept as the case history",
+    "what_happened": "techniques.json was written 2026-08-25. Commit 70b2d00 added Goddek et al. (2019) on 2026-08-26 — one day later — taking the corpus from 1354 to 3935 chunks. Nothing was re-measured, so every constant here was calibrated for a corpus that no longer existed.",
+    "cost_of_the_drift": {
+      "hit_rate": -0.091,
+      "recall@k": -0.136,
+      "precision@k": -0.096,
+      "MRR": -0.091,
+      "MAP@k": -0.119,
+      "off_topic_rejected": "8/10 -> 4/10"
+    },
+    "what_moved_and_what_did_not": "The floor and the cap both moved; beta did not. That is informative rather than incidental: beta describes the relationship between two RANKING SIGNALS, a property of the query language and the embedding model. The floor and the cap describe the corpus's shape — how far a stranger's question lands from it, and how many chances one source gets to answer. Corpus growth moves the second kind and leaves the first alone.",
+    "the_fix_is_a_command_not_a_resolution": "`python -m scripts.retrieval_sweep --all` re-picks all three and prints the evidence. The drift happened because re-measuring was an afternoon of ad-hoc scripting; it will happen again if it stays that way. Re-run it after any corpus or embedding-model change.",
+    "measurement_bug_found_while_fixing_it": "The band edges were being read through a CAPPED result set. The cap can displace the chunk that is closest in L2 (when it is a source's second passage), so the on-topic worst distance read 1.416 under cap=1 instead of the true 1.383 — which would have overstated how tight a floor could safely be, on exactly the decision it feeds. `retrieve(max_per_source=0)` now exists so evaluators see the pool the floor really gates, and scripts/retrieval_eval.py uses it for the unfiltered pass."
+  },
+  "corpus_now": {
+    "measured": "2026-09-01",
+    "chunks": 3935,
+    "distinct_sources": 25,
+    "largest": {
+      "Goddek et al. 2019": 2576,
+      "FAO 589": 992,
+      "smart aquaponics review": 215,
+      "Love et al. 2014": 65,
+      "curated knowledge/*.md (21 files)": 82
+    }
+  },
+  "final_2026_09": {
+    "config": {
+      "relevance_floor": 1.5,
+      "max_per_source": 1,
+      "hybrid_beta": 0.9
+    },
+    "hit_rate": 0.879,
+    "recall@k": 0.833,
+    "precision@k": 0.364,
+    "MRR": 0.657,
+    "MAP@k": 0.624,
+    "latency_ms": 272,
+    "off_topic_rejected": "8/10",
+    "real_queries_silenced": "0/33",
+    "band_edges": {
+      "worst_on_topic": 1.383,
+      "closest_off_topic": 1.411,
+      "separable": true,
+      "headroom_at_1.50": 0.117
+    },
+    "vs_pre_tuning_on_the_same_corpus": {
+      "was": {
+        "config": {
+          "relevance_floor": 1.65,
+          "max_per_source": 2,
+          "hybrid_beta": 0.9
+        },
+        "hit_rate": 0.848,
+        "recall@k": 0.758,
+        "precision@k": 0.444,
+        "MRR": 0.646,
+        "MAP@k": 0.578,
+        "off_topic_rejected": "4/10"
+      },
+      "delta": {
+        "hit_rate": 0.031,
+        "recall@k": 0.075,
+        "precision@k": -0.08,
+        "MRR": 0.011,
+        "MAP@k": 0.046,
+        "off_topic_rejected": "+4"
+      },
+      "on_the_precision_drop": "Real but partly structural. `relevant` is labelled at DOCUMENT granularity, so cap=1 bounds precision@3 at 0.333 for any query with a single relevant document, however good the answer. Recall and MAP are not so bounded and both move decisively the other way, so they decided it."
+    }
+  }
 }

--- a/docs/dpg/retrieval_eval/techniques.json
+++ b/docs/dpg/retrieval_eval/techniques.json
@@ -19,20 +19,20 @@
     {
       "name": "Relevance floor",
       "ships": "ON (1.50, was 1.65)",
-      "evidence": "3935 chunks: rejects 8/10 off-topic, silences 0/33 real, 0.117 headroom above the worst real query (1.383). At 1354 chunks: 1.65, 8/10, 0/33.",
+      "evidence": "3941 chunks: rejects 8/10 off-topic, silences 0/33 real, 0.117 headroom above the worst real query (1.383). COSTS retrieval quality to do it (1.65 scores hit 0.909 / MAP 0.624 against 1.50's 0.879 / 0.604) — a safety trade, not an improvement.",
       "note": "REVERSED PREMISE. The bands OVERLAPPED at 1354 chunks (on-topic worst 1.548 above off-topic best 1.426) and no floor could separate them. At 3935 they SEPARATE (1.383 < 1.411), because more corpus means a closer match for every real question. Not tightened to 1.40 despite that rejecting 10/10: it clears the worst real query by 0.017, and this project already rejected a 0.032 margin as too thin. The golden set has 33 queries; headroom is what protects the 34th."
     },
     {
       "name": "Hybrid BM25 + RRF",
       "ships": "ON (beta=0.90)",
-      "evidence": "362 chunks: lost at every beta. 1354 chunks: recall +0.091, MAP +0.091 3935 chunks: re-confirmed at beta=0.90, and now ahead of dense-only on hit_rate too (0.879 vs 0.848).",
+      "evidence": "362 chunks: lost at every beta. 1354 chunks: recall +0.091, MAP +0.091 3941 chunks: re-confirmed at beta=0.90, and now ahead of dense-only on hit_rate too (0.879 vs 0.848 for dense-only).",
       "note": "REVERSED. The technique did not change; the corpus did. Only 10% keyword weight is correct. Beta is the ONE constant a 3x corpus growth did not move."
     },
     {
       "name": "Per-source cap",
       "ships": "ON (1, was 2)",
-      "evidence": "3935 chunks, floor 1.50: cap=1 hit 0.879 / recall 0.833 / MAP 0.624 vs cap=2's 0.818 / 0.727 / 0.568. At 1354 chunks cap=2 won on precision.",
-      "note": "REVERSED. cap=2 was right against ONE oversized source; there are now TWO (3853 of 3935 chunks are books, curated files are 2%), so cap=2 lets books take two of three slots — the same failure the cap exists to stop, through a door it left open. The deciding gap widened roughly fourfold: cap=1 bought +0.031 hit at 1354 chunks and buys +0.061 here."
+      "evidence": "3941 chunks, floor 1.50: cap=1 hit 0.879 / recall 0.833 / MAP 0.604 vs cap=2's 0.788 / 0.697 / 0.538. At 1354 chunks cap=2 won on precision.",
+      "note": "REVERSED. cap=2 was right against ONE oversized source; there are now TWO (3848 of 3941 chunks are books, curated files are 2.4%), so cap=2 lets books take two of three slots — the same failure the cap exists to stop, through a door it left open. The deciding gap widened roughly fourfold: cap=1 bought +0.031 hit at 1354 chunks and buys +0.061 here."
     },
     {
       "name": "PDF cleaning",
@@ -62,7 +62,7 @@
       "name": "Cross-encoder reranking",
       "ships": "OFF",
       "evidence": "hit 0.939->0.879, latency 274->761 ms",
-      "note": "ms-marco model is out of domain for operator phrasing against agronomy prose. NOT re-measured at 3935 chunks — recorded as stale rather than presented as current. A technique that lost on every metric and tripled latency does not become the priority when the corpus grows."
+      "note": "ms-marco model is out of domain for operator phrasing against agronomy prose. NOT re-measured at 3941 chunks — recorded as stale rather than presented as current. A technique that lost on every metric and tripled latency does not become the priority when the corpus grows."
     },
     {
       "name": "Query rewriting",
@@ -79,7 +79,7 @@
       "name": "Sweep harness (scripts/retrieval_sweep.py)",
       "ships": "N/A — tooling",
       "evidence": "Reproduces the floor/cap/beta tables above in one command.",
-      "note": "Built because the drift above was not a carelessness problem. Re-measuring three constants was an afternoon of ad-hoc scripting, so it did not happen when the corpus changed. The floor picker encodes the project's ACTUAL decision rule — zero real queries silenced, then a minimum 0.10 headroom, then maximum rejections — rather than maximising a metric, because a naive picker chose 1.40 here and 1.40 is the wrong answer for a reason no metric in the table can see."
+      "note": "Built because the drift above was not a carelessness problem. Re-measuring three constants was an afternoon of ad-hoc scripting, so it did not happen when the corpus changed. The floor picker encodes the project's ACTUAL decision rule — zero real queries silenced, then a minimum 0.10 headroom, then maximum rejections — rather than maximising a metric, because a naive picker chose 1.40 here and 1.40 is the wrong answer for a reason no metric in the table can see. A second rule was added after the first real use: differences under 0.01 in a rate metric do not decide anything. A strict argmax picked beta=1.0 (hybrid OFF) over 0.90 on a 0.002 MAP win while hit_rate and recall each fell ~0.030 — one query out of 33 is 0.030, so 0.002 is noise."
     }
   ],
   "the_pattern": "Four of the eight measured techniques LOST, and three of those four share one mechanism: they add topic words (a section crumb, a chapter name, a heading) to chunks in a corpus where every document already shares a vocabulary domain. Words that appear in every chunk about a topic carry no discriminating information — they only dilute the distinctive content already in the vector. What DID work was structural instead of lexical: refusing irrelevant passages, refusing error pages, and refusing to let one source occupy every slot. A ninth technique has since been added and a corpus drift recorded: see `corpus_drift_warning`. The lesson the hybrid reversal taught — a measurement is a property of a corpus and expires when the corpus moves — has now applied to the per-source cap and the relevance floor as well.",
@@ -87,27 +87,30 @@
     "status": "RESOLVED 2026-09-01 by re-calibration; kept as the case history",
     "what_happened": "techniques.json was written 2026-08-25. Commit 70b2d00 added Goddek et al. (2019) on 2026-08-26 — one day later — taking the corpus from 1354 to 3935 chunks. Nothing was re-measured, so every constant here was calibrated for a corpus that no longer existed.",
     "cost_of_the_drift": {
-      "hit_rate": -0.091,
-      "recall@k": -0.136,
-      "precision@k": -0.096,
-      "MRR": -0.091,
-      "MAP@k": -0.119,
+      "note": "Measured on the 3941-chunk corpus with the 1354-era constants still in place.",
+      "hit_rate": -0.121,
+      "recall@k": -0.167,
+      "precision@k": -0.111,
+      "MRR": -0.121,
+      "MAP@k": -0.149,
       "off_topic_rejected": "8/10 -> 4/10"
     },
     "what_moved_and_what_did_not": "The floor and the cap both moved; beta did not. That is informative rather than incidental: beta describes the relationship between two RANKING SIGNALS, a property of the query language and the embedding model. The floor and the cap describe the corpus's shape — how far a stranger's question lands from it, and how many chances one source gets to answer. Corpus growth moves the second kind and leaves the first alone.",
     "the_fix_is_a_command_not_a_resolution": "`python -m scripts.retrieval_sweep --all` re-picks all three and prints the evidence. The drift happened because re-measuring was an afternoon of ad-hoc scripting; it will happen again if it stays that way. Re-run it after any corpus or embedding-model change.",
-    "measurement_bug_found_while_fixing_it": "The band edges were being read through a CAPPED result set. The cap can displace the chunk that is closest in L2 (when it is a source's second passage), so the on-topic worst distance read 1.416 under cap=1 instead of the true 1.383 — which would have overstated how tight a floor could safely be, on exactly the decision it feeds. `retrieve(max_per_source=0)` now exists so evaluators see the pool the floor really gates, and scripts/retrieval_eval.py uses it for the unfiltered pass."
+    "measurement_bug_found_while_fixing_it": "The band edges were being read through a CAPPED result set. The cap can displace the chunk that is closest in L2 (when it is a source's second passage), so the on-topic worst distance read 1.416 under cap=1 instead of the true 1.383 — which would have overstated how tight a floor could safely be, on exactly the decision it feeds. `retrieve(max_per_source=0)` now exists so evaluators see the pool the floor really gates, and scripts/retrieval_eval.py uses it for the unfiltered pass.",
+    "it_happened_again_during_this_work": "While this branch was open, main added a 22nd knowledge file and the corpus moved from 3935 to 3941 chunks. The sweep was re-run rather than the earlier numbers reused. That is the whole argument for the harness: the corpus moved twice in eight days."
   },
   "corpus_now": {
     "measured": "2026-09-01",
-    "chunks": 3935,
-    "distinct_sources": 25,
+    "chunks": 3941,
+    "distinct_sources": 26,
+    "curated_files": 22,
+    "curated_chunks": 93,
     "largest": {
       "Goddek et al. 2019": 2576,
       "FAO 589": 992,
       "smart aquaponics review": 215,
-      "Love et al. 2014": 65,
-      "curated knowledge/*.md (21 files)": 82
+      "Love et al. 2014": 65
     }
   },
   "final_2026_09": {
@@ -119,9 +122,8 @@
     "hit_rate": 0.879,
     "recall@k": 0.833,
     "precision@k": 0.364,
-    "MRR": 0.657,
-    "MAP@k": 0.624,
-    "latency_ms": 272,
+    "MRR": 0.636,
+    "MAP@k": 0.604,
     "off_topic_rejected": "8/10",
     "real_queries_silenced": "0/33",
     "band_edges": {
@@ -130,29 +132,30 @@
       "separable": true,
       "headroom_at_1.50": 0.117
     },
-    "vs_pre_tuning_on_the_same_corpus": {
+    "vs_previous_config_same_corpus": {
       "was": {
         "config": {
           "relevance_floor": 1.65,
           "max_per_source": 2,
           "hybrid_beta": 0.9
         },
-        "hit_rate": 0.848,
-        "recall@k": 0.758,
-        "precision@k": 0.444,
-        "MRR": 0.646,
-        "MAP@k": 0.578,
+        "hit_rate": 0.818,
+        "recall@k": 0.727,
+        "precision@k": 0.429,
+        "MRR": 0.616,
+        "MAP@k": 0.548,
         "off_topic_rejected": "4/10"
       },
       "delta": {
-        "hit_rate": 0.031,
-        "recall@k": 0.075,
-        "precision@k": -0.08,
-        "MRR": 0.011,
-        "MAP@k": 0.046,
+        "hit_rate": 0.061,
+        "recall@k": 0.106,
+        "precision@k": -0.065,
+        "MRR": 0.02,
+        "MAP@k": 0.056,
         "off_topic_rejected": "+4"
-      },
-      "on_the_precision_drop": "Real but partly structural. `relevant` is labelled at DOCUMENT granularity, so cap=1 bounds precision@3 at 0.333 for any query with a single relevant document, however good the answer. Recall and MAP are not so bounded and both move decisively the other way, so they decided it."
-    }
+      }
+    },
+    "which_change_did_what": "The two constants pull in opposite directions and the writeup must not blur them. The FLOOR alone COSTS retrieval quality: at cap=1, loosening to 1.65 scores hit 0.909 / MAP 0.624 against 1.50's 0.879 / 0.604. It is bought deliberately, doubling off-topic refusal from 4/10 to 8/10. The CAP is what pays for it: at floor 1.50, cap=1 gives 0.879 / 0.833 / 0.604 against cap=2's 0.788 / 0.697 / 0.538. Net, the pair is ahead on every metric except precision.",
+    "on_the_precision_drop": "Real but partly structural. `relevant` is labelled at DOCUMENT granularity, so cap=1 bounds precision@3 at 0.333 for any query with a single relevant document, however good the answer. Recall and MAP are not so bounded and both move decisively the other way."
   }
 }

--- a/scripts/faithfulness_eval.py
+++ b/scripts/faithfulness_eval.py
@@ -1,0 +1,361 @@
+"""Generation quality scorer — faithfulness, response relevancy and citation accuracy.
+
+`scripts/retrieval_eval.py` answers "did the retriever find the right documents". It cannot
+answer the question RAG actually exists to answer: did the ANSWER use them. A system can score
+recall@k 0.894 and still hallucinate every number in its reply, and until now nothing here
+would have noticed.
+
+Three metrics, deliberately of three different kinds:
+
+  faithfulness       (LLM-judged) The answer is decomposed into atomic claims and each claim is
+                     judged supported or unsupported BY THE RETRIEVED CONTEXT ALONE. This is the
+                     grounding measure: the fraction of claims the context actually backs.
+                     A claim that is true in the world but absent from the context counts as
+                     UNSUPPORTED, and that is the point — an answer the retrieval did not
+                     justify is a hallucination that happened to land well.
+
+  response_relevancy (LLM-judged + embeddings) The judge writes questions the answer would be a
+                     good reply to; those are embedded and compared to the real query. It scores
+                     whether the answer addressed what was asked, and says nothing about truth.
+
+  citation_accuracy  (CODE-judged, no model) Every "[source: X]" the answer cites must be a
+                     source that was actually retrieved. Cheap, exact, and it catches the
+                     specific failure the course warns about twice: LLMs hallucinate citations,
+                     and a fabricated citation is worse than none because it survives review.
+
+WHY THE JUDGE IS TREATED AS A WITNESS, NOT AN ORACLE. M5 is explicit that LLM-as-judge splits
+the difference between cost and flexibility, and M4 that judges favour their own model family.
+So: every rubric is binary with named labels, an unparseable verdict is counted as UNJUDGED
+rather than quietly folded into either side, and `n_unjudged` is printed next to every score.
+A metric with a third of its claims unjudged is not a 0.9, it is a 0.9 you should not trust,
+and the report has to be able to say so.
+
+NOT HERMETIC. It calls the configured LLM over the network, so it is opt-in
+(AGRONAUT_FAITHFULNESS_EVAL=1), never runs in CI, and never blocks a merge. The parsing and
+scoring functions are pure and take plain strings, so the arithmetic is unit-tested without a
+model (agronaut_agent/tests/test_faithfulness_eval.py).
+
+Run it:
+    AGRONAUT_FAITHFULNESS_EVAL=1 python -m scripts.faithfulness_eval
+    AGRONAUT_FAITHFULNESS_EVAL=1 python -m scripts.faithfulness_eval --limit 8 --save report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+_GOLDEN = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "retrieval_eval" / "golden_set.json"
+_OUT_DIR = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "faithfulness_eval"
+
+# How many questions the relevancy judge is asked to reverse-engineer from an answer. RAGAS uses
+# three; more would smooth the estimate but every one is a model call per query.
+_N_REVERSE_QUESTIONS = 3
+
+
+# --- pure parsing and scoring (no model, no network — unit-testable) ---------
+
+def parse_claims(text: str) -> list[str]:
+    """Pull atomic claims out of a judge's numbered or bulleted list.
+
+    Tolerant of the three shapes models actually emit ("1. x", "- x", "* x") and of a preamble
+    before the list, because a judge told to answer with only a list will still sometimes open
+    with "Here are the claims:". Lines that survive as empty are dropped.
+    """
+    claims = []
+    for line in (text or "").splitlines():
+        line = line.strip()
+        m = re.match(r"^(?:[-*•]|\d+[.)])\s+(.*)$", line)
+        if m and m.group(1).strip():
+            claims.append(m.group(1).strip())
+    return claims
+
+
+def parse_verdict(text: str) -> bool | None:
+    """SUPPORTED -> True, UNSUPPORTED -> False, anything else -> None (unjudged).
+
+    Order matters: "UNSUPPORTED" contains "SUPPORTED", so the negative label must be tested
+    first or every rejection would read as an acceptance. Checked on a bare-word boundary so a
+    judge that explains itself ("UNSUPPORTED — the context never mentions...") still parses.
+    """
+    up = (text or "").upper()
+    if re.search(r"\bUNSUPPORTED\b", up):
+        return False
+    if re.search(r"\bSUPPORTED\b", up):
+        return True
+    return None
+
+
+def cited_sources(answer: str) -> list[str]:
+    """Source labels the answer cites, in the "[source: knowledge/foo.md]" form the retriever
+    stamps onto every passage. Deduplicated, order preserved."""
+    seen, out = set(), []
+    for m in re.finditer(r"\[source:\s*([^\]]+)\]", answer or ""):
+        label = m.group(1).strip()
+        if label and label not in seen:
+            seen.add(label)
+            out.append(label)
+    return out
+
+
+def citation_accuracy(answer: str, retrieved: list[str]) -> tuple[float | None, list[str]]:
+    """(fraction of cited sources that were actually retrieved, the fabricated ones).
+
+    None when the answer cites nothing — that is not a score of zero. An answer with no
+    citations has no citation accuracy to measure, and averaging it in as 0.0 would make an
+    uncited system look like a lying one. The two failures are different and the report keeps
+    them apart.
+    """
+    cites = cited_sources(answer)
+    if not cites:
+        return None, []
+    allowed = set(retrieved)
+    bogus = [c for c in cites if c not in allowed]
+    return (len(cites) - len(bogus)) / len(cites), bogus
+
+
+def faithfulness_score(verdicts: list) -> dict:
+    """Supported / judged, with the unjudged count carried alongside rather than hidden.
+
+    `score` is None when nothing could be judged, so a run where the judge failed entirely
+    reports "no measurement" instead of a confident zero.
+    """
+    judged = [v for v in verdicts if v is not None]
+    return {
+        "score": (sum(1 for v in judged if v) / len(judged)) if judged else None,
+        "n_claims": len(verdicts),
+        "n_judged": len(judged),
+        "n_unjudged": len(verdicts) - len(judged),
+    }
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity, 0.0 for a zero-length vector rather than a ZeroDivisionError."""
+    num = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    return (num / (na * nb)) if na and nb else 0.0
+
+
+def aggregate(per_query: list[dict]) -> dict:
+    """Mean each metric over the queries that produced one, never over all queries.
+
+    A query whose judge failed contributes to `n` for its own metric and to nothing else, so a
+    partially failed run reports smaller samples rather than depressed scores.
+    """
+    def _mean(key):
+        vals = [q[key] for q in per_query if q.get(key) is not None]
+        return {"mean": (sum(vals) / len(vals)) if vals else None, "n": len(vals)}
+
+    return {
+        "queries": len(per_query),
+        "faithfulness": _mean("faithfulness"),
+        "response_relevancy": _mean("response_relevancy"),
+        "citation_accuracy": _mean("citation_accuracy"),
+        "claims_unjudged": sum(q.get("n_unjudged", 0) for q in per_query),
+        "fabricated_citations": sum(len(q.get("fabricated", [])) for q in per_query),
+    }
+
+
+# --- prompts ----------------------------------------------------------------
+
+_CLAIMS_PROMPT = """Break the ANSWER into atomic factual claims.
+
+Rules:
+- One claim per line, numbered "1.", "2.", ...
+- Each claim must stand alone and state ONE fact.
+- Copy the substance of the answer; do not add, correct, or evaluate anything.
+- Ignore questions, greetings, and offers of further help — those are not claims.
+- Output the numbered list and nothing else.
+
+ANSWER:
+{answer}"""
+
+_VERDICT_PROMPT = """Decide whether the CONTEXT supports the CLAIM.
+
+Answer with exactly one word:
+- SUPPORTED   if the CONTEXT states or directly implies the claim.
+- UNSUPPORTED if it does not.
+
+Judge ONLY against the CONTEXT. A claim you believe is true in the real world is still
+UNSUPPORTED if the CONTEXT does not back it. When genuinely unsure, answer UNSUPPORTED.
+
+CONTEXT:
+{context}
+
+CLAIM: {claim}"""
+
+_REVERSE_PROMPT = """Read the ANSWER and write {n} questions it would be a good reply to.
+
+Rules:
+- One question per line, numbered "1.", "2.", ...
+- Base them only on what the ANSWER actually addresses.
+- Output the numbered list and nothing else.
+
+ANSWER:
+{answer}"""
+
+
+# --- the run ----------------------------------------------------------------
+
+def score_query(query: str, answer: str, context: str, retrieved: list[str],
+                ask, embed) -> dict:
+    """Score one (query, answer, context) triple. `ask` is str->str, `embed` is str->vector.
+
+    Both are injected so the whole scoring path can be exercised with fakes; nothing in here
+    reaches the network on its own.
+    """
+    claims = parse_claims(ask(_CLAIMS_PROMPT.format(answer=answer)))
+    verdicts = [parse_verdict(ask(_VERDICT_PROMPT.format(context=context, claim=c)))
+                for c in claims]
+    faith = faithfulness_score(verdicts)
+
+    relevancy = None
+    try:
+        reverse = parse_claims(ask(_REVERSE_PROMPT.format(n=_N_REVERSE_QUESTIONS, answer=answer)))
+        if reverse:
+            qv = embed(query)
+            sims = [cosine(qv, embed(r)) for r in reverse]
+            relevancy = sum(sims) / len(sims)
+    except Exception as exc:  # noqa: BLE001 — one failed metric must not void the other two
+        print(f"    relevancy unavailable: {exc}")
+
+    cite_acc, bogus = citation_accuracy(answer, retrieved)
+    return {
+        "query": query,
+        "faithfulness": faith["score"],
+        "n_claims": faith["n_claims"],
+        "n_unjudged": faith["n_unjudged"],
+        "response_relevancy": relevancy,
+        "citation_accuracy": cite_acc,
+        "fabricated": bogus,
+        "retrieved": retrieved,
+    }
+
+
+def run(limit: int | None = None, ask=None, embed=None, answer_fn=None) -> dict:
+    """Score the golden-set queries end to end: retrieve, answer, then judge.
+
+    The answer is generated by the SAME model and the SAME grounding instruction the live
+    agent uses, but through a single direct call rather than the tool loop. That keeps the
+    measurement about generation quality: a tool-loop answer's faithfulness would also be
+    measuring whether the model chose to call the retriever at all, which is a different
+    question with its own metric already.
+    """
+    from agronaut_agent import rag
+
+    golden = json.loads(_GOLDEN.read_text())
+    queries = golden["queries"][:limit] if limit else golden["queries"]
+
+    if ask is None or embed is None or answer_fn is None:
+        ask, embed, answer_fn = _live_backends(ask, embed, answer_fn)
+
+    per_query = []
+    for i, item in enumerate(queries, start=1):
+        q = item["query"]
+        print(f"[{i}/{len(queries)}] {q[:70]}")
+        hits = rag.retrieve(q, k=golden.get("k", 3))
+        if not hits:
+            print("    no passages retrieved — skipped (that is a RETRIEVAL result, "
+                  "already scored by scripts/retrieval_eval.py)")
+            continue
+        context = "\n\n".join(f"[source: {h['source']}]\n{h['text']}" for h in hits)
+        sources = [h["source"] for h in hits]
+        try:
+            answer = answer_fn(q, context)
+        except Exception as exc:  # noqa: BLE001
+            print(f"    generation failed: {exc}")
+            continue
+        row = score_query(q, answer, context, sources, ask, embed)
+        row["id"] = item.get("id")
+        per_query.append(row)
+        print(f"    faithfulness={_fmt(row['faithfulness'])} "
+              f"relevancy={_fmt(row['response_relevancy'])} "
+              f"citations={_fmt(row['citation_accuracy'])}"
+              + (f"  FABRICATED: {row['fabricated']}" if row["fabricated"] else ""))
+
+    return {"summary": aggregate(per_query), "per_query": per_query}
+
+
+def _live_backends(ask, embed, answer_fn):
+    """Build the real judge, embedder and answerer. Imported lazily so `run()` with fakes
+    never needs a model installed or an API key set."""
+    from agent.llm import get_llm
+    from agronaut_agent import semantic
+
+    judge = get_llm(temperature=0.0)
+    ask = ask or (lambda prompt: judge.invoke(prompt))
+    if embed is None:
+        # semantic.default_embedder() is batch-shaped (list of texts -> array of vectors);
+        # the metrics here compare one text at a time, so adapt rather than reshape callers.
+        batch = semantic.default_embedder()
+        if batch is None:
+            raise RuntimeError("No embedding model available; response_relevancy needs one. "
+                               "Unset AGRONAUT_EMBEDDINGS=off, or install sentence-transformers.")
+
+        def embed(text):
+            return list(batch([text])[0])
+
+    def _answer(query: str, context: str) -> str:
+        return judge.invoke(
+            "You are Agronaut, an aquaponics assistant. Answer the QUESTION using ONLY the "
+            "CONTEXT. Cite each source you use inline as [source: <label>], exactly as the "
+            "label appears. If the context does not answer the question, say so plainly.\n\n"
+            f"CONTEXT:\n{context}\n\nQUESTION: {query}")
+
+    return ask, embed, (answer_fn or _answer)
+
+
+def _fmt(v) -> str:
+    return "  n/a" if v is None else f"{v:.3f}"
+
+
+def _print(report: dict) -> None:
+    s = report["summary"]
+    print("\n" + "=" * 62)
+    print(f"Generation quality over {s['queries']} answered queries")
+    print("=" * 62)
+    for key in ("faithfulness", "response_relevancy", "citation_accuracy"):
+        m = s[key]
+        print(f"  {key:20s} {_fmt(m['mean'])}   (n={m['n']})")
+    print(f"  claims unjudged      {s['claims_unjudged']}")
+    print(f"  fabricated citations {s['fabricated_citations']}")
+    if s["citation_accuracy"]["n"] < s["queries"]:
+        print(f"\n  NOTE: {s['queries'] - s['citation_accuracy']['n']} answer(s) cited nothing at "
+              "all. Uncited is not the same failure as miscited and is not averaged in.")
+    if s["claims_unjudged"]:
+        print("\n  NOTE: some claims could not be judged. Treat faithfulness as measured over "
+              "the judged subset only.")
+
+
+def main() -> int:  # pragma: no cover - CLI
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit", type=int, help="score only the first N golden-set queries")
+    ap.add_argument("--save", help="write the full report to this JSON path")
+    args = ap.parse_args()
+
+    if os.getenv("AGRONAUT_FAITHFULNESS_EVAL", "").lower() not in {"1", "true", "yes"}:
+        print("Generation eval is opt-in — it calls the configured LLM over the network.")
+        print("  Run: AGRONAUT_FAITHFULNESS_EVAL=1 python -m scripts.faithfulness_eval")
+        return 0
+
+    report = run(limit=args.limit)
+    _print(report)
+    if args.save:
+        out = Path(args.save)
+        if not out.is_absolute() and out.parent == Path("."):
+            _OUT_DIR.mkdir(parents=True, exist_ok=True)
+            out = _OUT_DIR / out.name
+        out.write_text(json.dumps(report, indent=2))
+        print(f"\nSaved {out}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/retrieval_eval.py
+++ b/scripts/retrieval_eval.py
@@ -121,7 +121,10 @@ def run(k: int | None = None, retrieve=None, unfiltered=None, no_floor: bool = F
         inf = float("inf")
         retrieve = (lambda q, kk: rag.retrieve(q, kk, max_dist=inf)) if no_floor else rag.retrieve
         if unfiltered is None:
-            unfiltered = lambda q, kk: rag.retrieve(q, kk, max_dist=inf)  # noqa: E731
+            # No floor AND no per-source cap. The cap can displace the very chunk that is closest
+            # in L2 (when it is a source's second passage), so a "raw" distance measured through
+            # a capped result set is too high and would overstate how tight a floor can be.
+            unfiltered = lambda q, kk: rag.retrieve(q, kk, max_dist=inf, max_per_source=0)  # noqa: E731
     if unfiltered is None:
         unfiltered = retrieve
 

--- a/scripts/retrieval_sweep.py
+++ b/scripts/retrieval_sweep.py
@@ -1,0 +1,253 @@
+"""Re-measure the tunable retrieval constants against the CURRENT corpus.
+
+Every number in `docs/dpg/retrieval_eval/techniques.json` is a property of the corpus it was
+measured on. That has now bitten twice: hybrid search lost at 362 chunks and won at 1354, and
+the floor/cap values calibrated at 1354 chunks were invalidated the next day when a 2576-chunk
+book joined and nobody re-ran anything. The lesson is not "be more careful" — it is that
+re-measuring has to be one command, or it does not happen.
+
+Three constants, each swept independently:
+
+    --floor  AGRONAUT_RELEVANCE_MAX_DISTANCE   how far a passage may sit and still be used
+    --cap    AGRONAUT_MAX_PER_SOURCE           passages allowed from any one source
+    --beta   AGRONAUT_HYBRID_BETA              weight on semantic vs keyword ranking
+
+SWEPT IN THAT ORDER, NOT AS A GRID. A full grid is 100+ variants and roughly an hour, and the
+three constants are close to separable: the floor decides WHETHER the corpus may answer, the cap
+decides WHO fills the slots among passages that already cleared it, and beta only reorders. So
+each stage fixes the winner of the previous one, and `--verify` re-runs the final combination
+end to end. Where that assumption is weakest — a much tighter floor shrinks the pool the cap then
+draws from — the cap stage is run under the NEW floor, which is exactly where the interaction
+lives.
+
+The floor is judged on different evidence from the rest. Its job is refusal, so it is scored on
+the negative controls (off-topic queries it rejects) against the constraint that must never
+break: zero real queries silenced. A floor that scores well on recall by admitting everything has
+not done its job.
+
+Run it:
+    python -m scripts.retrieval_sweep --floor 1.30 1.40 1.50 1.65
+    python -m scripts.retrieval_sweep --all --save sweep_2026_09.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts import retrieval_eval  # noqa: E402
+
+_OUT_DIR = Path(__file__).resolve().parents[1] / "docs" / "dpg" / "retrieval_eval"
+
+# Defaults chosen around the values that ship today, plus the region the separation report
+# points at. Overridable per run.
+_FLOORS = [1.30, 1.35, 1.40, 1.45, 1.50, 1.65]
+_CAPS = [1, 2, 3, 0]           # 0 = no cap
+_BETAS = [0.50, 0.70, 0.90, 1.00]
+
+_METRICS = ["hit_rate", "recall@k", "precision@k", "MRR", "MAP@k"]
+
+# Minimum distance a floor must sit ABOVE the worst real query before it is considered shippable.
+#
+# Not invented here: it is the rule this project already applied and wrote down. The original
+# calibration chose 1.65 over a tighter 1.58 explicitly because 1.58 "leaves only 0.032 of
+# headroom above the worst real query, versus 0.10 at 1.65", and judged that "a threefold cut in
+# safety margin for one extra rejection" was a bad trade. 0.10 is the value that reasoning
+# accepted, so it is the constraint, and the picker enforces it instead of leaving it to whoever
+# reads the table.
+#
+# The constraint exists because "silences 0 of 33 real queries" is measured on 33 queries. The
+# 34th is the one that matters, and headroom is the only thing standing between it and a refusal.
+_MIN_HEADROOM = 0.10
+
+
+def _score(floor=None, cap=None, beta=None) -> dict:
+    """Score one configuration. Env vars are the seam because that is how the shipped code
+    reads these constants — a sweep that bypassed them could pass while the real path fails."""
+    from agronaut_agent import rag
+
+    env = {}
+    if floor is not None:
+        env["AGRONAUT_RELEVANCE_MAX_DISTANCE"] = str(floor)
+    if cap is not None:
+        env["AGRONAUT_MAX_PER_SOURCE"] = str(cap)
+    if beta is not None:
+        env["AGRONAUT_HYBRID_BETA"] = str(beta)
+    old = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        inf = float("inf")
+        report = retrieval_eval.run(
+            retrieve=rag.retrieve,
+            # No floor and no cap: the band edges must not move as the swept constants move,
+            # or headroom is not comparable between rows.
+            unfiltered=lambda q, kk: rag.retrieve(q, kk, max_dist=inf, max_per_source=0))
+    finally:
+        for k, v in old.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    # Carry the two band edges alongside the metrics. They are measured UNFILTERED, so they do
+    # not move as the floor moves — which is what makes headroom comparable across variants.
+    s = dict(report["summary"])
+    on = [r["raw_top_score"] for r in report["per_query"] if r.get("raw_top_score") is not None]
+    off = [n["top_score"] for n in report["negative_controls"] if n["top_score"] is not None]
+    s["worst_on_topic"] = max(on) if on else None
+    s["best_off_topic"] = min(off) if off else None
+    return s
+
+
+def _row(label: str, s: dict, headroom=None) -> str:
+    line = (f"  {label:<7}"
+            + "".join(f"{s[m]:>8.3f}" for m in _METRICS)
+            + f"{s['floor_silenced_on_topic']:>9d}"
+            + f"{s['floor_rejected_off_topic']:>8d}/{s['negative_controls']}")
+    if headroom is not None:
+        line += f"{headroom:>10.3f}"
+    return line
+
+
+def _header(with_headroom: bool = False) -> str:
+    h = ("  " + f"{'value':<7}" + "".join(f"{m:>8}" for m in _METRICS)
+         + f"{'silenced':>9}" + f"{'rejected':>10}")
+    return h + f"{'headroom':>10}" if with_headroom else h
+
+
+def sweep(kind: str, values: list, fixed: dict) -> list[dict]:
+    is_floor = kind == "floor"
+    print(f"\n{'=' * 88}\n{kind.upper()} sweep   (holding {fixed or 'shipped defaults'})\n{'=' * 88}")
+    print(_header(with_headroom=is_floor))
+    out = []
+    for v in values:
+        s = _score(**{**fixed, kind: v})
+        row = {"value": v, **{m: round(s[m], 4) for m in _METRICS},
+               "silenced_on_topic": s["floor_silenced_on_topic"],
+               "rejected_off_topic": s["floor_rejected_off_topic"],
+               "negative_controls": s["negative_controls"],
+               "latency_ms": round(s["latency_ms_mean"])}
+        headroom = None
+        if is_floor and s["worst_on_topic"] is not None:
+            headroom = round(v - s["worst_on_topic"], 4)
+            row["worst_on_topic"] = round(s["worst_on_topic"], 4)
+            row["headroom"] = headroom
+        out.append(row)
+        label = "none" if (kind == "cap" and v == 0) else str(v)
+        print(_row(label, s, headroom))
+    return out
+
+
+def pick_floor(rows: list[dict]) -> dict | None:
+    """Best floor under TWO hard constraints, then most off-topic rejections.
+
+    Constraint 1 — silences zero real queries. Not a metric to trade against: an off-topic
+    question that gets an honest "no matching passages" has been served correctly, while a real
+    question refused service has not.
+
+    Constraint 2 — at least `_MIN_HEADROOM` above the worst real query. This is the constraint a
+    naive picker misses and it changes the answer. Maximising rejections alone selects the
+    tightest floor that happens to clear the 33 queries in the golden set, which on this corpus
+    means sitting 0.017 away from a real query — a value that passes the sample and would refuse
+    the next operator whose phrasing lands slightly further out.
+
+    Ties break toward MORE headroom, never toward tighter: when two floors reject the same number
+    of controls with the same hit rate, the looser one is strictly safer and costs nothing.
+    """
+    viable = [r for r in rows if r["silenced_on_topic"] == 0
+              and r.get("headroom", 0) >= _MIN_HEADROOM]
+    if not viable:
+        return None
+    best_reject = max(r["rejected_off_topic"] for r in viable)
+    front = [r for r in viable if r["rejected_off_topic"] == best_reject]
+    best_hit = max(r["hit_rate"] for r in front)
+    front = [r for r in front if r["hit_rate"] >= best_hit - 0.001]
+    return max(front, key=lambda r: r.get("headroom", 0.0))
+
+
+def pick_by(rows: list[dict], metric: str) -> dict:
+    return max(rows, key=lambda r: (r[metric], r["hit_rate"]))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--floor", nargs="*", type=float, metavar="D")
+    ap.add_argument("--cap", nargs="*", type=int, metavar="N")
+    ap.add_argument("--beta", nargs="*", type=float, metavar="B")
+    ap.add_argument("--all", action="store_true", help="sweep all three, in order")
+    ap.add_argument("--save", metavar="FILE", help="write the sweep to docs/dpg/retrieval_eval/")
+    args = ap.parse_args()
+
+    if not any([args.floor is not None, args.cap is not None, args.beta is not None, args.all]):
+        ap.error("nothing to sweep — pass --floor/--cap/--beta, or --all")
+
+    result: dict = {"description": "Re-measurement of the tunable retrieval constants against "
+                                   "the corpus as it stands at run time."}
+    fixed: dict = {}
+
+    if args.all or args.floor is not None:
+        rows = sweep("floor", args.floor or _FLOORS, {})
+        chosen = pick_floor(rows)
+        result["floor"] = {"rows": rows, "chosen": chosen}
+        if chosen is None:
+            print(f"\n  NO VIABLE FLOOR — no candidate both silences 0 real queries and keeps "
+                  f"{_MIN_HEADROOM} headroom. Keeping the shipped value and sweeping the rest "
+                  f"under it.")
+        else:
+            print(f"\n  -> {chosen['value']}: rejects "
+                  f"{chosen['rejected_off_topic']}/{chosen['negative_controls']} off-topic, "
+                  f"silences 0 real, {chosen['headroom']:.3f} headroom above the worst real "
+                  f"query ({chosen['worst_on_topic']:.3f}), hit {chosen['hit_rate']:.3f}")
+            rejected_tighter = [r for r in rows
+                                if r["silenced_on_topic"] == 0
+                                and r["rejected_off_topic"] > chosen["rejected_off_topic"]]
+            for r in rejected_tighter:
+                print(f"     (not {r['value']}: rejects {r['rejected_off_topic']} but leaves only "
+                      f"{r['headroom']:.3f} headroom, under the {_MIN_HEADROOM} minimum)")
+            fixed["floor"] = chosen["value"]
+
+    if args.all or args.cap is not None:
+        rows = sweep("cap", args.cap if args.cap is not None else _CAPS, dict(fixed))
+        chosen = pick_by(rows, "MAP@k")
+        result["cap"] = {"rows": rows, "chosen": chosen, "held": dict(fixed)}
+        print(f"\n  -> best MAP@k at cap={chosen['value'] or 'none'} "
+              f"(MAP {chosen['MAP@k']:.3f}, recall {chosen['recall@k']:.3f}, "
+              f"precision {chosen['precision@k']:.3f})")
+        fixed["cap"] = chosen["value"]
+
+    if args.all or args.beta is not None:
+        rows = sweep("beta", args.beta or _BETAS, dict(fixed))
+        chosen = pick_by(rows, "MAP@k")
+        result["beta"] = {"rows": rows, "chosen": chosen, "held": dict(fixed)}
+        print(f"\n  -> best MAP@k at beta={chosen['value']} (MAP {chosen['MAP@k']:.3f})")
+        fixed["beta"] = chosen["value"]
+
+    if fixed:
+        print(f"\n{'=' * 78}\nVERIFY — the chosen combination, measured together\n{'=' * 78}")
+        print(_header())
+        s = _score(**fixed)
+        print(_row("chosen", s))
+        result["verified"] = {"config": fixed,
+                              **{m: round(s[m], 4) for m in _METRICS},
+                              "silenced_on_topic": s["floor_silenced_on_topic"],
+                              "rejected_off_topic": s["floor_rejected_off_topic"],
+                              "latency_ms": round(s["latency_ms_mean"])}
+        print(f"\n  config: {fixed}")
+
+    if args.save:
+        out = Path(args.save)
+        if not out.is_absolute() and out.parent == Path("."):
+            out = _OUT_DIR / out.name
+        out.write_text(json.dumps(result, indent=2))
+        print(f"\nsaved -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/retrieval_sweep.py
+++ b/scripts/retrieval_sweep.py
@@ -65,6 +65,18 @@ _METRICS = ["hit_rate", "recall@k", "precision@k", "MRR", "MAP@k"]
 # 34th is the one that matters, and headroom is the only thing standing between it and a refusal.
 _MIN_HEADROOM = 0.10
 
+# Smallest difference in a rate metric that is allowed to DECIDE anything.
+#
+# The golden set has 33 queries, so one query flipping moves hit_rate by 0.030. A MAP gap of
+# 0.002 is a fifteenth of that: it is sampling noise wearing a decimal point. Without this, the
+# picker chose beta=1.0 (dense-only, hybrid off) over beta=0.90 on a 0.002 MAP win while
+# hit_rate fell 0.031 and recall 0.030 the other way — turning a whole retrieval technique off
+# on the strength of a rounding difference.
+#
+# Ties inside this band are broken on hit_rate, then recall: "did the operator get a relevant
+# document at all" outranks "how well was it ranked" when the ranking difference is not real.
+_NOISE = 0.01
+
 
 def _score(floor=None, cap=None, beta=None) -> dict:
     """Score one configuration. Env vars are the seam because that is how the shipped code
@@ -171,7 +183,15 @@ def pick_floor(rows: list[dict]) -> dict | None:
 
 
 def pick_by(rows: list[dict], metric: str) -> dict:
-    return max(rows, key=lambda r: (r[metric], r["hit_rate"]))
+    """Best row by `metric`, treating differences under `_NOISE` as no difference.
+
+    Rows within the noise band of the leader are re-ranked on hit_rate, then recall. A strict
+    argmax over a 33-query sample will happily hand a decision to the third decimal place, and
+    on this corpus it did.
+    """
+    best = max(r[metric] for r in rows)
+    front = [r for r in rows if r[metric] >= best - _NOISE]
+    return max(front, key=lambda r: (r["hit_rate"], r["recall@k"], r[metric]))
 
 
 def main() -> int:


### PR DESCRIPTION
## What this changes

Audited the retrieval stack against all five RAG course modules. Retrieval was ahead of the syllabus on method; observability was about half of it. Four gaps closed, plus a regression found while verifying the first.

**Metadata filtering** — the third leg of M2 hybrid search. The metadata already existed on every chunk (`source_type`, `kb_tag`, `chapter`, `page`, `url_category`) and nothing filtered on it. Applied to **both** pools before fusion, matching the course's per-list diagram: filtering after fusion would let excluded chunks eat pool slots first. A chunk missing the filtered key is excluded, not admitted, so "only FAO chapter 8" cannot return the whole markdown corpus. Off by default.

**Turn tracing** — analytics rows were independent counters, so "that answer was slow" could never resolve into "because the model ran four times". Every event a turn produces now carries one random per-turn id, read from a ContextVar rather than threaded through callsites, because a trace that depends on callers remembering it has holes exactly where nobody looked. Photo and voice turns join their inner text turn rather than minting a second id. Rendered by `agronaut traces`.

**Latency and cost** — only retrieval was timed, which is the fast, cheap stage; the course is blunt that the transformer is the bottleneck. Every model call now goes through one instrumented seam. Absent token usage is omitted rather than written as `0`, so a provider that reports nothing cannot drag cost aggregates toward zero. The turn is recorded in a `finally`, because a failed turn is the one whose latency must not leave the distribution.

**Generation quality** (`scripts/faithfulness_eval.py`) — `retrieval_eval` scores whether the right documents were found and cannot score whether the answer used them. RAGAS-style faithfulness and response relevancy, plus citation accuracy in pure code. Binary rubrics, unparseable verdicts counted as UNJUDGED rather than folded into either side, `n_unjudged` printed beside every score. Opt-in, never CI.

**Human feedback** — `/good` and `/bad`, stored as a bare `1`/`-1` with no comment field, since that is the one place message content could enter the analytics log.

## The regression the verification turned up

Confirming metadata filtering caused no regression meant re-running the eval. It did not — but *both* runs sat far below the recorded baseline. `techniques.json` was written 2026-08-25; commit `70b2d00` added Goddek et al. (2019) on **2026-08-26**, taking the corpus from 1354 to 3935 chunks. Every constant had been calibrated for a corpus that no longer existed.

All numbers below are on the current 3941-chunk corpus, so the delta isolates the constants rather than mixing in the corpus change:

| | at 1354 (recorded) | at 3941, old constants | at 3941, re-tuned |
|---|---|---|---|
| hit_rate | 0.939 | 0.818 | **0.879** |
| recall@k | 0.894 | 0.727 | **0.833** |
| MAP@k | 0.697 | 0.548 | **0.604** |
| off-topic refused | 8/10 | 4/10 | **8/10** |

Floor **1.65 → 1.50**, cap **2 → 1**, β **holds at 0.90**.

**The two changes pull opposite ways, and the writeup says so.** The floor *costs* retrieval quality: at cap=1, staying at 1.65 would score hit 0.909 and MAP 0.624 against 1.50's 0.879 and 0.604. It is bought deliberately, to double off-topic refusal from 4/10 to 8/10 — a safety trade, not an improvement. The cap is what pays for it: at floor 1.50, cap=1 gives 0.879/0.833/0.604 against cap=2's 0.788/0.697/0.538.

The floor was **not** tightened to 1.40, though that refuses all 10 controls: it clears the worst real query by 0.017, and this project had already rejected a 0.032 margin as too thin. 33 golden queries say nothing about the 34th.

β held because it describes the relationship between two ranking signals — a property of the query language and the embedding model — while the floor and the cap describe the corpus's shape.

### Two measurement bugs found while doing this

**The band edges were read through a capped result set.** The cap can displace the very chunk closest in L2, reading 1.416 instead of the true 1.383 — which would have overstated how tight a floor could safely be, on exactly the decision it feeds. `retrieve(max_per_source=0)` now exists so evaluators see the pool the floor really gates.

**A rounding error nearly turned hybrid search off.** After rebasing onto a corpus that had moved again, the beta sweep picked 1.0 (dense-only) over 0.90 on a MAP margin of **0.002**, while hit_rate and recall each fell by ~0.030. With 33 queries, one flipping *is* 0.030, so the winning margin was a fifteenth of the noise. `pick_by()` now treats sub-0.01 differences as no difference and re-ranks on hit_rate inside that band.

`scripts/retrieval_sweep.py` makes re-measurement one command. It earned its keep immediately: while this PR was open, main added a 22nd knowledge file (3935 → 3941 chunks) and re-running was one command rather than an afternoon. Its floor picker encodes the project's actual rule — zero real queries silenced, then 0.10 minimum headroom, then maximum refusals — rather than maximising a metric, since a naive picker chose 1.40 here for a reason no column in the table can see.

## How it was verified

```
1030 passed, 1 failed
```

The one failure is **pre-existing and unrelated**: `aqua_model/tests/test_schematic.py::test_font_sizes_stay_distinct_when_a_truetype_resolves`. It fails identically on pristine `origin/main` in a clean worktree on this machine (a local font-resolution difference), and `aqua_model/` is untouched by this branch.

```
Advice-safety golden set: 373/373 passed (score 1.000)
  honesty      331/331     sizing        4/4     trust_gate    6/6
  vision_guard  23/23      visual_triage 9/9
exit code: 0
```

```
RETRIEVAL @k=3  (33 queries)
  hit_rate       0.879     recall@k    0.833     precision@k  0.364
  MRR            0.636     MAP@k       0.604     latency      253 ms/query

  floor rejected 8/10 off-topic queries
  floor silenced 0/33 REAL queries  <- must stay 0
  on-topic  worst(max) distance: 1.383
  off-topic best(min) distance: 1.411
  -> separable — a floor can work
```

`ruff check .` clean under the pinned E4/E7/E9/F/I ruleset.

**No-regression proof for metadata filtering:** the scorecard was measured with the change stashed and unstashed on the same corpus, giving identical results. Passing no filter leaves the retrieval path byte-identical.

- [x] `pytest` is green (modulo the pre-existing schematic failure above)
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

54 new tests: the trace's privacy guarantee (no message content reaches the log even when a caller passes it), filter placement in the pipeline (including that BM25 cannot reintroduce an excluded chunk through fusion), the eval arithmetic's refusal to average unlike things, and the sweep's decision rules including the 0.002-vs-0.030 case.

## Trust-zone checklist

Not applicable — `aqua_model/` is untouched and no user-facing number changed.

## What this does NOT do

- **Cross-encoder reranking was not re-measured.** Its table predates the corpus growth. Recorded as stale in `techniques.json` rather than presented as current: a technique that lost on every metric and tripled latency does not become the priority when the corpus grows.
- **Nothing calls metadata filtering with a filter yet.** It is a capability, not a ranking change, so no golden-set number moves and none is claimed. Letting the model choose filters would be query rewriting wearing a different hat, and that technique is recorded as measured-and-lost for this corpus.
- **The floor change costs retrieval quality.** Stated plainly above rather than buried: 1.65 outscores 1.50 on every retrieval metric. If refusing off-topic questions matters less than recall for some deployment, `AGRONAUT_RELEVANCE_MAX_DISTANCE=1.65` restores it.
- **The precision drop from cap=1 is real**, not only a metric artefact. `AGRONAUT_MAX_PER_SOURCE=2` restores the old behaviour.
- **No observability platform integration** (Phoenix/Arize, OpenTelemetry). Traces are local JSONL, consistent with the local-only privacy guarantee.
- **No A/B testing on live traffic.** All experimentation remains offline against the golden set.
- **`faithfulness_eval` has no recorded baseline yet** — it needs a network LLM, so the first real run is a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uzh4XS5BguifdxV99AJG8M
