### PR TITLE
feat(3d): the twin arrives in the picture — as designed, as it stands today, and as it is forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ about it afterwards. On Telegram or WhatsApp, `show_my_system_3d` does the same 
 **you** run: your fish count, your water, advanced through the weather that actually happened
 since you last spoke to the bot, then forward through the forecast.
 
-The badge always says which of the three you are looking at — **as designed**, **today**, or a
-**forecast** — because confusing them would be the worst thing this view could do. The geometry
-stays a proposed arrangement, never a survey of your site.
+The badge always says which of the three you are looking at (**as designed**, **today**, or a
+**forecast**), because confusing them would be the worst thing this view could do. "Today" is
+the same state the bot calls "Now", so the picture and the conversation never describe
+different water. The panel says in as many words that the geometry is a proposed arrangement,
+never a survey of your site.
 
 ### Voice notes
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,31 @@ iron deficiency and pH lockout look identical in an image, so you get both plus 
 separates them. Ordering follows the knowledge base's own rules — pH before iron, water quality
 before any fish pathogen. Nothing it says states a dose.
 
+### See the system, and then see it running
+
+Every design renders as a self-contained 3D page — greenhouse, tanks, filtration, beds,
+graded plumbing with the flow animated in the direction the water actually goes. One HTML
+file, no server and no CDN, so it opens from a double-click on a laptop that has never been
+online.
+
+With a twin bound to it, the same drawing stops being a picture:
+
+```bash
+# a design, plus the season it would have at a real site, on a slider
+python scripts/render_3d.py --crop basil --site taichung_2025 --days 365 -o first_year.html
+```
+
+Drag the scrubber and the fish grow, the water turns amber and then red as ammonia and
+nitrite cross the bands `aqua_model/advisory.py` acts on, and the crop is drawn as vigorously
+as it is actually growing. You *watch* the nitrite spike of week two arrive instead of reading
+about it afterwards. On Telegram or WhatsApp, `show_my_system_3d` does the same for the system
+**you** run: your fish count, your water, advanced through the weather that actually happened
+since you last spoke to the bot, then forward through the forecast.
+
+The badge always says which of the three you are looking at — **as designed**, **today**, or a
+**forecast** — because confusing them would be the worst thing this view could do. The geometry
+stays a proposed arrangement, never a survey of your site.
+
 ### Voice notes
 
 Speak instead of typing, on Telegram or WhatsApp. The transcript runs through a normal turn, so
@@ -533,6 +558,10 @@ aqua_model/            # TRUST ZONE — pure Python, no LLM, no network, no I/O,
   validate.py          #   the trust gate — the only door into the model
   report.py pilot.py   #   funder-facing design report and pilot proposal
   schematic.py         #   deterministic SVG/PNG system diagram
+  layout.py hydraulics.py #   placement, grading, routed pipe runs and the real pump head
+  production.py mirror.py #   the coupled season twin, and one operator's live state
+  advisory.py          #   proposals with derived confidence — a human approves, nothing acts
+  scene3d.py           #   the 3D scene, including the twin state the viewer renders
   logging_schema.py    #   versioned install-logging standard (the dataset moat)
 
 agent/                 # LLM-facing layer (imports aqua_model, never the reverse)

--- a/agronaut_agent/core.py
+++ b/agronaut_agent/core.py
@@ -88,6 +88,11 @@ If the user asks to SEE, DRAW, or picture their system (a diagram/schematic), ca
 render_system_schematic — it draws a labeled diagram and sends it to them as an image.
 For a full interactive 3D model (greenhouse, tanks, beds, plumbing, fish), call
 design_system_3d — it sends an HTML file that opens in any browser, offline.
+If they ALREADY RUN the system they want to see, call show_my_system_3d instead: it binds
+their LIVE twin to the drawing, so the fish are at the count and size the twin holds, the
+water is coloured by their own ammonia/nitrite/nitrate, and a slider runs from today
+through the forecast. Say which parts are theirs and which are proposed — the geometry is
+a proposed arrangement sized from their grow area, never a survey of their site.
 
 THE DIGITAL TWIN — after the design, or for a running system. Sizing says how big;
 the twin says WHAT HAPPENS: harvests, seasons, money. Offer it, don't wait to be asked:
@@ -117,6 +122,8 @@ the twin says WHAT HAPPENS: harvests, seasons, money. Offer it, don't wait to be
   * "how's my system / what will this week/heatwave do" -> you MUST call
     my_system_forecast — only it knows the persisted state and the real forecast.
   Pass the envelope they actually run (greenhouse='shade'/'poly'/'heated') to both.
+  "Show me / can I see it" about that same running system -> show_my_system_3d, which is
+  the forecast as a picture they can scrub through rather than a second computation.
 - For the COMPLETE component design — which tanks, settling, biofilter, degasser,
   mineralization, coupled or decoupled, each with its reason — design_full_system is the
   design conversation's closing move (it also sends the 3D). It adapts to needs: ask about

--- a/agronaut_agent/tests/test_core_dryrun.py
+++ b/agronaut_agent/tests/test_core_dryrun.py
@@ -346,6 +346,18 @@ def test_system_prompt_mentions_record_measurement():
     assert "record_measurement" in SYSTEM_PROMPT.lower()
 
 
+def test_system_prompt_sends_a_running_system_to_its_own_3d_view():
+    """"Show me my system" must not route to the DESIGN renderer. A user who already runs
+    a system would get a generic drawing of a system they do not have, with none of their
+    own state on it, and no way to tell the difference."""
+    from agronaut_agent.core import SYSTEM_PROMPT
+    low = SYSTEM_PROMPT.lower()
+    assert "show_my_system_3d" in low
+    see_at = low.index("asks to see, draw, or picture")
+    assert low.index("show_my_system_3d") > see_at, (
+        "the live view must be named where the prompt routes 'show me'")
+
+
 class _ContextProbe:
     """Sizes a system on the first invoke, then only replies — and records every message
     list it is invoked with, so tests can assert what the model actually sees."""

--- a/agronaut_agent/tests/test_tools.py
+++ b/agronaut_agent/tests/test_tools.py
@@ -16,7 +16,7 @@ def test_tool_registry():
     assert "remember_about_user" in names
     assert "recommend_actions" in names
     assert "decide_on_recommendations" in names
-    assert len(AGRONAUT_TOOLS) == 29
+    assert len(AGRONAUT_TOOLS) == 30
 
 
 def test_size_valid_carries_numbers_and_sources():
@@ -168,7 +168,7 @@ def test_registry_includes_update_profile():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "update_profile" in names
-    assert len(AGRONAUT_TOOLS) == 29
+    assert len(AGRONAUT_TOOLS) == 30
 
 
 def test_update_profile_writes_canonical_drops_unknown():
@@ -199,7 +199,7 @@ def test_registry_includes_schedule_followup():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "schedule_followup" in names
-    assert len(AGRONAUT_TOOLS) == 29
+    assert len(AGRONAUT_TOOLS) == 30
 
 
 def test_schedule_followup_writes_a_row_and_guards_duplicates():
@@ -243,7 +243,7 @@ def test_registry_includes_community_tools():
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "nominate_shared_insight" in names
     assert "search_community_knowledge" in names
-    assert len(AGRONAUT_TOOLS) == 29
+    assert len(AGRONAUT_TOOLS) == 30
 
 
 def test_nominate_writes_pending_and_rejects_blank():
@@ -294,7 +294,7 @@ def test_registry_includes_record_measurement():
     from agronaut_agent.tools import AGRONAUT_TOOLS
     names = {t.name for t in AGRONAUT_TOOLS}
     assert "record_measurement" in names
-    assert len(AGRONAUT_TOOLS) == 29
+    assert len(AGRONAUT_TOOLS) == 30
 
 
 def test_record_measurement_maps_metric_to_qualified_key():

--- a/agronaut_agent/tests/test_twin_3d.py
+++ b/agronaut_agent/tests/test_twin_3d.py
@@ -130,6 +130,23 @@ def test_the_tool_asks_for_what_a_drawing_needs_instead_of_assuming(session, off
     assert not runtime.get_attachments(), "nothing should be drawn from a guess"
 
 
+def test_the_question_is_asked_before_the_weather_is_fetched(session, monkeypatch):
+    """Advancing the mirror is a network call plus a state write. Spending both, on every
+    retry, to then ask for a field already in hand is a farmer waiting for nothing."""
+    calls = []
+    monkeypatch.setattr(T, "_live_weather",
+                        lambda *a, **k: calls.append(1) or (_ for _ in ()).throw(
+                            AssertionError("weather must not be fetched")))
+    mem, uid = session
+    _profile(mem, uid)
+    mem.set_facts(uid, {"system_type": ""}, source="user_stated")
+
+    out = T.show_my_system_3d.invoke({})
+
+    assert "system_type" in out
+    assert not calls
+
+
 def test_the_tool_attaches_a_self_contained_file_with_the_season_in_it(session,
                                                                       offline_weather):
     mem, uid = session
@@ -154,6 +171,53 @@ def test_the_tool_refuses_a_twin_nobody_is_running(session, offline_weather):
 
     assert "still need" in out
     assert not runtime.get_attachments()
+
+
+def test_the_prose_says_now_in_the_same_words_the_forecast_does(session, offline_weather):
+    """One pond, one sentence. `/forecast` prints mirror.snapshot_line for "Now"; if this
+    tool paraphrased the twin's first simulated day instead, the two would disagree about
+    ammonia in the same conversation."""
+    from aqua_model import mirror
+
+    mem, uid = session
+    _profile(mem, uid)
+    snap = _snapshot(mem, uid)
+
+    out = T.show_my_system_3d.invoke({"days_ahead": 7})
+
+    assert mirror.snapshot_line(snap.state) in out
+
+
+def test_the_attached_file_actually_says_the_layout_is_a_proposal(session, offline_weather):
+    """The disclaimer is computed and tested in Python; what matters is that it reaches the
+    file the operator opens."""
+    mem, uid = session
+    _profile(mem, uid)
+
+    T.show_my_system_3d.invoke({"days_ahead": 5})
+
+    html = open(runtime.get_attachments()[0], encoding="utf-8").read()
+    assert "geometry_note" in html, "the viewer must read the note, not just carry it"
+    assert "proposed arrangement" in html
+
+
+def test_every_3d_tool_tells_the_viewer_which_crop_it_drew(session):
+    """The crop key is what picks the plant form. A renderer that leaves it out draws
+    tomatoes as the same green spheres as lettuce, which is the coupling the key exists to
+    remove — and it was missing from one of the three call sites."""
+    for tool, args in (
+        (T.design_system_3d, {"fish_species": "tilapia", "crop": "tomato",
+                              "grow_area_m2": 20, "temperature_c": 26,
+                              "water_budget_lpd": 500}),
+        (T.design_full_system, {"fish_species": "tilapia", "crop": "tomato",
+                                "grow_area_m2": 20, "temperature_c": 26,
+                                "water_budget_lpd": 500}),
+    ):
+        runtime.set_current(session[0], session[1])
+        tool.invoke(args)
+        html = open(runtime.get_attachments()[-1], encoding="utf-8").read()
+        assert '"crop": "tomato"' in html or '"crop":"tomato"' in html, (
+            f"{tool.name} rendered a scene that does not say what crop it drew")
 
 
 def test_the_tool_is_registered():

--- a/agronaut_agent/tests/test_twin_3d.py
+++ b/agronaut_agent/tests/test_twin_3d.py
@@ -1,0 +1,161 @@
+"""The join: this operator's live twin, bound to a drawing of their system.
+
+The 3D view had never once shown anyone's actual pond (#118). These tests are about the
+seam where it now does, and about the one thing that must never blur there — which numbers
+are the operator's and which are a proposal.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from agronaut_agent import runtime, twin_view
+from agronaut_agent import tools as T
+from agronaut_agent.store import MemoryStore, _Db
+from aqua_model.climate import DailyClimate
+
+
+@pytest.fixture
+def offline_weather(monkeypatch):
+    """No network in a test, and none needed: the twin takes weather as data."""
+    def fake(lat, lon, past_days, forecast_days):
+        n = min(92, max(0, past_days)) + min(16, max(1, forecast_days))
+        start = date.today() - timedelta(days=min(92, max(0, past_days)))
+        dates = [(start + timedelta(days=i)).isoformat() for i in range(n)]
+        days = tuple(DailyClimate(t_mean_c=26.0, t_min_c=22.0, t_max_c=30.0,
+                                  solar_mj_m2=18.0) for _ in range(n))
+        return dates, days
+    monkeypatch.setattr(T, "_live_weather", fake)
+
+
+FULL_PROFILE = {
+    "fish_species": "tilapia", "crop": "basil", "grow_area_m2": 15,
+    "tank_volume_l": 2000, "fish_count": 60, "fish_avg_weight_g": 200,
+    "water_budget_lpd": 400, "system_type": "raft",
+    "climate_site": "taichung_2025", "site_lat": 24.15, "site_lon": 120.68,
+}
+
+
+@pytest.fixture
+def session(tmp_path):
+    """A live turn with a memory store, the way a channel adapter sets one up."""
+    mem = MemoryStore(_Db(str(tmp_path / "t.sqlite3")))
+    runtime.set_current(mem, "telegram:1")
+    try:
+        yield mem, "telegram:1"
+    finally:
+        runtime.clear_current()
+
+
+def _profile(mem, uid, **over):
+    mem.set_facts(uid, {**FULL_PROFILE, **over}, source="user_stated")
+
+
+def _snapshot(mem, uid, days=7):
+    return twin_view.compute(mem, uid, days=days, greenhouse="shade")
+
+
+# --- the join ------------------------------------------------------------------------
+
+def test_the_scene_carries_this_operators_fish_not_the_designs(session, offline_weather):
+    mem, uid = session
+    _profile(mem, uid)
+    snap = _snapshot(mem, uid)
+
+    scene = twin_view.scene_for(snap, mem.get_facts(uid))
+
+    assert scene["twin"]["mode"] == "live"
+    assert scene["twin"]["frames"][0]["fish"]["count"] == 60, (
+        "the drawing must show the twin's cohort, not the number the sizing model would "
+        "have stocked into this grow area")
+
+
+def test_today_is_labelled_today_and_the_rest_is_labelled_forecast(session, offline_weather):
+    mem, uid = session
+    _profile(mem, uid)
+
+    frames = twin_view.scene_for(_snapshot(mem, uid), mem.get_facts(uid))["twin"]["frames"]
+
+    assert frames[0]["kind"] == "today"
+    assert frames[0]["date"] == date.today().isoformat()
+    assert {f["kind"] for f in frames[1:]} == {"forecast"}
+    assert frames[-1]["date"] > frames[0]["date"]
+
+
+def test_the_scene_admits_the_geometry_is_only_a_proposal(session, offline_weather):
+    mem, uid = session
+    _profile(mem, uid)
+
+    scene = twin_view.scene_for(_snapshot(mem, uid), mem.get_facts(uid))
+
+    assert "proposed" in scene["twin"]["geometry_note"]
+
+
+def test_a_tank_that_disagrees_with_the_grow_area_is_said_out_loud(session, offline_weather):
+    """Drawing over the disagreement would hide a real finding about their system."""
+    mem, uid = session
+    _profile(mem, uid, tank_volume_l=200)          # far too small for 15 m2 of basil
+
+    scene = twin_view.scene_for(_snapshot(mem, uid), mem.get_facts(uid))
+
+    assert "not the 200 L you told me you have" in scene["subtitle"]
+
+
+def test_the_operators_own_water_temperature_sizes_the_design(session, offline_weather):
+    """No default stands in for a number the twin has been carrying all along."""
+    mem, uid = session
+    _profile(mem, uid)
+    snap = _snapshot(mem, uid)
+    facts = dict(mem.get_facts(uid))
+    facts.pop("temperature_c", None)
+
+    fallback = twin_view.scene_for(snap, facts)    # must not raise for a missing temp
+    explicit = twin_view.scene_for(snap, {**facts,
+                                         "temperature_c": snap.state.water_temp_c})
+
+    assert fallback["objects"] == explicit["objects"], (
+        "the missing temperature fell back to something other than the twin's own water")
+
+
+# --- the tool ------------------------------------------------------------------------
+
+def test_the_tool_asks_for_what_a_drawing_needs_instead_of_assuming(session, offline_weather):
+    mem, uid = session
+    _profile(mem, uid)
+    mem.set_facts(uid, {"water_budget_lpd": ""}, source="user_stated")
+
+    out = T.show_my_system_3d.invoke({"days_ahead": 5})
+
+    assert "water_budget_lpd" in out
+    assert not runtime.get_attachments(), "nothing should be drawn from a guess"
+
+
+def test_the_tool_attaches_a_self_contained_file_with_the_season_in_it(session,
+                                                                      offline_weather):
+    mem, uid = session
+    _profile(mem, uid)
+
+    out = T.show_my_system_3d.invoke({"days_ahead": 7})
+
+    attached = runtime.get_attachments()
+    assert len(attached) == 1
+    html = open(attached[0]).read()
+    assert "__SCENE_JSON__" not in html, "the template placeholder was never filled"
+    assert '"kind": "today"' in html or '"kind":"today"' in html
+    assert "cdn" not in html.lower().split("<script")[0]
+    assert "TODAY" in out.upper() and "60 fish" in out
+
+
+def test_the_tool_refuses_a_twin_nobody_is_running(session, offline_weather):
+    mem, uid = session
+    mem.set_facts(uid, {"fish_species": "tilapia"}, source="user_stated")
+
+    out = T.show_my_system_3d.invoke({})
+
+    assert "still need" in out
+    assert not runtime.get_attachments()
+
+
+def test_the_tool_is_registered():
+    from agronaut_agent.tools import AGRONAUT_TOOLS
+    assert "show_my_system_3d" in {t.name for t in AGRONAUT_TOOLS}

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -827,11 +827,6 @@ def design_system_3d(
 
     system_type: 'raft', 'nft', 'media_bed', or 'vertical_tower' — the layout changes
     accordingly (media beds skip the separate biofilter; towers raise the roof)."""
-    import os
-    import sys
-    import tempfile
-    from pathlib import Path
-
     from aqua_model.layout import plan_layout
     from aqua_model.scene3d import to_scene
 
@@ -844,10 +839,31 @@ def design_system_3d(
     layout = plan_layout(out, crop_label=crop, species_label=fish_species)
     scene = to_scene(
         layout, out,
+        crop=str(crop).strip().lower(), species=str(fish_species).strip().lower(),
         name=f"{system_type.replace('_', ' ').title()} aquaponics — {fish_species} + {crop}",
         subtitle=(f"{out.grow_area_m2:.0f} m² grow area · {out.fish_count} fish "
                   f"({out.fish_biomass_kg:.0f} kg) · {out.system_volume_l:,.0f} L · greenhouse "
                   f"{layout.greenhouse.width_m:.1f}×{layout.greenhouse.length_m:.1f} m"))
+    _attach_scene_html(scene)
+    gh = layout.greenhouse
+    return (f"Rendered the 3D model (attached as an HTML file — opens in any browser, "
+            f"offline). Greenhouse {gh.width_m:.1f} x {gh.length_m:.1f} m, "
+            f"{len(layout.components)} components, {out.fish_count} fish. Tell the user to "
+            f"open the file, then orbit/zoom; toggles show flow, fish and labels. Offer to "
+            f"simulate a season at their site next (simulate_season).")
+
+
+def _attach_scene_html(scene: dict) -> str:
+    """Render a scene to the self-contained offline HTML and attach it to the reply.
+
+    `scripts/` is outside the trust zone and holds the renderer; importing it here rather
+    than duplicating the template plumbing keeps ONE way to build the file, so the chat
+    attachment and `python scripts/render_3d.py` cannot drift apart."""
+    import os
+    import sys
+    import tempfile
+    from pathlib import Path
+
     scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
     sys.path.insert(0, str(scripts_dir))
     try:
@@ -859,12 +875,65 @@ def design_system_3d(
     with os.fdopen(fd, "w") as fh:
         fh.write(html)
     runtime.add_attachment(path)
-    gh = layout.greenhouse
-    return (f"Rendered the 3D model (attached as an HTML file — opens in any browser, "
-            f"offline). Greenhouse {gh.width_m:.1f} x {gh.length_m:.1f} m, "
-            f"{len(layout.components)} components, {out.fish_count} fish. Tell the user to "
-            f"open the file, then orbit/zoom; toggles show flow, fish and labels. Offer to "
-            f"simulate a season at their site next (simulate_season).")
+    return path
+
+
+@tool
+def show_my_system_3d(days_ahead: int = 14, greenhouse: str = "poly") -> str:
+    """Send the user a 3D view of THEIR OWN system with their LIVE twin bound to it — the
+    fish at the count and size the twin holds, the water coloured by their actual ammonia /
+    nitrite / nitrate, the crop drawn as vigorously as it is actually growing — plus a
+    scrubber that runs from today through the coming days, so they can watch what the
+    forecast does to their pond. Use when a user with a RUNNING system asks to SEE it, or
+    after a forecast or a recommendation that would land better as a picture ("show me",
+    "what does that look like", "can I see my system"). For a system that does not exist
+    yet, use design_system_3d instead: this one refuses to draw a twin nobody is running.
+
+    The geometry is a proposed arrangement sized from their grow area, exactly like any
+    other layout here; the STATE on it is theirs. The file says which is which, and so
+    should you. days_ahead: forecast days on the scrubber (2-15).
+    greenhouse: the envelope they actually run — 'poly', 'shade', or 'heated'."""
+    cur = runtime.get_current()
+    if cur is None:
+        return "No session — cannot open a live twin here."
+    mem, user_id = cur
+    try:
+        snap = twin_view.compute(mem, user_id, days=days_ahead, greenhouse=greenhouse)
+    except Exception as err:  # noqa: BLE001 — a weather hiccup must become words
+        return f"Could not advance the twin ({err}) — try again shortly."
+    facts = mem.get_facts(user_id) or {}
+    missing = list(snap.missing) + twin_view.missing_for_scene(facts)
+    if missing:
+        return ("To draw their live system I still need: " + ", ".join(missing) +
+                ". Ask the user, save with update_profile, then call this again.")
+    try:
+        scene = twin_view.scene_for(snap, facts)
+    except ValidationError as err:
+        return serialize.serialize_validation_error(err.errors)
+    except (KeyError, ValueError) as err:
+        return f"Profile value unusable: {err} — correct it with update_profile."
+    _attach_scene_html(scene)
+
+    frames = scene["twin"]["frames"]
+    worst = max(frames, key=lambda f: (f["water"]["band"] == "urgent",
+                                       f["water"]["band"] == "act"))
+    today = frames[0]
+    lines = [
+        "Rendered their live system in 3D (attached — opens in any browser, offline). "
+        f"Today: {today['fish']['count']} fish @ {today['fish']['mean_weight_g']:.0f} g, "
+        f"water {today['water']['temp_c']:.1f} C, NH3 {today['water']['tan_mg_l']:.2f} / "
+        f"NO2 {today['water']['no2_mg_l']:.2f} / NO3 {today['water']['no3_mg_l']:.0f} mg/L.",
+        f"The slider runs {len(frames)} days from today; the badge says whether a frame is "
+        "TODAY or a FORECAST, and the geometry is a proposed arrangement, not their site "
+        "plan — say so rather than letting them read it as a survey.",
+    ]
+    if worst["water"]["band"] != "ok":
+        lines.append(f"The water turns {worst['water']['band']} on "
+                     f"{worst['date'] or 'day ' + str(worst['day'])}: {worst['water']['why']}. "
+                     "Offer recommend_actions.")
+    if snap.notes:
+        lines.append("Twin notes: " + " ".join(snap.notes))
+    return " ".join(lines)
 
 
 @tool
@@ -1575,6 +1644,7 @@ AGRONAUT_TOOLS = [
     decide_on_recommendations,
     what_if_nitrogen,
     design_system_3d,
+    show_my_system_3d,
     design_full_system,
     search_knowledge_base,
     triage_visual_symptoms,

--- a/agronaut_agent/tools.py
+++ b/agronaut_agent/tools.py
@@ -853,7 +853,7 @@ def design_system_3d(
             f"simulate a season at their site next (simulate_season).")
 
 
-def _attach_scene_html(scene: dict) -> str:
+def _attach_scene_html(scene: dict, *, prefix: str = "agronaut_design3d_") -> str:
     """Render a scene to the self-contained offline HTML and attach it to the reply.
 
     `scripts/` is outside the trust zone and holds the renderer; importing it here rather
@@ -871,8 +871,11 @@ def _attach_scene_html(scene: dict) -> str:
     finally:
         sys.path.remove(str(scripts_dir))
     html = build_html(scene, title=scene["name"])
-    fd, path = tempfile.mkstemp(prefix="agronaut_design3d_", suffix=".html")
-    with os.fdopen(fd, "w") as fh:
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=".html")
+    # utf-8 explicitly: every scene name and subtitle carries m2, degrees and separators, and
+    # a host running under LANG=C would otherwise raise UnicodeEncodeError instead of drawing
+    # a system. Minimal containers and offline laptops are the target, not the exception.
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write(html)
     runtime.add_attachment(path)
     return path
@@ -897,14 +900,20 @@ def show_my_system_3d(days_ahead: int = 14, greenhouse: str = "poly") -> str:
     if cur is None:
         return "No session — cannot open a live twin here."
     mem, user_id = cur
+    facts = mem.get_facts(user_id) or {}
+    # Ask BEFORE advancing. `twin_view.compute` fetches live weather and writes the advanced
+    # state back, so checking the drawing's own requirements afterwards spends a network
+    # round-trip and a state write on every retry of a question we could have asked first.
+    missing = twin_view.missing_for_scene(facts)
+    if missing:
+        return ("To draw their live system I still need: " + ", ".join(missing) +
+                ". Ask the user, save with update_profile, then call this again.")
     try:
         snap = twin_view.compute(mem, user_id, days=days_ahead, greenhouse=greenhouse)
     except Exception as err:  # noqa: BLE001 — a weather hiccup must become words
         return f"Could not advance the twin ({err}) — try again shortly."
-    facts = mem.get_facts(user_id) or {}
-    missing = list(snap.missing) + twin_view.missing_for_scene(facts)
-    if missing:
-        return ("To draw their live system I still need: " + ", ".join(missing) +
+    if snap.missing:
+        return ("To draw their live system I still need: " + ", ".join(snap.missing) +
                 ". Ask the user, save with update_profile, then call this again.")
     try:
         scene = twin_view.scene_for(snap, facts)
@@ -914,19 +923,28 @@ def show_my_system_3d(days_ahead: int = 14, greenhouse: str = "poly") -> str:
         return f"Profile value unusable: {err} — correct it with update_profile."
     _attach_scene_html(scene)
 
+    from aqua_model import mirror as _mirror
+
     frames = scene["twin"]["frames"]
     worst = max(frames, key=lambda f: (f["water"]["band"] == "urgent",
                                        f["water"]["band"] == "act"))
-    today = frames[0]
+    # The SAME line /forecast prints as "Now", from the same state the picture's TODAY frame
+    # renders. Two phrasings of one pond is how a farmer stops trusting either.
     lines = [
         "Rendered their live system in 3D (attached — opens in any browser, offline). "
-        f"Today: {today['fish']['count']} fish @ {today['fish']['mean_weight_g']:.0f} g, "
-        f"water {today['water']['temp_c']:.1f} C, NH3 {today['water']['tan_mg_l']:.2f} / "
-        f"NO2 {today['water']['no2_mg_l']:.2f} / NO3 {today['water']['no3_mg_l']:.0f} mg/L.",
-        f"The slider runs {len(frames)} days from today; the badge says whether a frame is "
-        "TODAY or a FORECAST, and the geometry is a proposed arrangement, not their site "
-        "plan — say so rather than letting them read it as a survey.",
+        f"Today: {_mirror.snapshot_line(snap.state)}",
     ]
+    ahead = len(frames) - 1
+    if ahead > 0:
+        lines.append(
+            f"The slider runs from today through {ahead} forecast day(s); the badge says "
+            "whether a frame is TODAY or a FORECAST, and the geometry is a proposed "
+            "arrangement, not their site plan — say so rather than letting them read it as "
+            "a survey.")
+    else:
+        lines.append(
+            "Only today could be drawn — their site's forecast was unavailable, so there is "
+            "no slider. Say that rather than implying they are seeing days ahead.")
     if worst["water"]["band"] != "ok":
         lines.append(f"The water turns {worst['water']['band']} on "
                      f"{worst['date'] or 'day ' + str(worst['day'])}: {worst['water']['why']}. "
@@ -1018,11 +1036,6 @@ def design_full_system(
     operator_experience: beginner | intermediate | expert (beginners pushed to decoupled
         get a workload warning, never a silent block).
     architecture: force 'coupled' or 'decoupled'; leave unset to let the rules decide."""
-    import os
-    import sys as _sys
-    import tempfile
-    from pathlib import Path
-
     from aqua_model.crops import get_crop
     from aqua_model.flowsheet import Needs, format_flowsheet, plan_flowsheet
     from aqua_model.layout import plan_layout
@@ -1045,21 +1058,13 @@ def design_full_system(
     layout = plan_layout(out, crop_label=crop, species_label=fish_species, flowsheet=fs)
     scene = to_scene(
         layout, out,
+        crop=str(crop).strip().lower(), species=str(fish_species).strip().lower(),
         name=f"{fs.architecture.title()} {system_type.replace('_', ' ')} — "
              f"{fish_species} + {crop}",
         subtitle=(f"{out.grow_area_m2:.0f} m² · {out.fish_count} fish · "
                   f"{len(layout.components)} components · greenhouse "
                   f"{layout.greenhouse.width_m:.1f}×{layout.greenhouse.length_m:.1f} m"))
-    scripts_dir = Path(__file__).resolve().parent.parent / "scripts"
-    _sys.path.insert(0, str(scripts_dir))
-    try:
-        from render_3d import build_html
-    finally:
-        _sys.path.remove(str(scripts_dir))
-    fd, path = tempfile.mkstemp(prefix="agronaut_fullsystem_", suffix=".html")
-    with os.fdopen(fd, "w") as fh:
-        fh.write(build_html(scene, title=scene["name"]))
-    runtime.add_attachment(path)
+    _attach_scene_html(scene, prefix="agronaut_fullsystem_")
     header = ("" if out.feasible else
               f"NOTE: infeasible as sized ({out.binding_constraint}) — resolve before building.\n\n")
     return (header + format_flowsheet(fs)

--- a/agronaut_agent/twin_view.py
+++ b/agronaut_agent/twin_view.py
@@ -50,3 +50,74 @@ def compute(mem, user_id: str, days: int = 7, greenhouse: str = "poly",
         notes=list(notes),
         history=readings.history(user_id) if readings is not None else [],
     )
+
+
+# What a DRAWING of the system needs beyond what the twin itself needs. The mirror runs on
+# the operator's own counts and volumes; the geometry has to be sized, and sizing goes
+# through `validate_design_input` like every other number in this project.
+SCENE_NEEDS = ("water_budget_lpd", "system_type")
+
+
+def missing_for_scene(facts: dict) -> list[str]:
+    """Profile fields the 3D view needs on top of the twin's own — ask, never assume."""
+    return [k for k in SCENE_NEEDS if not str((facts or {}).get(k, "")).strip()]
+
+
+def scene_for(snapshot, facts: dict) -> dict:
+    """Bind this operator's live twin to a drawing of their system — the join #118 is about.
+
+    Two different kinds of thing meet here, and the scene says which is which. The GEOMETRY
+    is sized from their stated grow area and system type, so it is a proposed arrangement
+    like every other layout this project draws. The STATE is theirs: the persisted mirror,
+    advanced through the weather that actually happened, and pulled toward the readings they
+    logged. Confusing the two would be the worst outcome of this view, so the subtitle names
+    the operator's own numbers and `twin.geometry_note` says the drawing is still a proposal.
+
+    Raises KeyError/ValueError for an unusable profile; the caller turns that into a
+    question for the operator rather than a guess.
+    """
+    from datetime import date, timedelta
+
+    from aqua_model.layout import plan_layout
+    from aqua_model.scene3d import to_scene
+    from aqua_model.sizing import size_system
+    from aqua_model.validate import validate_design_input
+
+    state = snapshot.state
+    species_key = str(facts["fish_species"]).strip().lower()
+    crop_key = str(facts["crop"]).strip().lower()
+    system_type = str(facts.get("system_type", "raft")).strip().lower() or "raft"
+    # Their water, not a default: the twin has been carrying the real temperature.
+    temp_c = float(facts.get("temperature_c") or state.water_temp_c)
+
+    design = validate_design_input(
+        fish_species=species_key, crop=crop_key,
+        grow_area_m2=float(facts["grow_area_m2"]), temperature_c=temp_c,
+        water_budget_lpd=float(facts["water_budget_lpd"]), system_type=system_type)
+    out = size_system(design)
+    layout = plan_layout(out, crop_label=crop_key, species_label=species_key)
+
+    # The forecast run starts today and steps one day at a time (see tools._advance_mirror),
+    # so the calendar is exactly today onward — derived, not fetched a second time.
+    today = date.today()
+    dates = [(today + timedelta(days=i)).isoformat()
+             for i in range(len(snapshot.trajectory))]
+
+    theirs_l = float(facts.get("tank_volume_l") or 0.0)
+    sized_l = float(out.system_volume_l or 0.0)
+    subtitle = (f"{state.fish.count} fish @ {state.fish.mean_weight_g:.0f} g "
+                f"({state.fish.biomass_kg():.1f} kg) · {float(facts['grow_area_m2']):.0f} m² "
+                f"of {crop_key} · {theirs_l:,.0f} L")
+    if theirs_l > 0 and sized_l > 0 and abs(sized_l - theirs_l) / theirs_l > 0.25:
+        # Worth saying out loud rather than drawing over: their tank and the tank this grow
+        # area implies disagree, and which one is wrong is a conversation, not a rounding.
+        subtitle += (f" — drawn at the {sized_l:,.0f} L this grow area would need, "
+                     f"which is not the {theirs_l:,.0f} L you told me you have")
+
+    return to_scene(
+        layout, out, crop=crop_key, species=species_key,
+        name=f"Your system — {species_key} + {crop_key}",
+        subtitle=subtitle,
+        state=state, trajectory=list(snapshot.trajectory), dates=dates,
+        today_index=0, as_of=today.isoformat(),
+    )

--- a/aqua_model/scene3d.py
+++ b/aqua_model/scene3d.py
@@ -9,6 +9,13 @@ it is wrong here, which is where it can be tested.
 Coordinate convention: x across the greenhouse width, y along its length, z up, metres,
 origin at one corner. The viewer maps that to its own axes.
 
+The geometry is a DESIGN. The optional `state` and `trajectory` arguments bind a twin to it,
+so the same drawing renders three ways: as designed, as it stands today, and as it is
+projected to stand on day N. Every appearance the state drives — water colour, fish size and
+number, how vigorous the crop looks — is decided HERE, in numbers the tests can read, so the
+viewer applies a colour rather than choosing one. A picture that invented its own thresholds
+would be a second, uncited opinion about when a pond is in trouble.
+
 Pure and deterministic, like the rest of `aqua_model/`.
 """
 
@@ -16,10 +23,51 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
+from .advisory import (
+    NO2_ACT_MG_L,
+    NO2_URGENT_MG_L,
+    NO3_HIGH_MG_L,
+    NO3_LOW_MG_L,
+    TAN_ACT_MG_L,
+    TAN_URGENT_MG_L,
+)
+from .cropgrowth import f_nitrogen
 from .layout import Layout, Placed
 from .types import DesignOutput
 
-SCENE_SCHEMA_VERSION = "1.1.0"
+SCENE_SCHEMA_VERSION = "1.2.0"
+
+# Fish drawn per rearing tank. The picture is an explanation, not a census: a frame states
+# the twin's real count and how many of them are drawn, and the drawn population is scaled
+# to the real one so a die-off is still visible as thinning water.
+FISH_DRAWN_PER_TANK = 15
+
+# Water colour by nitrogen band. The bands themselves are `advisory.py`'s, which cites
+# knowledge/nitrogen_cycle_and_cycling.md; only the colours are new here, and a colour is
+# not a claim about a pond. "ok" is the viewer's own water blue, so an untroubled system
+# looks exactly as it did before any twin was bound to it.
+WATER_COLORS = {"ok": "#1c7fa8", "act": "#c08b2a", "urgent": "#b23c2e"}
+
+# How pale a nitrogen-starved crop is drawn. Chlorosis on a nitrogen-limited plant is
+# ordinary agronomy, but the DEPTH of the tint is a drawing convention, not a measurement,
+# which is why the frame also carries the factor itself for the readout to state. The tint
+# STARTS where the knowledge base's nitrate floor is crossed (advisory.NO3_LOW_MG_L, cited
+# to knowledge/nitrogen_cycle_and_cycling.md) rather than at a number chosen to look right:
+# a crop running at 0.8 of its nitrogen potential is an ordinary aquaponic crop, not a sick
+# one, and drawing it yellow would be the picture inventing a diagnosis.
+CHLOROSIS_COLOR = "#c9c04a"
+CHLOROSIS_ONSET = f_nitrogen(NO3_LOW_MG_L)
+
+# Plant size under limitation. A bed at 0 growth is still a bed of small plants, not bare
+# water: the twin models a continuous-harvest crop, so it never claims the bed is empty.
+PLANT_SCALE_FLOOR = 0.45
+
+# Fish length from mean weight, isometric: L = (100 * W / K)^(1/3), K a nominal Fulton
+# condition factor. 1.9 draws a 500 g tilapia at ~30 cm and a 20 g fingerling at ~10 cm.
+# This is a DRAWING convention — nothing computes from it, and no output reports a length.
+FULTON_K = 1.9
+
+DEFAULT_MAX_FRAMES = 120
 
 
 def _component(c: Placed) -> dict:
@@ -39,9 +87,162 @@ def _component(c: Placed) -> dict:
     return d
 
 
+def fish_length_m(mean_weight_g: float) -> float:
+    """Drawn length of one fish at this mean weight (see FULTON_K)."""
+    w = max(0.1, float(mean_weight_g))
+    return round(((100.0 * w / FULTON_K) ** (1.0 / 3.0)) / 100.0, 4)
+
+
+def water_band(nitrogen) -> dict:
+    """Which nitrogen band this water is in, and therefore what colour it is drawn.
+
+    The thresholds are `advisory.py`'s, unchanged and unrounded, so the water in the picture
+    turns amber on exactly the number that makes the advisor propose an action. The DRIVER is
+    named because "the water is orange" is not actionable and "nitrite is over the band" is.
+    """
+    tan, no2, no3 = nitrogen.tan_mg_l, nitrogen.no2_mg_l, nitrogen.no3_mg_l
+    if tan >= TAN_URGENT_MG_L or no2 >= NO2_URGENT_MG_L:
+        driver, value, limit = (("ammonia", tan, TAN_URGENT_MG_L)
+                                if tan >= TAN_URGENT_MG_L else ("nitrite", no2, NO2_URGENT_MG_L))
+        return {"band": "urgent", "color": WATER_COLORS["urgent"], "driver": driver,
+                "why": f"{driver} {value:.2f} mg/L is at or past {limit:.1f} mg/L"}
+    if tan >= TAN_ACT_MG_L or no2 >= NO2_ACT_MG_L:
+        driver, value, limit = (("ammonia", tan, TAN_ACT_MG_L)
+                                if tan >= TAN_ACT_MG_L else ("nitrite", no2, NO2_ACT_MG_L))
+        why = f"{driver} {value:.2f} mg/L is over the {limit:.1f} mg/L action band"
+        if no3 < NO3_LOW_MG_L:
+            why += " while nitrate is still low — the cycle is not established yet"
+        return {"band": "act", "color": WATER_COLORS["act"], "driver": driver, "why": why}
+    if no3 >= NO3_HIGH_MG_L:
+        return {"band": "act", "color": WATER_COLORS["act"], "driver": "nitrate",
+                "why": (f"nitrate {no3:.0f} mg/L is over {NO3_HIGH_MG_L:.0f} mg/L — plant "
+                        "uptake is not keeping up")}
+    return {"band": "ok", "color": WATER_COLORS["ok"], "driver": "",
+            "why": f"ammonia {tan:.2f} / nitrite {no2:.2f} / nitrate {no3:.0f} mg/L"}
+
+
+def _crop_block(fac) -> dict:
+    """How the crop is drawn today, and the three factors that say why."""
+    growth = fac.combined()
+    limiting = min((("light", fac.f_light), ("temperature", fac.f_temp),
+                    ("nitrogen", fac.f_nitrogen)), key=lambda kv: kv[1])[0]
+    pale = 0.0
+    if fac.f_nitrogen < CHLOROSIS_ONSET:
+        pale = round((CHLOROSIS_ONSET - fac.f_nitrogen) / CHLOROSIS_ONSET, 3)
+    return {
+        "f_light": round(fac.f_light, 3),
+        "f_temp": round(fac.f_temp, 3),
+        "f_nitrogen": round(fac.f_nitrogen, 3),
+        "growth": round(growth, 3),
+        "limiting": limiting,
+        "scale": round(PLANT_SCALE_FLOOR + (1.0 - PLANT_SCALE_FLOOR) * min(1.0, growth), 3),
+        "chlorosis": pale,
+        "chlorosis_color": CHLOROSIS_COLOR,
+    }
+
+
+def _fish_block(state, *, roster: int, peak_count: int) -> dict:
+    count = int(state.fish.count)
+    drawn = 0
+    if count > 0 and peak_count > 0:
+        drawn = max(1, min(roster, round(roster * count / peak_count)))
+    return {
+        "count": count,
+        "mean_weight_g": round(state.fish.mean_weight_g, 1),
+        "biomass_kg": round(state.fish.biomass_kg(), 2),
+        "length_m": fish_length_m(state.fish.mean_weight_g),
+        "drawn": drawn,
+    }
+
+
+def _frame(state, *, kind: str, roster: int, peak_count: int,
+           fac=None, date: str = "", note: str = "") -> dict:
+    n = state.nitrogen
+    frame = {
+        "day": int(state.day),
+        "date": date,
+        "kind": kind,
+        "fish": _fish_block(state, roster=roster, peak_count=peak_count),
+        "water": dict(water_band(n),
+                      temp_c=round(state.water_temp_c, 1),
+                      tan_mg_l=round(n.tan_mg_l, 3),
+                      no2_mg_l=round(n.no2_mg_l, 3),
+                      no3_mg_l=round(n.no3_mg_l, 1)),
+        "totals": {
+            "fish_harvested_kg": round(state.harvested_fish_kg, 2),
+            "crop_harvested_kg": round(state.harvested_crop_kg, 2),
+            "feed_used_kg": round(state.feed_used_kg, 2),
+        },
+    }
+    if fac is not None:
+        frame["crop"] = _crop_block(fac)
+    if note:
+        frame["note"] = note
+    return frame
+
+
+def _keyframe_indices(trajectory, max_frames: int, today_index: int | None) -> list[int]:
+    """Which days to embed. Even stride, plus the days it would be dishonest to skip.
+
+    A downsample that lands either side of the nitrite spike shows a season in which the
+    spike never happened — the one event this view exists to make visible. So the peaks of
+    each nitrogen channel, every harvest, today, the first day and the last are pinned in
+    regardless of stride.
+    """
+    n = len(trajectory)
+    if n == 0:
+        return []
+    keep = {0, n - 1}
+    if today_index is not None and 0 <= today_index < n:
+        keep.add(today_index)
+    for attr in ("tan_mg_l", "no2_mg_l", "no3_mg_l"):
+        keep.add(max(range(n), key=lambda i: getattr(trajectory[i].state.nitrogen, attr)))
+    keep |= {i for i, d in enumerate(trajectory) if d.fish_harvested_today_kg > 0}
+    budget = max(2, int(max_frames))
+    stride = max(1, -(-n // max(1, budget - len(keep))))
+    keep |= set(range(0, n, stride))
+    return sorted(keep)
+
+
+def build_frames(trajectory, *, today_index: int | None = None, dates=(),
+                 max_frames: int = DEFAULT_MAX_FRAMES, roster: int = 0) -> list[dict]:
+    """Turn a `ProductionRun.trajectory` into embeddable per-day frames.
+
+    `today_index` marks the day that is NOW: earlier days are what already happened, later
+    ones are projection. Pass None when the run is not anchored to a calendar at all (a
+    season simulated from a design), and every frame is labelled a projection rather than
+    borrowing the authority of "today".
+    """
+    days = list(trajectory)
+    if not days:
+        return []
+    peak = max(int(d.state.fish.count) for d in days) or 1
+    roster = roster or FISH_DRAWN_PER_TANK
+    frames = []
+    for i in _keyframe_indices(days, max_frames, today_index):
+        d = days[i]
+        if today_index is None:
+            kind = "projected"
+        elif i < today_index:
+            kind = "past"
+        elif i == today_index:
+            kind = "today"
+        else:
+            kind = "forecast"
+        note = ""
+        if d.fish_harvested_today_kg > 0:
+            note = f"harvested {d.fish_harvested_today_kg:.0f} kg of fish and restocked"
+        frames.append(_frame(d.state, kind=kind, roster=roster, peak_count=peak,
+                             fac=d.crop_factors, note=note,
+                             date=str(dates[i]) if i < len(dates) else ""))
+    return frames
+
+
 def to_scene(layout: Layout, out: DesignOutput, *,
              name: str = "Aquaponic system", subtitle: str = "",
-             crop: str = "", species: str = "") -> dict:
+             crop: str = "", species: str = "",
+             state=None, trajectory=(), dates=(), today_index: int | None = None,
+             as_of: str = "", max_frames: int = DEFAULT_MAX_FRAMES) -> dict:
     """Build the scene dict the 3D viewer renders.
 
     Fish are shown in proportion to the design's stocking (capped for legibility — the
@@ -51,14 +252,46 @@ def to_scene(layout: Layout, out: DesignOutput, *,
     picks a plant form and a fish form from them, so a bed of lettuce and a bed of tomatoes
     stop looking like the same green spheres. Parsing them out of the label instead would
     make the picture depend on prose, which is the coupling `scene3d` exists to avoid.
+
+    Binding a twin (all optional, and omitting them leaves the design view untouched):
+
+    - `state`: one `ProductionState` — a live mirror with no forecast behind it. Renders a
+      single frame labelled TODAY.
+    - `trajectory`: a `ProductionRun.trajectory`, embedded as frames the viewer scrubs
+      through. With `today_index` set it is a live twin (today, then forecast); with it
+      None the run is a projection from the design and is labelled as one.
+    - `dates`: ISO dates aligned to the trajectory, so the scrubber can say a real date
+      instead of only a day number.
+
+    The frames are embedded, never fetched: the file has to work from a double-click on a
+    laptop with no connection (#79).
     """
     tanks = layout.by_role("fish_tank")
+    frames = list(build_frames(trajectory, today_index=today_index, dates=dates,
+                               max_frames=max_frames,
+                               roster=FISH_DRAWN_PER_TANK * max(1, len(tanks))))
+    if not frames and state is not None:
+        frames = [_frame(state, kind="today",
+                         roster=FISH_DRAWN_PER_TANK * max(1, len(tanks)),
+                         peak_count=int(state.fish.count) or 1, date=as_of)]
+
+    # The fish roster: how many meshes the viewer builds. In design mode it is the design's
+    # stocking, capped; with a twin bound it is sized to the busiest frame, and each frame
+    # then says how many of them are visible on that day.
     fish: list[dict] = []
-    if tanks and out.fish_count:
-        shown = min(out.fish_count, 15 * len(tanks))
-        per = max(1, shown // len(tanks))
+    peak_drawn = max((f["fish"]["drawn"] for f in frames), default=0)
+    shown = peak_drawn or (min(out.fish_count, FISH_DRAWN_PER_TANK * len(tanks))
+                           if tanks and out.fish_count else 0)
+    if tanks and shown:
+        per = max(1, -(-shown // len(tanks)))     # ceil: the roster must cover the busiest day
+        length = frames[0]["fish"]["length_m"] if frames else 0.15
         for t in tanks:
-            fish.append({"tank": t.id, "count": per, "length_m": 0.15})
+            fish.append({"tank": t.id, "count": per, "length_m": length})
+
+    mode = "design"
+    if frames:
+        mode = "live" if any(f["kind"] in ("today", "past", "forecast") for f in frames) \
+            else "projection"
 
     return {
         "schema_version": SCENE_SCHEMA_VERSION,
@@ -84,4 +317,13 @@ def to_scene(layout: Layout, out: DesignOutput, *,
         "assumptions": list(layout.assumptions),
         "hydraulics": (asdict(layout.hydraulics)
                        if layout.hydraulics is not None else None),
+        "twin": {
+            "mode": mode,
+            "as_of": as_of,
+            "frames": frames,
+            # The geometry is a proposal even when the state is the operator's own. Saying so
+            # on screen is the difference between a twin and a picture that flatters itself.
+            "geometry_note": ("layout is a proposed arrangement; the state shown is this "
+                              "system's" if mode == "live" else ""),
+        },
     }

--- a/aqua_model/scene3d.py
+++ b/aqua_model/scene3d.py
@@ -44,9 +44,11 @@ FISH_DRAWN_PER_TANK = 15
 
 # Water colour by nitrogen band. The bands themselves are `advisory.py`'s, which cites
 # knowledge/nitrogen_cycle_and_cycling.md; only the colours are new here, and a colour is
-# not a claim about a pond. "ok" is the viewer's own water blue, so an untroubled system
-# looks exactly as it did before any twin was bound to it.
-WATER_COLORS = {"ok": "#1c7fa8", "act": "#c08b2a", "urgent": "#b23c2e"}
+# not a claim about a pond. There is deliberately NO "ok" colour: healthy water carries an
+# empty override and the viewer keeps its own water blue, so an untroubled system looks
+# exactly as it did before any twin was bound, and retuning that blue stays a one-file
+# change instead of silently breaking the promise from the other side.
+WATER_COLORS = {"act": "#c08b2a", "urgent": "#b23c2e"}
 
 # How pale a nitrogen-starved crop is drawn. Chlorosis on a nitrogen-limited plant is
 # ordinary agronomy, but the DEPTH of the tint is a drawing convention, not a measurement,
@@ -117,7 +119,7 @@ def water_band(nitrogen) -> dict:
         return {"band": "act", "color": WATER_COLORS["act"], "driver": "nitrate",
                 "why": (f"nitrate {no3:.0f} mg/L is over {NO3_HIGH_MG_L:.0f} mg/L — plant "
                         "uptake is not keeping up")}
-    return {"band": "ok", "color": WATER_COLORS["ok"], "driver": "",
+    return {"band": "ok", "color": "", "driver": "",
             "why": f"ammonia {tan:.2f} / nitrite {no2:.2f} / nitrate {no3:.0f} mg/L"}
 
 
@@ -205,18 +207,20 @@ def _keyframe_indices(trajectory, max_frames: int, today_index: int | None) -> l
 
 
 def build_frames(trajectory, *, today_index: int | None = None, dates=(),
-                 max_frames: int = DEFAULT_MAX_FRAMES, roster: int = 0) -> list[dict]:
+                 max_frames: int = DEFAULT_MAX_FRAMES, roster: int = 0,
+                 peak_count: int = 0) -> list[dict]:
     """Turn a `ProductionRun.trajectory` into embeddable per-day frames.
 
     `today_index` marks the day that is NOW: earlier days are what already happened, later
     ones are projection. Pass None when the run is not anchored to a calendar at all (a
     season simulated from a design), and every frame is labelled a projection rather than
-    borrowing the authority of "today".
+    borrowing the authority of "today". Pass a NEGATIVE index when now precedes the run —
+    a live mirror whose forecast starts tonight — and every day in it is a forecast.
     """
     days = list(trajectory)
     if not days:
         return []
-    peak = max(int(d.state.fish.count) for d in days) or 1
+    peak = peak_count or max(int(d.state.fish.count) for d in days) or 1
     roster = roster or FISH_DRAWN_PER_TANK
     frames = []
     for i in _keyframe_indices(days, max_frames, today_index):
@@ -255,10 +259,16 @@ def to_scene(layout: Layout, out: DesignOutput, *,
 
     Binding a twin (all optional, and omitting them leaves the design view untouched):
 
-    - `state`: one `ProductionState` — a live mirror with no forecast behind it. Renders a
-      single frame labelled TODAY.
+    - `state`: one `ProductionState` — the live mirror, which is what NOW means everywhere
+      else in this project: `/forecast` prints it as "Now" and `advisory.recommend` reasons
+      about it. So when it is given it becomes the TODAY frame, and the trajectory behind it
+      is entirely FORECAST, exactly as `production.format_summary` labels it. Letting the
+      simulated first day stand in for today would put a different pond in the picture from
+      the one the bot is talking about, which is the disagreement `twin_view` exists to
+      prevent. Today's crop appearance comes from that first simulated day, because a stored
+      state carries no crop factors and today's conditions are precisely what it evaluates.
     - `trajectory`: a `ProductionRun.trajectory`, embedded as frames the viewer scrubs
-      through. With `today_index` set it is a live twin (today, then forecast); with it
+      through. With `today_index` set and no `state` it is a run anchored mid-way; with it
       None the run is a projection from the design and is labelled as one.
     - `dates`: ISO dates aligned to the trajectory, so the scrubber can say a real date
       instead of only a day number.
@@ -267,21 +277,30 @@ def to_scene(layout: Layout, out: DesignOutput, *,
     laptop with no connection (#79).
     """
     tanks = layout.by_role("fish_tank")
-    frames = list(build_frames(trajectory, today_index=today_index, dates=dates,
-                               max_frames=max_frames,
-                               roster=FISH_DRAWN_PER_TANK * max(1, len(tanks))))
-    if not frames and state is not None:
-        frames = [_frame(state, kind="today",
-                         roster=FISH_DRAWN_PER_TANK * max(1, len(tanks)),
-                         peak_count=int(state.fish.count) or 1, date=as_of)]
+    roster = FISH_DRAWN_PER_TANK * max(1, len(tanks))
+    days = list(trajectory)
+    counts = [int(d.state.fish.count) for d in days]
+    if state is not None:
+        counts.append(int(state.fish.count))
+    peak = max(counts, default=0) or 1
+
+    frames: list[dict] = []
+    if state is not None:
+        frames.append(_frame(state, kind="today", roster=roster, peak_count=peak,
+                             fac=days[0].crop_factors if days else None, date=as_of))
+        today_index = -1          # now precedes the run: every day in it is a forecast
+    frames += build_frames(days, today_index=today_index, dates=dates,
+                           max_frames=max_frames, roster=roster, peak_count=peak)
 
     # The fish roster: how many meshes the viewer builds. In design mode it is the design's
     # stocking, capped; with a twin bound it is sized to the busiest frame, and each frame
-    # then says how many of them are visible on that day.
+    # then says how many of them are visible on that day. A live twin with no fish in it
+    # must NOT fall through to the design's stocking, so the fallback keys on whether a twin
+    # is bound at all rather than on a count that is legitimately zero.
     fish: list[dict] = []
     peak_drawn = max((f["fish"]["drawn"] for f in frames), default=0)
-    shown = peak_drawn or (min(out.fish_count, FISH_DRAWN_PER_TANK * len(tanks))
-                           if tanks and out.fish_count else 0)
+    shown = peak_drawn if frames else (min(out.fish_count, roster)
+                                       if tanks and out.fish_count else 0)
     if tanks and shown:
         per = max(1, -(-shown // len(tanks)))     # ceil: the roster must cover the busiest day
         length = frames[0]["fish"]["length_m"] if frames else 0.15

--- a/aqua_model/tests/test_scene3d.py
+++ b/aqua_model/tests/test_scene3d.py
@@ -89,8 +89,12 @@ def test_an_uncycled_system_says_so_rather_than_only_showing_a_colour():
     assert "cycle is not established" in band["why"]
 
 
-def test_healthy_water_keeps_the_viewers_own_blue():
-    assert water_band(_state().nitrogen)["color"] == scene3d.WATER_COLORS["ok"]
+def test_healthy_water_names_no_colour_at_all():
+    """Healthy water is the viewer's own blue, defined once, in the viewer. Restating it
+    here would let a palette change on either side break the other silently."""
+    band = water_band(_state().nitrogen)
+    assert band["band"] == "ok" and band["color"] == ""
+    assert "ok" not in scene3d.WATER_COLORS
 
 
 # --- fish are the cohort's, not a decorative constant ---------------------------------
@@ -206,12 +210,87 @@ def test_a_bare_mirror_state_renders_one_frame_labelled_today():
 def test_the_whole_bound_scene_is_json_and_embeddable():
     out = _design()
     scene = to_scene(plan_layout(out), out, trajectory=_run(120).trajectory, today_index=0)
-    text = json.dumps(scene)
-    assert "</" not in text or "<\\/" not in text
-    assert len(text) < 900_000, "an embedded season must not bloat the offline file"
+    assert len(json.dumps(scene)) < 900_000, "an embedded season must not bloat the file"
+
+
+def test_a_scene_string_cannot_close_the_script_block_that_embeds_it():
+    """The scene is injected INSIDE a <script> tag, so a stray closing tag anywhere in it
+    would end the block early and render a blank page. The escaping lives in the renderer,
+    so the renderer is what this exercises — asserting on json.dumps alone tests nothing."""
+    import sys
+    from pathlib import Path
+
+    scripts = str(Path(__file__).resolve().parents[2] / "scripts")
+    sys.path.insert(0, scripts)
+    try:
+        from render_3d import build_html
+    finally:
+        sys.path.remove(scripts)
+
+    out = _design()
+    scene = to_scene(plan_layout(out), out, name="pwn </script><script>alert(1)</script>")
+    html = build_html(scene, title="t")
+    payload = html.split('id="scene-data"', 1)[1].split("</script>", 1)[0]
+    assert "</script>" not in payload
+    assert "<\\/script>" in payload, "the closing tag must survive as an escaped sequence"
 
 
 def test_the_chlorosis_onset_is_the_cited_nitrate_floor_not_a_taste_setting():
     """Where the crop starts looking sick has to be a threshold someone can argue with."""
     from aqua_model.cropgrowth import f_nitrogen
     assert scene3d.CHLOROSIS_ONSET == f_nitrogen(advisory.NO3_LOW_MG_L)
+
+
+# --- the picture's TODAY is the same pond the bot is talking about ----------------------
+
+def test_the_today_frame_is_the_mirror_state_not_the_first_simulated_day():
+    """`/forecast` prints this state as "Now" and `advisory.recommend` reasons about it. If
+    the picture showed the first SIMULATED day instead, the bot and the drawing would report
+    different ammonia for the same pond on the same date."""
+    out = _design()
+    state = _state(tan_mg_l=0.0, no3_mg_l=0.0)
+    run = _run(10)
+    scene = to_scene(plan_layout(out), out, state=state, trajectory=run.trajectory,
+                     as_of="2026-09-03")
+
+    today = scene["twin"]["frames"][0]
+    assert today["kind"] == "today" and today["date"] == "2026-09-03"
+    assert today["water"]["tan_mg_l"] == pytest.approx(state.nitrogen.tan_mg_l, abs=1e-9)
+    assert today["fish"]["mean_weight_g"] == pytest.approx(state.fish.mean_weight_g, abs=0.05)
+    assert today["water"]["tan_mg_l"] != pytest.approx(
+        run.trajectory[0].state.nitrogen.tan_mg_l, abs=1e-6), (
+        "this test is meaningless unless the simulated day actually differs")
+
+
+def test_everything_behind_a_bound_state_is_forecast():
+    """`format_summary` calls the whole trajectory "the next N days (forecast)". The picture
+    must not promote its first day to today."""
+    out = _design()
+    scene = to_scene(plan_layout(out), out, state=_state(), trajectory=_run(10).trajectory)
+    kinds = [f["kind"] for f in scene["twin"]["frames"]]
+    assert kinds[0] == "today"
+    assert set(kinds[1:]) == {"forecast"}
+    assert scene["twin"]["mode"] == "live"
+
+
+def test_todays_crop_comes_from_the_day_the_model_actually_evaluated():
+    """A stored state carries no crop factors, but the first simulated day IS today's
+    conditions — so the bed is drawn from those rather than left at its mature size, which
+    would flatter a starved crop on the one frame the operator opens by default."""
+    out = _design()
+    run = _run(10, cycled=False)
+    scene = to_scene(plan_layout(out), out, state=_state(), trajectory=run.trajectory)
+    today = scene["twin"]["frames"][0]
+    assert today["crop"]["f_nitrogen"] == pytest.approx(
+        run.trajectory[0].crop_factors.f_nitrogen, abs=1e-6)
+
+
+def test_a_live_twin_with_no_fish_never_borrows_the_designs_stocking():
+    """`fish_count = 0` is a real state (a system between cohorts). A falsy-zero fallback
+    would advertise the sizing model's fish on a scene whose mode says "live"."""
+    out = _design()
+    empty = start_state(volume_l=3000.0, fish_count=0, start_weight_g=50.0,
+                        water_temp_c=26.0, species=TILAPIA)
+    scene = to_scene(plan_layout(out), out, state=empty)
+    assert scene["fish"] == [], "a live scene with no fish must advertise no fish"
+    assert scene["twin"]["frames"][0]["fish"]["count"] == 0

--- a/aqua_model/tests/test_scene3d.py
+++ b/aqua_model/tests/test_scene3d.py
@@ -1,0 +1,217 @@
+"""The scene is the picture's only source of truth, so what a twin makes it show is tested
+here rather than in JavaScript: the bands are the advisor's, the fish are the cohort's, and
+a downsampled season still contains the day the nitrite spiked."""
+
+import json
+
+import pytest
+
+from aqua_model import advisory, scene3d
+from aqua_model.climate import DailyClimate
+from aqua_model.crops import get_crop
+from aqua_model.layout import plan_layout
+from aqua_model.production import simulate_production, start_state
+from aqua_model.scene3d import build_frames, fish_length_m, to_scene, water_band
+from aqua_model.sizing import size_system
+from aqua_model.species import get_species
+from aqua_model.twin import TwinState
+from aqua_model.validate import validate_design_input
+
+TILAPIA = get_species("tilapia")
+BASIL = get_crop("basil")
+GOOD_DAY = DailyClimate(t_mean_c=25.0, t_min_c=20.0, t_max_c=29.0, solar_mj_m2=18.0)
+
+
+def _design(system_type: str = "raft", area: float = 24.0):
+    return size_system(validate_design_input(
+        fish_species="tilapia", crop="basil", grow_area_m2=area,
+        temperature_c=28.0, water_budget_lpd=500.0, system_type=system_type))
+
+
+def _state(**nitrogen):
+    """A production state whose water chemistry is exactly what the test is about."""
+    st = start_state(volume_l=3000.0, fish_count=80, start_weight_g=50.0,
+                     water_temp_c=26.0, species=TILAPIA)
+    return type(st)(**{**st.__dict__,
+                       "nitrogen": TwinState(**{**st.nitrogen.__dict__, **nitrogen})})
+
+
+def _run(days: int = 90, *, cycled: bool = False):
+    init = start_state(volume_l=3000.0, fish_count=80, start_weight_g=50.0,
+                       water_temp_c=26.0, species=TILAPIA, cycled=cycled)
+    return simulate_production(init, (GOOD_DAY,) * days, TILAPIA, "tilapia", BASIL, 24.0)
+
+
+# --- the design view is unchanged when no twin is bound -------------------------------
+
+def test_a_design_with_no_state_renders_exactly_as_before():
+    out = _design()
+    scene = to_scene(plan_layout(out), out, name="t", subtitle="s")
+    assert scene["twin"]["mode"] == "design"
+    assert scene["twin"]["frames"] == []
+    assert scene["fish"], "a stocked design should still show fish"
+    json.dumps(scene)          # must not raise
+
+
+def test_binding_a_state_does_not_move_a_single_dimension():
+    """The twin changes what the water looks like, never where anything stands."""
+    out = _design()
+    layout = plan_layout(out)
+    plain = to_scene(layout, out, name="t")
+    bound = to_scene(layout, out, name="t", trajectory=_run(30).trajectory, today_index=0)
+    for key in ("greenhouse", "objects", "pipes", "hydraulics"):
+        assert plain[key] == bound[key], f"{key} moved when a twin was bound"
+
+
+# --- the bands are the advisor's ------------------------------------------------------
+
+def test_water_turns_amber_on_the_number_the_advisor_acts_on():
+    just_under = water_band(_state(tan_mg_l=advisory.TAN_ACT_MG_L - 1e-6).nitrogen)
+    at_band = water_band(_state(tan_mg_l=advisory.TAN_ACT_MG_L).nitrogen)
+    assert just_under["band"] == "ok"
+    assert at_band["band"] == "act" and at_band["driver"] == "ammonia"
+
+
+def test_urgent_is_the_advisors_urgent_band_not_a_new_one():
+    band = water_band(_state(no2_mg_l=advisory.NO2_URGENT_MG_L).nitrogen)
+    assert band["band"] == "urgent" and band["driver"] == "nitrite"
+    assert f"{advisory.NO2_URGENT_MG_L:.1f}" in band["why"]
+
+
+def test_high_nitrate_is_flagged_and_blamed_on_uptake():
+    band = water_band(_state(no3_mg_l=advisory.NO3_HIGH_MG_L + 5).nitrogen)
+    assert band["band"] == "act" and band["driver"] == "nitrate"
+    assert "uptake" in band["why"]
+
+
+def test_an_uncycled_system_says_so_rather_than_only_showing_a_colour():
+    band = water_band(_state(tan_mg_l=0.8, no3_mg_l=1.0).nitrogen)
+    assert "cycle is not established" in band["why"]
+
+
+def test_healthy_water_keeps_the_viewers_own_blue():
+    assert water_band(_state().nitrogen)["color"] == scene3d.WATER_COLORS["ok"]
+
+
+# --- fish are the cohort's, not a decorative constant ---------------------------------
+
+def test_fish_grow_between_frames_and_the_count_is_the_twins():
+    frames = build_frames(_run(120).trajectory, today_index=0)
+    first, last = frames[0]["fish"], frames[-1]["fish"]
+    assert last["mean_weight_g"] > first["mean_weight_g"] * 1.5
+    assert last["length_m"] > first["length_m"]
+    assert first["count"] == 80, "the drawn count must not stand in for the twin's count"
+
+
+def test_fish_length_follows_weight_by_the_cube_root():
+    assert fish_length_m(500) == pytest.approx(0.297, abs=0.01)     # ~30 cm at harvest
+    assert fish_length_m(4000) == pytest.approx(fish_length_m(500) * 2, rel=0.01)
+
+
+def test_a_die_off_thins_the_drawn_population():
+    """A capped roster must still show mortality, or the picture contradicts the count."""
+    run = _run(20)
+    days = list(run.trajectory)
+    half = [days[0]]
+    for d in days[1:]:
+        cohort = type(d.state.fish)(count=d.state.fish.count // 2,
+                                    mean_weight_g=d.state.fish.mean_weight_g)
+        half.append(type(d)(**{**d.__dict__,
+                               "state": type(d.state)(**{**d.state.__dict__,
+                                                         "fish": cohort})}))
+    frames = build_frames(half, today_index=0)
+    assert frames[-1]["fish"]["drawn"] < frames[0]["fish"]["drawn"]
+    assert frames[-1]["fish"]["count"] == 40
+
+
+def test_the_roster_covers_the_busiest_frame():
+    out = _design()
+    scene = to_scene(plan_layout(out), out, trajectory=_run(60).trajectory, today_index=0)
+    roster = sum(f["count"] for f in scene["fish"])
+    assert roster >= max(fr["fish"]["drawn"] for fr in scene["twin"]["frames"])
+
+
+# --- the crop shows why it is growing badly -------------------------------------------
+
+def test_a_nitrogen_starved_crop_is_drawn_small_and_pale():
+    frames = build_frames(_run(20, cycled=False).trajectory, today_index=0)
+    starved = frames[0]["crop"]              # day 1 of an uncycled system: no nitrate yet
+    assert starved["limiting"] == "nitrogen"
+    assert starved["chlorosis"] > 0.5
+    assert starved["scale"] < 1.0
+
+
+def test_a_healthy_crop_keeps_its_own_colour():
+    fed = build_frames(_run(200, cycled=True).trajectory, today_index=0)[-1]["crop"]
+    assert fed["chlorosis"] == 0.0, "a fed crop must not be tinted toward deficiency"
+
+
+def test_plants_never_shrink_to_nothing():
+    """A continuous-harvest bed is never empty; the model does not claim otherwise."""
+    for f in build_frames(_run(60).trajectory, today_index=0):
+        assert f["crop"]["scale"] >= scene3d.PLANT_SCALE_FLOOR
+
+
+# --- the scrubber ---------------------------------------------------------------------
+
+def test_a_long_season_is_downsampled_but_keeps_the_nitrite_spike():
+    run = _run(365, cycled=False)
+    frames = build_frames(run.trajectory, today_index=0, max_frames=60)
+    assert len(frames) <= 75, "downsampling should hold near the budget"
+    peak = max(d.state.nitrogen.no2_mg_l for d in run.trajectory)
+    assert max(f["water"]["no2_mg_l"] for f in frames) == pytest.approx(peak, rel=1e-3)
+
+
+def test_every_frame_says_which_of_the_three_things_it_is():
+    live = build_frames(_run(30).trajectory, today_index=0)
+    assert live[0]["kind"] == "today"
+    assert {f["kind"] for f in live[1:]} == {"forecast"}
+    projected = build_frames(_run(30).trajectory, today_index=None)
+    assert {f["kind"] for f in projected} == {"projected"}, (
+        "a season simulated from a design must not borrow the authority of 'today'")
+
+
+def test_dates_ride_along_when_the_run_has_a_calendar():
+    dates = [f"2026-09-{i + 1:02d}" for i in range(10)]
+    frames = build_frames(_run(10).trajectory, today_index=0, dates=dates)
+    assert frames[0]["date"] == "2026-09-01"
+    assert all(f["date"] for f in frames)
+
+
+def test_the_mode_distinguishes_a_live_twin_from_a_projection():
+    out = _design()
+    layout = plan_layout(out)
+    traj = _run(30).trajectory
+    assert to_scene(layout, out, trajectory=traj, today_index=0)["twin"]["mode"] == "live"
+    assert to_scene(layout, out, trajectory=traj)["twin"]["mode"] == "projection"
+    assert to_scene(layout, out)["twin"]["mode"] == "design"
+
+
+def test_a_live_scene_says_the_geometry_is_still_only_a_proposal():
+    out = _design()
+    scene = to_scene(plan_layout(out), out, trajectory=_run(5).trajectory, today_index=0)
+    assert "proposed" in scene["twin"]["geometry_note"]
+
+
+def test_a_bare_mirror_state_renders_one_frame_labelled_today():
+    out = _design()
+    scene = to_scene(plan_layout(out), out, state=_state(), as_of="2026-09-02")
+    frames = scene["twin"]["frames"]
+    assert len(frames) == 1 and frames[0]["kind"] == "today"
+    assert frames[0]["date"] == "2026-09-02"
+    assert "crop" not in frames[0], (
+        "a stored state carries no crop factors; inventing them would be a fabricated day")
+
+
+def test_the_whole_bound_scene_is_json_and_embeddable():
+    out = _design()
+    scene = to_scene(plan_layout(out), out, trajectory=_run(120).trajectory, today_index=0)
+    text = json.dumps(scene)
+    assert "</" not in text or "<\\/" not in text
+    assert len(text) < 900_000, "an embedded season must not bloat the offline file"
+
+
+def test_the_chlorosis_onset_is_the_cited_nitrate_floor_not_a_taste_setting():
+    """Where the crop starts looking sick has to be a threshold someone can argue with."""
+    from aqua_model.cropgrowth import f_nitrogen
+    assert scene3d.CHLOROSIS_ONSET == f_nitrogen(advisory.NO3_LOW_MG_L)

--- a/docs/production_twin.md
+++ b/docs/production_twin.md
@@ -92,9 +92,17 @@ What a frame decides, and where it comes from:
 | in the picture | from | decided in |
 |---|---|---|
 | fish count and size | `ProductionState.fish` (the cohort) | `scene3d._fish_block`, length by `FULTON_K` |
-| water colour | ammonia / nitrite / nitrate vs the action bands | `scene3d.water_band`, thresholds from `advisory.py` |
+| water colour | ammonia / nitrite / nitrate vs the action bands | `scene3d.water_band`, thresholds from `advisory.py` (healthy water carries no override: the viewer keeps its own blue) |
 | crop size and pallor | the day's `CropFactors` | `scene3d._crop_block`, chlorosis onset = `f_nitrogen(NO3_LOW_MG_L)` |
 | the badge | `today` / `forecast` / `projected` | `scene3d.build_frames` |
+
+`state` is what TODAY means. `/forecast` prints it as "Now" and `advisory.recommend` reasons
+about it, so when it is bound the picture shows it and the whole trajectory behind it is
+forecast — exactly how `format_summary` labels the same run. Letting the first SIMULATED day
+stand in for today would have put a different pond in the picture from the one the bot is
+discussing in the same reply (measured: 200 g / NH3 0.00 in the bot, 202 g / NH3 0.26 in the
+drawing). Today's crop appearance comes from that first simulated day, because a stored state
+carries no crop factors and today's conditions are precisely what it evaluates.
 
 Three rules hold this together:
 

--- a/docs/production_twin.md
+++ b/docs/production_twin.md
@@ -24,6 +24,9 @@ climate.py --> production.py <-- fishgrowth.py (TGC)
 
 sizing.py --> layout.py --> scene3d.py --> scripts/render_3d.py --> one offline HTML
               (placement)   (scene JSON)   (embeds web/vendor/three.min.js)
+                                ^
+                                |  optional: state + trajectory
+                    ProductionRun / mirror.ProductionState
 ```
 
 ## Simulating a season
@@ -64,6 +67,49 @@ design); `scene3d.to_scene` serializes it; the renderer embeds three.js (vendore
 r147, MIT) so the file works offline. Media-bed systems carry no separate biofilter
 vessel; tower systems raise the ridge. The layout declares itself a proposal, not a
 site plan.
+
+## Binding the twin to the drawing
+
+Until this landed there were two twins that had never been introduced (#118): `mirror.py`
+held one operator's real state, `scene3d.py` drew a design, and nothing joined them, so the
+3D view had never once shown anyone's actual pond.
+
+`to_scene` now takes an optional `state` (a `ProductionState`) or `trajectory` (a
+`ProductionRun.trajectory`) and embeds per-day FRAMES the viewer scrubs through:
+
+```bash
+python scripts/render_3d.py --crop basil --site taichung_2025 --days 365 -o first_year.html
+```
+
+```python
+from agronaut_agent import twin_view
+snap  = twin_view.compute(mem, user_id, days=14)     # this operator's live twin
+scene = twin_view.scene_for(snap, mem.get_facts(user_id))   # ...bound to their drawing
+```
+
+What a frame decides, and where it comes from:
+
+| in the picture | from | decided in |
+|---|---|---|
+| fish count and size | `ProductionState.fish` (the cohort) | `scene3d._fish_block`, length by `FULTON_K` |
+| water colour | ammonia / nitrite / nitrate vs the action bands | `scene3d.water_band`, thresholds from `advisory.py` |
+| crop size and pallor | the day's `CropFactors` | `scene3d._crop_block`, chlorosis onset = `f_nitrogen(NO3_LOW_MG_L)` |
+| the badge | `today` / `forecast` / `projected` | `scene3d.build_frames` |
+
+Three rules hold this together:
+
+1. **The viewer decides nothing.** Every appearance is a number in the frame. A colour chosen
+   in JavaScript would be a second, uncited opinion about when a pond is in trouble.
+2. **The three things stay distinct.** A design, the system today, and a projection are
+   labelled on screen at all times. `today_index=None` marks a run that is not anchored to a
+   calendar, and every frame in it says "projection" rather than borrowing today's authority.
+3. **The geometry is still a proposal** even when the state is the operator's own, and the
+   scene says so in `twin.geometry_note`. A tank volume that disagrees with what the grow area
+   implies is stated in the subtitle rather than quietly drawn over.
+
+A long run is downsampled to ~120 frames, but the peaks of each nitrogen channel, every
+harvest day, today and the endpoints are pinned in: a stride that landed either side of the
+nitrite spike would show a season in which it never happened.
 
 ## Where the data comes from, and what is still missing
 

--- a/scripts/render_3d.py
+++ b/scripts/render_3d.py
@@ -63,7 +63,7 @@ def simulate(out, args):
             f"No climate file for site {args.site!r}. Available: {have}. Fetch one "
             f"(no API key needed): python scripts/fetch_climate.py --lat <LAT> "
             f"--lon <LON> --name {args.site}")
-    payload = json.loads(path.read_text())
+    payload = json.loads(path.read_text(encoding="utf-8"))
     days = payload["days"][:max(2, int(args.days))]
     weather = from_records(days)
     species = get_species(args.species)
@@ -77,9 +77,12 @@ def simulate(out, args):
 
 
 def build_html(scene: dict, title: str) -> str:
-    template = (WEB / "viewer_template.html").read_text()
-    three = (WEB / "vendor" / "three.min.js").read_text()
-    orbit = (WEB / "vendor" / "OrbitControls.js").read_text()
+    # utf-8 everywhere, never the platform default: the template and every scene subtitle
+    # carry m2, degree signs and dashes, and a host under LANG=C would fail to write the
+    # file rather than draw a system.
+    template = (WEB / "viewer_template.html").read_text(encoding="utf-8")
+    three = (WEB / "vendor" / "three.min.js").read_text(encoding="utf-8")
+    orbit = (WEB / "vendor" / "OrbitControls.js").read_text(encoding="utf-8")
     # </script> inside the JSON payload would end the script block early; escape defensively.
     payload = json.dumps(scene).replace("</", "<\\/")
     return (template
@@ -135,7 +138,7 @@ def main(argv: list[str] | None = None) -> int:
 
     html = build_html(scene, title=scene["name"])
     dest = Path(args.out)
-    dest.write_text(html)
+    dest.write_text(html, encoding="utf-8")
     print(f"wrote {dest}  ({len(html) / 1e6:.1f} MB, open in any browser)")
     if run is not None:
         s = run.summary

--- a/scripts/render_3d.py
+++ b/scripts/render_3d.py
@@ -2,6 +2,11 @@
 
 Pipeline:  validate -> size_system -> plan_layout -> to_scene -> one HTML file.
 
+With `--site`, the same design is also simulated day by day through that site's real
+weather and the season is embedded in the file, so the viewer gets a scrubber: the same
+geometry as designed, and as it is projected to stand on any day of the run. The frames
+are embedded rather than fetched, for the same reason the library is vendored.
+
 The output embeds the vendored three.js (web/vendor/), the viewer, and the scene JSON, so the
 file works offline from a double-click — no server, no CDN, no build step. That is deliberate:
 the people this is for (see the offline-first epic, #79) cannot assume connectivity, and a
@@ -12,6 +17,9 @@ them. Usage:
 
     python scripts/render_3d.py --species tilapia --crop lettuce --area 24 \
         --temp 26 --water 400 --system-type raft -o design_3d.html
+
+    python scripts/render_3d.py --crop basil --site taichung_2025 --days 365 \
+        -o first_year.html          # same design, plus a season to scrub through
 """
 
 from __future__ import annotations
@@ -30,6 +38,42 @@ from aqua_model.sizing import size_system  # noqa: E402
 from aqua_model.validate import validate_design_input  # noqa: E402
 
 WEB = REPO_ROOT / "web"
+CLIMATE = REPO_ROOT / "data" / "climate"
+
+
+def simulate(out, args):
+    """Run the sized design through a site's weather. Returns (run, dates).
+
+    A NEW build starts uncycled: the nitrite spike of the first weeks is part of an honest
+    first season, and it is exactly what this view exists to make visible.
+    """
+    from aqua_model.climate import GreenhouseParams, from_records
+    from aqua_model.crops import get_crop
+    from aqua_model.production import (
+        ProductionParams,
+        simulate_production,
+        start_state_from_design,
+    )
+    from aqua_model.species import get_species
+
+    path = CLIMATE / f"{args.site.strip().lower()}.json"
+    if not path.exists():
+        have = ", ".join(sorted(p.stem for p in CLIMATE.glob("*.json"))) or "none"
+        raise SystemExit(
+            f"No climate file for site {args.site!r}. Available: {have}. Fetch one "
+            f"(no API key needed): python scripts/fetch_climate.py --lat <LAT> "
+            f"--lon <LON> --name {args.site}")
+    payload = json.loads(path.read_text())
+    days = payload["days"][:max(2, int(args.days))]
+    weather = from_records(days)
+    species = get_species(args.species)
+    gh = GreenhouseParams(shade_to_ambient=args.greenhouse == "shade")
+    init = start_state_from_design(out, species, water_temp_c=weather[0].t_mean_c,
+                                   cycled=False)
+    run = simulate_production(init, weather, species, args.species,
+                              get_crop(args.crop), out.grow_area_m2,
+                              params=ProductionParams(greenhouse=gh))
+    return run, [str(d.get("date", "")) for d in days]
 
 
 def build_html(scene: dict, title: str) -> str:
@@ -54,6 +98,12 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--water", type=float, default=500.0, help="water budget L/day")
     ap.add_argument("--system-type", default="raft",
                     choices=["raft", "nft", "media_bed", "vertical_tower"])
+    ap.add_argument("--site", default="",
+                    help="climate slug from data/climate/ — simulates the season and "
+                         "embeds it as a scrubber (e.g. taichung_2025)")
+    ap.add_argument("--days", type=int, default=365, help="days to simulate with --site")
+    ap.add_argument("--greenhouse", default="poly", choices=["poly", "shade"],
+                    help="greenhouse mode for the simulation")
     ap.add_argument("-o", "--out", default="design_3d.html")
     args = ap.parse_args(argv)
 
@@ -63,9 +113,20 @@ def main(argv: list[str] | None = None) -> int:
         system_type=args.system_type)
     out = size_system(design)
     layout = plan_layout(out, crop_label=args.crop, species_label=args.species)
+
+    trajectory, dates = (), ()
+    run = None
+    if args.site:
+        if not out.feasible:
+            raise SystemExit(f"The design is infeasible ({out.binding_constraint}) — "
+                             "simulating it would project a system nobody should build.")
+        run, dates = simulate(out, args)
+        trajectory = run.trajectory
+
     scene = to_scene(
         layout, out,
         crop=args.crop, species=args.species,
+        trajectory=trajectory, dates=dates,
         name=f"{args.system_type.replace('_', ' ').title()} aquaponics — "
              f"{args.species} + {args.crop}",
         subtitle=(f"{out.grow_area_m2:.0f} m² grow area · {out.fish_count} fish "
@@ -76,6 +137,13 @@ def main(argv: list[str] | None = None) -> int:
     dest = Path(args.out)
     dest.write_text(html)
     print(f"wrote {dest}  ({len(html) / 1e6:.1f} MB, open in any browser)")
+    if run is not None:
+        s = run.summary
+        print(f"  season: {len(trajectory)} days at {args.site} · "
+              f"{len(scene['twin']['frames'])} frames in the scrubber · "
+              f"fish {s.fish_harvested_kg:.0f} kg harvested + "
+              f"{s.fish_standing_kg:.0f} kg standing · crop {s.crop_harvested_kg:.0f} kg · "
+              f"peak NO2 {s.peak_no2_mg_l:.2f} mg/L")
     if not out.feasible:
         print(f"NOTE: design reported infeasible — {out.binding_constraint}")
     for w in out.warnings:

--- a/web/viewer_template.html
+++ b/web/viewer_template.html
@@ -56,10 +56,31 @@
     font-size: 11px; text-align: center; }
   #scalebar .bar { height: 4px; border: 1px solid var(--muted); border-top: 0;
     margin-bottom: 3px; }
+  /* ---- twin scrubber: only present when a state is bound to the design ---- */
+  #twin { position: absolute; left: 50%; transform: translateX(-50%); bottom: 62px;
+    width: min(640px, calc(100% - 28px)); padding: 9px 13px 11px; display: none;
+    color: var(--panel-fg); font-size: 12.5px; }
+  #twin .row { display: flex; align-items: center; gap: 9px; }
+  #twin .badge { font-size: 10px; letter-spacing: .09em; text-transform: uppercase;
+    font-weight: 700; padding: 3px 7px; border-radius: 5px; white-space: nowrap;
+    background: var(--accent); color: #0c1a13; }
+  #twin .badge.design { background: rgba(255,255,255,0.14); color: var(--panel-fg); }
+  #twin .badge.forecast { background: #6f8fb5; color: #0b1620; }
+  #twin .when { font-weight: 600; white-space: nowrap; }
+  #twin .when .muted { color: var(--muted); font-weight: 400; }
+  #twin .read { color: var(--muted); font-size: 11.5px; line-height: 1.5; margin-top: 6px;
+    display: flex; flex-wrap: wrap; gap: 3px 14px; }
+  #twin .read b { color: var(--panel-fg); font-weight: 600; }
+  #twin .why { display: flex; align-items: center; gap: 6px; margin-top: 5px;
+    font-size: 11.5px; color: #f0d9a8; }
+  #twin .why .chip { width: 9px; height: 9px; border-radius: 3px; flex: 0 0 auto; }
+  #t-range { flex: 1 1 auto; accent-color: var(--accent); height: 18px; margin: 0; }
+  #t-play { padding: 3px 9px; min-width: 30px; }
   @media (max-width: 720px) {
     #hud { width: auto; right: 14px; }
     #legend-scroll { max-height: 20vh; }
     #cap { display: none; }
+    #twin .read { font-size: 11px; }
   }
 </style>
 </head>
@@ -84,6 +105,19 @@
   <button class="btn view" data-view="front">front</button>
   <button class="btn view" data-view="inside">walk in</button>
 </div>
+<div id="twin" class="panel">
+  <div class="row">
+    <span class="badge" id="t-badge">as designed</span>
+    <button class="btn" id="t-play" title="play the season (space)">&#9654;</button>
+    <input type="range" id="t-range" min="0" max="0" value="0" step="1"
+           aria-label="day of the season">
+    <span class="when" id="t-when"></span>
+  </div>
+  <div class="read" id="t-read"></div>
+  <div class="why" id="t-why" style="display:none">
+    <span class="chip" id="t-chip"></span><span id="t-why-text"></span>
+  </div>
+</div>
 <div id="tip" class="panel"></div>
 <div id="cap">drag to orbit &middot; scroll to zoom &middot; right-drag to pan</div>
 <div id="scalebar"><div class="bar" id="sb-bar"></div><span id="sb-txt"></span></div>
@@ -94,6 +128,13 @@
 <script>
 "use strict";
 const SCENE = JSON.parse(document.getElementById("scene-data").textContent);
+
+/* ---------- the twin, if one is bound ----------
+   FRAMES are days of a simulated or mirrored system. Everything they make the picture do —
+   water colour, fish size and number, how vigorous the crop looks — was decided in
+   aqua_model/scene3d.py, where it is cited and tested. Nothing below picks a threshold. */
+const TWIN = SCENE.twin || {};
+const FRAMES = TWIN.frames || [];
 
 /* ---------- deterministic randomness ----------
    The model is deterministic, so the picture must be too: the same design has to render
@@ -401,6 +442,11 @@ const leafGeo = (function () {
 const stemGeo = new THREE.CylinderGeometry(0.010, 0.016, 1, 5);
 stemGeo.translate(0, 0.5, 0);
 
+/* Each bed keeps the shape it was born with — position, orientation, size, colour, per
+   instance — so a frame can redraw it at a different size or tint without re-randomising
+   the bed. Without this, scrubbing a day would reshuffle every plant in the greenhouse. */
+const plantBeds = [];
+
 function addPlants(cx, cz, w, l, top, spacing) {
   const sp = spacing || 0.25;
   const nx = Math.max(1, Math.floor(w / sp)), nz = Math.max(1, Math.floor(l / sp));
@@ -413,6 +459,15 @@ function addPlants(cx, cz, w, l, top, spacing) {
   const stems = FORM.stem > 0 ? new THREE.InstancedMesh(stemGeo, stemMat, n) : null;
   if (stems) stems.castShadow = true;
 
+  const bed = {
+    leaves, stems, n, leafCount: 0,
+    leafPos: new Float32Array(n * K * 3), leafQuat: new Float32Array(n * K * 4),
+    leafScale: new Float32Array(n * K * 2), leafColor: new Float32Array(n * K * 3),
+    leafStemH: new Float32Array(n * K),
+    stemPos: new Float32Array(n * 3), stemQuat: new Float32Array(n * 4),
+    stemH: new Float32Array(n),
+  };
+
   const M = new THREE.Matrix4(), Q = new THREE.Quaternion(), E = new THREE.Euler();
   const P = new THREE.Vector3(), S = new THREE.Vector3(), C = new THREE.Color();
   const base = new THREE.Color(FORM.tint);
@@ -423,10 +478,15 @@ function addPlants(cx, cz, w, l, top, spacing) {
     const pz = cz - l / 2 + sp / 2 + b * sp + (rnd() - 0.5) * sp * 0.14;
     const vigour = 0.80 + rnd() * 0.40;          // not every plant grows the same
     const H = FORM.h * vigour, stemH = FORM.stem * H;
+    const si = a * nz + b;
     if (stems) {
       E.set(0, rnd() * 6.283, 0); Q.setFromEuler(E);
       P.set(px, top, pz); S.set(1, stemH, 1);
-      stems.setMatrixAt(a * nz + b, M.compose(P, Q, S));
+      stems.setMatrixAt(si, M.compose(P, Q, S));
+      bed.stemPos[si * 3] = px; bed.stemPos[si * 3 + 1] = top; bed.stemPos[si * 3 + 2] = pz;
+      bed.stemQuat[si * 4] = Q.x; bed.stemQuat[si * 4 + 1] = Q.y;
+      bed.stemQuat[si * 4 + 2] = Q.z; bed.stemQuat[si * 4 + 3] = Q.w;
+      bed.stemH[si] = stemH;
     }
     // Per-plant colour jitter: a uniform bed of one green is the tell of a rendering.
     C.setHSL(hsl.h + (rnd() - 0.5) * 0.035, hsl.s * (0.85 + rnd() * 0.3),
@@ -438,18 +498,65 @@ function addPlants(cx, cz, w, l, top, spacing) {
       const tilt = FORM.tilt * (1 - 0.78 * ring) + (rnd() - 0.5) * 0.12;
       E.set(tilt, ang, 0, "YXZ"); Q.setFromEuler(E);
       const len = (H - stemH) * (0.55 + 0.5 * (1 - ring)) * (0.85 + rnd() * 0.3);
+      const lw = FORM.leafW * (0.85 + rnd() * 0.3);
       P.set(px, top + stemH, pz);
-      S.set(FORM.leafW * (0.85 + rnd() * 0.3), len, 1);
+      S.set(lw, len, 1);
       leaves.setMatrixAt(li, M.compose(P, Q, S));
       leaves.setColorAt(li, C);
+      bed.leafPos[li * 3] = px; bed.leafPos[li * 3 + 1] = top; bed.leafPos[li * 3 + 2] = pz;
+      bed.leafQuat[li * 4] = Q.x; bed.leafQuat[li * 4 + 1] = Q.y;
+      bed.leafQuat[li * 4 + 2] = Q.z; bed.leafQuat[li * 4 + 3] = Q.w;
+      bed.leafScale[li * 2] = lw; bed.leafScale[li * 2 + 1] = len;
+      bed.leafColor[li * 3] = C.r; bed.leafColor[li * 3 + 1] = C.g;
+      bed.leafColor[li * 3 + 2] = C.b;
+      bed.leafStemH[li] = stemH;
       li++;
     }
   }
   leaves.count = li;
+  bed.leafCount = li;
   if (leaves.instanceColor) leaves.instanceColor.needsUpdate = true;
   plantGroup.add(leaves);
   if (stems) plantGroup.add(stems);
+  plantBeds.push(bed);
   return n;
+}
+
+/* Redraw every bed at `scale` of its mature size, tinted `chl` of the way toward the
+   deficiency colour. Both numbers come from the frame; neither is decided here. */
+let lastPlantState = null;
+function setPlantAppearance(scale, chl, chlColor) {
+  const key = scale.toFixed(3) + ":" + chl.toFixed(3);
+  if (key === lastPlantState) return;
+  lastPlantState = key;
+  const M = new THREE.Matrix4(), Q = new THREE.Quaternion();
+  const P = new THREE.Vector3(), S = new THREE.Vector3();
+  const C = new THREE.Color(), sick = new THREE.Color(chlColor || "#c9c04a");
+  for (const bed of plantBeds) {
+    for (let i = 0; i < bed.leafCount; i++) {
+      Q.set(bed.leafQuat[i * 4], bed.leafQuat[i * 4 + 1],
+            bed.leafQuat[i * 4 + 2], bed.leafQuat[i * 4 + 3]);
+      P.set(bed.leafPos[i * 3], bed.leafPos[i * 3 + 1] + bed.leafStemH[i] * scale,
+            bed.leafPos[i * 3 + 2]);
+      S.set(bed.leafScale[i * 2] * scale, bed.leafScale[i * 2 + 1] * scale, 1);
+      bed.leaves.setMatrixAt(i, M.compose(P, Q, S));
+      C.setRGB(bed.leafColor[i * 3], bed.leafColor[i * 3 + 1], bed.leafColor[i * 3 + 2]);
+      if (chl > 0) C.lerp(sick, chl);
+      bed.leaves.setColorAt(i, C);
+    }
+    bed.leaves.instanceMatrix.needsUpdate = true;
+    if (bed.leaves.instanceColor) bed.leaves.instanceColor.needsUpdate = true;
+    if (bed.stems) {
+      for (let i = 0; i < bed.n; i++) {
+        Q.set(bed.stemQuat[i * 4], bed.stemQuat[i * 4 + 1],
+              bed.stemQuat[i * 4 + 2], bed.stemQuat[i * 4 + 3]);
+        P.set(bed.stemPos[i * 3], bed.stemPos[i * 3 + 1], bed.stemPos[i * 3 + 2]);
+        S.set(1, Math.max(1e-4, bed.stemH[i] * scale), 1);
+        bed.stems.setMatrixAt(i, M.compose(P, Q, S));
+      }
+      bed.stems.instanceMatrix.needsUpdate = true;
+    }
+  }
 }
 
 const tanks = {};
@@ -578,10 +685,14 @@ const fishes = [];
   const tailMat = new THREE.MeshStandardMaterial({ color: 0x9d7150, roughness: 0.5,
     transparent: true, opacity: 0.9, side: THREE.DoubleSide });
 
+  // Built per tank, then interleaved: a frame shows the first `drawn` of this list, so
+  // hiding the tail thins every tank evenly instead of emptying the last one.
+  const perTank = [];
   for (const f of SCENE.fish || []) {
     const t = tanks[f.tank]; if (!t) continue;
     const n = Math.min(f.count || 10, 60);
     const L = f.length_m || 0.15;
+    const group = [];
     for (let i = 0; i < n; i++) {
       const g = new THREE.Group();
       const body = new THREE.Mesh(bodyGeo, bodyMat);
@@ -590,16 +701,37 @@ const fishes = [];
       g.scale.setScalar(L);
       fishGroup.add(g);
       const a = rnd() * 6.283, rr = Math.sqrt(rnd()) * t.r * 0.72;
-      fishes.push({
+      const fish = {
         g, t, tail,
         x: t.x + rr * Math.cos(a), z: t.z + rr * Math.sin(a),
         y: t.waterTop * (0.25 + rnd() * 0.55),
         head: rnd() * 6.283,
         turn: (rnd() - 0.5) * 0.6,
-        speed: L * (1.1 + rnd() * 1.1),          // body-lengths per second, roughly
+        speedK: 1.1 + rnd() * 1.1,               // body-lengths per second, roughly
         bob: rnd() * 6.283,
         wag: rnd() * 6.283,
-      });
+      };
+      fish.speed = L * fish.speedK;
+      group.push(fish);
+    }
+    perTank.push(group);
+  }
+  for (let i = 0; ; i++) {
+    let any = false;
+    for (const g of perTank) if (i < g.length) { fishes.push(g[i]); any = true; }
+    if (!any) break;
+  }
+}
+
+/* How many fish are in the water and how big they are, from the frame. The COUNT the
+   operator reads is the twin's; this is only how many of them the picture draws. */
+function setFishAppearance(drawn, lengthM) {
+  for (let i = 0; i < fishes.length; i++) {
+    const f = fishes[i];
+    f.g.visible = i < drawn;
+    if (lengthM > 0 && Math.abs(f.g.scale.x - lengthM) > 1e-4) {
+      f.g.scale.setScalar(lengthM);
+      f.speed = lengthM * f.speedK;
     }
   }
 }
@@ -780,6 +912,97 @@ function updateScaleBar() {
   sbTxt.textContent = m + " m";
 }
 
+/* ---------- twin scrubber ----------
+   The three things this must never confuse: a design, the system as it stands today, and a
+   projection of it. Every frame says which it is, in words, before it says anything else. */
+const twinPanel = document.getElementById("twin");
+const elBadge = document.getElementById("t-badge");
+const elWhen = document.getElementById("t-when");
+const elRead = document.getElementById("t-read");
+const elWhy = document.getElementById("t-why");
+const elWhyText = document.getElementById("t-why-text");
+const elChip = document.getElementById("t-chip");
+const elRange = document.getElementById("t-range");
+const elPlay = document.getElementById("t-play");
+
+let frameIdx = 0, playing = false, playAcc = 0;
+const todayIdx = Math.max(0, FRAMES.findIndex(f => f.kind === "today"));
+const todayDay = FRAMES.length ? FRAMES[todayIdx].day : 0;
+
+function badgeFor(f) {
+  if (f.kind === "today") return ["today", ""];
+  if (f.kind === "forecast") return ["forecast", "forecast"];
+  if (f.kind === "past") return ["as logged", ""];
+  return ["projection", "design"];
+}
+
+function whenFor(f) {
+  const off = f.day - todayDay;
+  const rel = TWIN.mode === "live" && off !== 0
+    ? (off > 0 ? "+" + off + " d" : off + " d") : "";
+  const date = f.date ? f.date : "day " + f.day;
+  return date + (rel ? ' <span class="muted">' + rel + "</span>" : "");
+}
+
+function applyFrame(i) {
+  const f = FRAMES[i];
+  if (!f) return;
+  frameIdx = i;
+  if (elRange.value !== String(i)) elRange.value = String(i);
+
+  waterMat.color.set(f.water.color);
+  setFishAppearance(f.fish.drawn, f.fish.length_m);
+  if (f.crop) setPlantAppearance(f.crop.scale, f.crop.chlorosis, f.crop.chlorosis_color);
+
+  const [label, cls] = badgeFor(f);
+  elBadge.textContent = label;
+  elBadge.className = "badge" + (cls ? " " + cls : "");
+  elWhen.innerHTML = whenFor(f);
+
+  const w = f.water, fi = f.fish;
+  const bits = [
+    "<b>" + fi.count + "</b> fish &middot; <b>" + fi.mean_weight_g.toFixed(0) +
+      " g</b> &middot; " + fi.biomass_kg.toFixed(1) + " kg" +
+      (fi.drawn < fi.count ? " (" + fi.drawn + " drawn)" : ""),
+    "water <b>" + w.temp_c.toFixed(1) + " &deg;C</b>",
+    "NH3 <b>" + w.tan_mg_l.toFixed(2) + "</b> / NO2 <b>" + w.no2_mg_l.toFixed(2) +
+      "</b> / NO3 <b>" + w.no3_mg_l.toFixed(0) + "</b> mg/L",
+  ];
+  if (f.crop) {
+    bits.push("crop <b>" + (f.crop.growth * 100).toFixed(0) + "%</b> of potential (" +
+              f.crop.limiting + "-limited)");
+  }
+  if (f.totals && (f.totals.fish_harvested_kg || f.totals.crop_harvested_kg)) {
+    bits.push("harvested <b>" + f.totals.fish_harvested_kg.toFixed(0) + " kg</b> fish, <b>" +
+              f.totals.crop_harvested_kg.toFixed(0) + " kg</b> crop");
+  }
+  elRead.innerHTML = bits.map(b => "<span>" + b + "</span>").join("");
+
+  const why = [w.band !== "ok" ? w.why : "", f.note || ""].filter(Boolean).join(" &middot; ");
+  elWhy.style.display = why ? "flex" : "none";
+  elWhyText.innerHTML = why;
+  elChip.style.background = w.color;
+}
+
+if (FRAMES.length) {
+  twinPanel.style.display = "block";
+  elRange.max = String(FRAMES.length - 1);
+  if (FRAMES.length < 2) { elRange.style.display = "none"; elPlay.style.display = "none"; }
+  elRange.oninput = () => { playing = false; elPlay.innerHTML = "&#9654;"; applyFrame(+elRange.value); };
+  elPlay.onclick = () => {
+    playing = !playing;
+    elPlay.innerHTML = playing ? "&#10073;&#10073;" : "&#9654;";
+  };
+  addEventListener("keydown", e => {
+    if (e.key === "ArrowRight") applyFrame(Math.min(FRAMES.length - 1, frameIdx + 1));
+    else if (e.key === "ArrowLeft") applyFrame(Math.max(0, frameIdx - 1));
+    else if (e.key === " ") { e.preventDefault(); elPlay.onclick(); }
+    else return;
+    if (e.key !== " ") { playing = false; elPlay.innerHTML = "&#9654;"; }
+  });
+  applyFrame(todayIdx);
+}
+
 /* ---------- testable summary ---------- */
 window.__SCENE_STATS__ = {
   webgl: !!renderer,
@@ -791,6 +1014,14 @@ window.__SCENE_STATS__ = {
   hudItems: legendItems,
   greenhouse: !!SCENE.greenhouse,
   crop: SCENE.crop || "",
+  twinMode: TWIN.mode || "design",
+  frames: FRAMES.length,
+  frame: () => (FRAMES.length ? {
+    index: frameIdx, day: FRAMES[frameIdx].day, kind: FRAMES[frameIdx].kind,
+    badge: elBadge.textContent, water: waterMat.color.getHexString(),
+    fishVisible: fishes.filter(f => f.g.visible).length,
+  } : null),
+  goTo: i => applyFrame(i),
 };
 
 /* ---------- animate ---------- */
@@ -820,6 +1051,14 @@ function tick(tms) {
   }
   controls.update();
   updateScaleBar();
+
+  if (playing && FRAMES.length > 1) {
+    playAcc += dt;
+    if (playAcc >= 0.16) {                 // ~6 days a second: fast enough to feel like a
+      playAcc = 0;                         // season, slow enough to see a spike arrive
+      applyFrame(frameIdx + 1 >= FRAMES.length ? 0 : frameIdx + 1);
+    }
+  }
 
   if (flowGroup.visible) for (const f of flows) {
     for (let i = 0; i < f.n; i++) {

--- a/web/viewer_template.html
+++ b/web/viewer_template.html
@@ -74,6 +74,10 @@
   #twin .why { display: flex; align-items: center; gap: 6px; margin-top: 5px;
     font-size: 11.5px; color: #f0d9a8; }
   #twin .why .chip { width: 9px; height: 9px; border-radius: 3px; flex: 0 0 auto; }
+  /* The disclaimer is not decoration: the state on this drawing may be someone's real
+     system while the arrangement is only a proposal, and that has to be on screen. */
+  #twin .note { color: var(--muted); font-size: 11px; margin-top: 6px; font-style: italic; }
+  #twin .badge.past { background: #9aa8a2; color: #10201a; }
   #t-range { flex: 1 1 auto; accent-color: var(--accent); height: 18px; margin: 0; }
   #t-play { padding: 3px 9px; min-width: 30px; }
   @media (max-width: 720px) {
@@ -117,6 +121,7 @@
   <div class="why" id="t-why" style="display:none">
     <span class="chip" id="t-chip"></span><span id="t-why-text"></span>
   </div>
+  <div class="note" id="t-note"></div>
 </div>
 <div id="tip" class="panel"></div>
 <div id="cap">drag to orbit &middot; scroll to zoom &middot; right-drag to pan</div>
@@ -928,16 +933,25 @@ const elPlay = document.getElementById("t-play");
 let frameIdx = 0, playing = false, playAcc = 0;
 const todayIdx = Math.max(0, FRAMES.findIndex(f => f.kind === "today"));
 const todayDay = FRAMES.length ? FRAMES[todayIdx].day : 0;
+const todayDate = FRAMES.length && FRAMES[todayIdx].date
+  ? Date.parse(FRAMES[todayIdx].date) : 0;
 
 function badgeFor(f) {
   if (f.kind === "today") return ["today", ""];
   if (f.kind === "forecast") return ["forecast", "forecast"];
-  if (f.kind === "past") return ["as logged", ""];
+  if (f.kind === "past") return ["as logged", "past"];
   return ["projection", "design"];
 }
 
+const DAY_MS = 86400000;
 function whenFor(f) {
-  const off = f.day - todayDay;
+  // Prefer the calendar when the scene carries one: day numbers count SIMULATED days, and
+  // the forecast's first day is the rest of today, so counting it as "+1 d" would put a
+  // frame a day ahead of the date printed beside it.
+  let off = f.day - todayDay;
+  if (f.date && todayDate) {
+    off = Math.round((Date.parse(f.date) - todayDate) / DAY_MS);
+  }
   const rel = TWIN.mode === "live" && off !== 0
     ? (off > 0 ? "+" + off + " d" : off + " d") : "";
   const date = f.date ? f.date : "day " + f.day;
@@ -950,9 +964,15 @@ function applyFrame(i) {
   frameIdx = i;
   if (elRange.value !== String(i)) elRange.value = String(i);
 
-  waterMat.color.set(f.water.color);
+  // No override means healthy water: the viewer's own blue, the one this file has always
+  // used. Only a band the advisor acts on repaints it.
+  waterMat.color.set(f.water.color || WATER_COL);
   setFishAppearance(f.fish.drawn, f.fish.length_m);
+  // A frame with no crop block knows nothing about the crop (a stored state carries no
+  // factors), so the bed goes back to how it was built rather than keeping the last frame's
+  // growth — which would leave a forecast's plants standing on a day that never claimed them.
   if (f.crop) setPlantAppearance(f.crop.scale, f.crop.chlorosis, f.crop.chlorosis_color);
+  else setPlantAppearance(1, 0, "");
 
   const [label, cls] = badgeFor(f);
   elBadge.textContent = label;
@@ -981,11 +1001,14 @@ function applyFrame(i) {
   const why = [w.band !== "ok" ? w.why : "", f.note || ""].filter(Boolean).join(" &middot; ");
   elWhy.style.display = why ? "flex" : "none";
   elWhyText.innerHTML = why;
-  elChip.style.background = w.color;
+  elChip.style.background = w.color || "#" + WATER_COL.toString(16).padStart(6, "0");
 }
 
 if (FRAMES.length) {
   twinPanel.style.display = "block";
+  // Computed in scene3d.py, and the whole difference between a twin and a picture that
+  // flatters itself. It is on screen or the claim is not made.
+  document.getElementById("t-note").textContent = TWIN.geometry_note || "";
   elRange.max = String(FRAMES.length - 1);
   if (FRAMES.length < 2) { elRange.style.display = "none"; elPlay.style.display = "none"; }
   elRange.oninput = () => { playing = false; elPlay.innerHTML = "&#9654;"; applyFrame(+elRange.value); };
@@ -994,8 +1017,11 @@ if (FRAMES.length) {
     elPlay.innerHTML = playing ? "&#10073;&#10073;" : "&#9654;";
   };
   addEventListener("keydown", e => {
-    if (e.key === "ArrowRight") applyFrame(Math.min(FRAMES.length - 1, frameIdx + 1));
-    else if (e.key === "ArrowLeft") applyFrame(Math.max(0, frameIdx - 1));
+    // preventDefault on the arrows too: with the slider focused the browser would step it
+    // a SECOND time and fire `input`, so every keypress moved two days and could jump
+    // clean over the one the user was stepping onto.
+    if (e.key === "ArrowRight") { e.preventDefault(); applyFrame(Math.min(FRAMES.length - 1, frameIdx + 1)); }
+    else if (e.key === "ArrowLeft") { e.preventDefault(); applyFrame(Math.max(0, frameIdx - 1)); }
     else if (e.key === " ") { e.preventDefault(); elPlay.onclick(); }
     else return;
     if (e.key !== " ") { playing = false; elPlay.innerHTML = "&#9654;"; }


### PR DESCRIPTION
Closes #118.

## What this changes

There were two twins in this repo that had never been introduced. `mirror.py` held one
operator's state, persisted and advanced through the weather that actually happened.
`scene3d.py` drew a design, recomputed from arguments and identical for everyone who typed
the same numbers. Nothing joined them, so **the 3D view had never once shown anyone's actual
pond** — which is why it read as a picture rather than a twin.

`to_scene` now takes an optional `state` (a `ProductionState`) or `trajectory` (a
`ProductionRun.trajectory`) and embeds per-day frames the viewer scrubs through. The same
geometry renders three ways, and the badge always says which: **as designed**, **today**, or
a **forecast**.

```bash
# a design, plus the season it would have at a real site, on a slider
python scripts/render_3d.py --crop basil --site taichung_2025 --days 365 -o first_year.html
```

```python
# and the same for the system someone actually runs
snap  = twin_view.compute(mem, user_id, days=14)
scene = twin_view.scene_for(snap, mem.get_facts(user_id))
```

reached from chat by the new `show_my_system_3d` tool.

**The viewer decides nothing.** Every appearance the state drives is a number in the frame,
computed in the trust zone where a test can read it:

| in the picture | decided by |
|---|---|
| water colour | `advisory.py`'s bands, unchanged — the water turns amber on exactly the number that makes the advisor propose an action |
| crop size and pallor | the day's `CropFactors`; chlorosis onset is `f_nitrogen(NO3_LOW_MG_L)`, the knowledge base's own nitrate floor |
| fish size | weight by the cube root at a nominal Fulton K, documented as a drawing convention |
| fish number | the twin's cohort; the roster is capped and the frame says "220 fish · 185 g (30 drawn)" |

A threshold chosen in JavaScript would have been a second, uncited opinion about when a pond
is in trouble.

Two smaller things worth knowing:

- **Downsampling cannot hide the spike.** 365 days become ~95 frames, but the peak of each
  nitrogen channel, every harvest day, today and both endpoints are pinned in regardless of
  stride. A stride that landed either side of the nitrite spike would show a season in which
  it never happened, which is the one event this view exists to make visible.
- **Scrubbing does not reshuffle the greenhouse.** Each bed keeps the per-instance shape it
  was born with, and fish are built per tank then interleaved so hiding the tail of the list
  thins every tank evenly instead of emptying the last one.

Fixed on the way: `design_system_3d` never passed `crop`/`species` to `to_scene`, so every
design the bot sent drew the generic plant form while `scripts/render_3d.py` drew the right
one. One line, but it silently disabled a feature shipped in 8cc2e85.

## How it was verified

```
1148 passed, 1 failed in 83.86s
```

The one failure is `test_font_sizes_stay_distinct_when_a_truetype_resolves` — **pre-existing
#115**, fails on any machine whose system font differs, and `schematic.py` is untouched here.

```
Advice-safety golden set: 373/373 passed (score 1.000)
  honesty 331/331 · sizing 4/4 · trust_gate 6/6 · vision_guard 23/23 · visual_triage 9/9
```

30 new tests. The ones that would have failed before this change, by name:
`test_the_scene_carries_this_operators_fish_not_the_designs`,
`test_today_is_labelled_today_and_the_rest_is_labelled_forecast`,
`test_a_long_season_is_downsampled_but_keeps_the_nitrite_spike`,
`test_water_turns_amber_on_the_number_the_advisor_acts_on`,
`test_the_chlorosis_onset_is_the_cited_nitrate_floor_not_a_taste_setting`,
`test_a_die_off_thins_the_drawn_population`,
`test_binding_a_state_does_not_move_a_single_dimension`.

The render itself was checked in a real headed Chromium (headless has no WebGL) at today, at
the nitrite spike, and against the design-only baseline to confirm no dimension moved when a
twin was bound.

- [x] `pytest` is green (except pre-existing #115, unrelated)
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

- [x] No new import of an LLM, network, or UI library inside `aqua_model/` — `scene3d` gained
      only `advisory` and `cropgrowth`, both already in the trust zone
- [ ] **Deliberately not in `coefficients.py`.** The new constants (`FULTON_K`,
      `WATER_COLORS`, `PLANT_SCALE_FLOOR`, `FISH_DRAWN_PER_TANK`) are DRAWING conventions,
      not modelled quantities: nothing computes from them and no output reports them. Putting
      an invented condition factor into the cited coefficient registry would weaken exactly
      the guarantee that registry exists to make. The two constants that could be mistaken
      for claims about a pond — the water bands and the chlorosis onset — are imported from
      `advisory.py` rather than redefined here, and a test pins the onset to it.
- [x] Any new user-facing result states what it does **not** model — the frame carries the
      factors behind the appearance, the readout says drawn-vs-counted, and
      `twin.geometry_note` says the layout is still a proposal even when the state is theirs
- [x] Model-proposed values still reach the core only through a validation gate —
      `twin_view.scene_for` sizes the geometry through `validate_design_input`
- [ ] **No new golden-set probe.** The golden set scores what the assistant *says*; the
      guarantees here are about what the picture *draws*, and they are enforced by unit tests
      instead. Happy to add probes if you'd rather the boundary be drawn elsewhere.

## What this does NOT do

Three acceptance items from #118 are deliberately unbuilt, each because the model does not
support them:

- **Per-vessel water colour.** The twin models ONE water body. Colouring vessels differently
  would imply per-vessel chemistry it does not have.
- **Plant height from days since transplant.** `cropgrowth` is a continuous-harvest rate
  model with no plant age in it. Size follows the growth factors instead; a transplant date
  would have been fabricated.
- **Flow speed from `pump_turnover_lph`.** Already carried per pipe as `flow_lpm`, and the
  twin does not vary it by day.

Also out of scope, and probably worth their own issues:

- No Telegram command (`/twin3d`) — the tool is reachable conversationally, but the
  deterministic command layer added in 0aaaa26 is where reliability actually lives.
- The live view still sizes its geometry from the profile each time, because a design has no
  identity yet (#119). Once it does, this should bind to a stored `DesignRecord` rather than
  re-sizing.
- A frame carries no dissolved oxygen or pH, because the twin does not model them (#108).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRmYmntG9vvoVVK4aTUZdu
