### PR TITLE
fix(setup): a first run that ends with nothing to type is a failed first run

### DIFF
--- a/agronaut_agent/setup_wizard.py
+++ b/agronaut_agent/setup_wizard.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import getpass
 import json
 import os
+import secrets
 import time
 import urllib.error
 import urllib.request
@@ -42,6 +43,48 @@ def env_path() -> Path:
     if here.is_file() or (Path.cwd() / "pyproject.toml").is_file():
         return here
     return user_config_dir() / ".env"
+
+
+def parse_env(text: str) -> dict[str, str]:
+    """The KEY=value pairs in a .env, ignoring comments and blanks.
+
+    Used to answer "what is configured overall", which is not the same question as "what did
+    this run change". Someone who set their model last week and adds a channel today has a
+    working model, and the closing advice has to know that.
+    """
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def next_steps(config: dict[str, str]) -> list[str]:
+    """The commands to print at the end of setup. Never empty.
+
+    This function exists because the wizard used to be able to end on a README pointer. A
+    first run that finishes with nothing to type is a failed first run, however much it
+    successfully configured, and that is exactly what happened to the maintainer on the day
+    after 1.0.0 shipped: model configured, WhatsApp chosen, and not one runnable command.
+
+    So the rule is encoded here rather than left to the flow: if a model is configured the
+    REPL is offered first, because `agronaut` with no arguments is the one channel that
+    needs no token, no account and no public address. The calculator is always offered,
+    because it needs no model either. Channels are added only once their credentials exist.
+    """
+    steps: list[str] = []
+    if config.get("LLM_PROVIDER"):
+        steps.append("agronaut            # chat with the agent, right here in this terminal")
+    steps.append(
+        "agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000")
+    if config.get("TELEGRAM_BOT_TOKEN"):
+        steps.append("agronaut bot        # then message your bot")
+    if config.get("WHATSAPP_TOKEN"):
+        steps.append("agronaut whatsapp   # with your tunnel running, see above")
+    return steps
 
 
 def merge_env(existing: str, updates: dict[str, str]) -> str:
@@ -170,6 +213,94 @@ def _capture_telegram_id(token: str) -> str | None:
     return None
 
 
+def _prompt_whatsapp() -> dict[str, str]:
+    """Collect the WhatsApp Cloud API values, in the order Meta's dashboard shows them.
+
+    The branch this replaces printed two lines and pointed at the README, so it collected
+    nothing at all: someone could choose WhatsApp, finish setup, and have a .env with no
+    WhatsApp variable in it. Every value here is one the adapter reads at startup, and
+    `whatsapp_doctor` already knows how to check each one, so the wizard asks and then lets
+    the doctor answer.
+
+    Empty input skips a value. A half-filled WhatsApp config is a normal state, because
+    these come from three different screens and people genuinely do stop halfway.
+    """
+    print("\n  WhatsApp needs a Meta app with WhatsApp added to it. From")
+    # flush: getpass writes straight to the terminal, while stdout is block-buffered as soon
+    # as this is piped or logged. Without the flush the explanation lands after the prompt it
+    # explains, which is exactly the kind of small confusion this wizard exists to remove.
+    print("  developers.facebook.com > your app > WhatsApp > API Setup:", flush=True)
+    out: dict[str, str] = {}
+
+    token = getpass.getpass("\n  Temporary access token (hidden, blank to skip): ").strip()
+    if token:
+        out["WHATSAPP_TOKEN"] = token
+
+    phone_id = input("  Phone number ID (a long number, NOT the phone number): ").strip()
+    if phone_id:
+        out["WHATSAPP_PHONE_NUMBER_ID"] = phone_id
+
+    # Invented by you, not issued by Meta. People routinely hunt for it in the dashboard,
+    # so generate one and say plainly where it goes.
+    verify = secrets.token_urlsafe(16)
+    print(f"\n  Verify token (you invent this one, so here is one): {verify}")
+    print("  Paste that same string into Meta's webhook form when it asks.", flush=True)
+    out["WHATSAPP_VERIFY_TOKEN"] = verify
+
+    secret = getpass.getpass(
+        "\n  App secret from Settings > Basic (hidden, blank to skip): ").strip()
+    if secret:
+        out["WHATSAPP_APP_SECRET"] = secret
+
+    print("\n  Which numbers may talk to the bot? Without this, anyone who finds your")
+    print("  webhook URL can. Use the full international form, e.g. 22670000000.")
+    allowed = input("  Allowed numbers, comma separated (blank to skip): ").strip()
+    if allowed:
+        out["AGRONAUT_ALLOWED_IDS"] = allowed
+    return out
+
+
+def _whatsapp_reachability_help(port: int = 8080) -> None:
+    """The step the README buries and the wizard used to skip entirely.
+
+    Telegram long-polls, so a laptop behind NAT works. WhatsApp is the other way round:
+    Meta POSTs to you, over HTTPS, at an address it can resolve. That single difference is
+    why one channel takes two minutes and the other defeats people, and not saying it out
+    loud is what left the maintainer stuck after a successful install.
+    """
+    print("\n  One more thing, and it is the part that actually blocks people.")
+    print("\n  Meta delivers messages by POSTing to YOUR machine over HTTPS. A laptop")
+    print("  has no public address, so you need a tunnel running beside the bot:")
+    print(f"\n    cloudflared tunnel --url http://localhost:{port}")
+    print(f"    ngrok http {port}")
+    print("\n  Either prints an https:// address. Your webhook URL is that address with")
+    print("  /webhook on the end. Paste it, and the verify token above, into")
+    print("  Meta > WhatsApp > Configuration, then subscribe to the 'messages' field.")
+    print("\n  The tunnel address changes each restart on the free plans, so for anything")
+    print("  lasting, run this on a host with a real certificate instead of a laptop.")
+
+
+def _run_whatsapp_doctor(collected: dict[str, str]) -> None:
+    """Check what was just entered, instead of telling the operator to check it later.
+
+    `whatsapp_doctor` reads its inputs from the environment, so the values have to be put
+    there before it runs: this is the same process that just collected them, and nothing
+    has reloaded the .env yet.
+    """
+    for key, value in collected.items():
+        os.environ[key] = value
+    print("\n  Checking what you entered...\n")
+    try:
+        from . import whatsapp_doctor
+
+        text, _ = whatsapp_doctor.report(whatsapp_doctor.run_checks())
+    except Exception as err:  # noqa: BLE001 — a failed check must not lose the .env write
+        print(f"  Could not run the checks ({err}).")
+        print("  Run `agronaut whatsapp --check` once you are online.")
+        return
+    print("\n".join("  " + line for line in text.splitlines()))
+
+
 def run() -> int:
     print("\n  Agronaut setup\n  " + "-" * 40)
     updates: dict[str, str] = {}
@@ -203,12 +334,18 @@ def run() -> int:
                            LLM_MODEL="mistralai/mistral-nemotron")
 
     # 2. the channel
+    #
+    # Ordered by what it costs the person answering, not by how impressive it sounds. The
+    # terminal is first because it is the only one that works the second this wizard exits,
+    # and WhatsApp is last with its real price on the label: the Meta account is the part
+    # people expect, and the public HTTPS address is the part that actually stops them.
     channel = _ask("Where do you want to talk to Agronaut?", [
-        ("Telegram", "about two minutes, nothing else needed"),
-        ("WhatsApp", "needs a Meta business account; run `agronaut whatsapp --check` after"),
-        ("Terminal only", "just `agronaut` on this machine"),
+        ("This terminal", "works as soon as setup finishes, nothing else needed"),
+        ("Telegram", "about two minutes, one token from BotFather"),
+        ("WhatsApp", "a Meta business account AND a public HTTPS address; "
+                     "best on a server, not a laptop"),
     ])
-    if channel == 1:
+    if channel == 2:
         print("\n  Open https://t.me/BotFather, send /newbot, and follow the prompts.")
         while True:
             token = input("  Paste the bot token it gives you: ").strip()
@@ -226,28 +363,38 @@ def run() -> int:
                 if uid:
                     updates["AGRONAUT_ALLOWED_IDS"] = uid
                 break
-    elif channel == 2:
-        print("\n  WhatsApp needs a Meta app, a business portfolio and a test number.")
-        print("  Follow the README's 'Run on WhatsApp', then: agronaut whatsapp --check")
-
-    if not updates:
-        print("\n  Nothing to save. Run `agronaut setup` again when you have your keys.\n")
-        return 0
+    elif channel == 3:
+        wa = _prompt_whatsapp()
+        updates.update(wa)
+        if wa.get("WHATSAPP_TOKEN"):
+            _run_whatsapp_doctor(wa)
+        _whatsapp_reachability_help()
 
     dest = env_path()
-    dest.parent.mkdir(parents=True, exist_ok=True)
     existing = dest.read_text() if dest.is_file() else ""
-    dest.write_text(merge_env(existing, updates))
-    try:
-        dest.chmod(0o600)          # it holds API keys; nobody else on the box needs them
-    except OSError:
-        pass
 
-    print(f"\n  Saved to {dest}")
-    print("  " + ", ".join(sorted(updates)))
+    if updates:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(merge_env(existing, updates))
+        try:
+            dest.chmod(0o600)      # it holds API keys; nobody else on the box needs them
+        except OSError:
+            pass
+        print(f"\n  Saved to {dest}")
+        print("  " + ", ".join(sorted(updates)))
+    else:
+        print("\n  Nothing new to save.")
+
+    # Always ends on something runnable. `next_steps` reads the whole configuration rather
+    # than this run's changes, so someone who set their model last week and only added a
+    # channel today still gets told about the chat they already have.
+    config = {**parse_env(existing), **updates}
     print("\n  Try it:")
-    print("    agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000")
-    if "TELEGRAM_BOT_TOKEN" in updates:
-        print("    agronaut bot        # then message your bot")
+    for step in next_steps(config):
+        print(f"    {step}")
+    if not config.get("LLM_PROVIDER"):
+        print("\n  No model configured, so chat is off, but the sizing engine above needs")
+        print("  none. Run `agronaut setup` again when you have a key, or pick Ollama to")
+        print("  run one on this machine with no key at all.")
     print()
     return 0

--- a/agronaut_agent/tests/test_setup_wizard.py
+++ b/agronaut_agent/tests/test_setup_wizard.py
@@ -127,9 +127,8 @@ def test_the_written_file_is_not_world_readable(tmp_path, monkeypatch):
     """It holds API keys. Nobody else on the machine needs them."""
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
-    monkeypatch.setattr(W, "_ask", lambda *a, **k: 4)        # skip model
     monkeypatch.setattr("builtins.input", lambda *a: "")
-    calls = iter([4, 3])                                     # skip model, terminal only
+    calls = iter([4, 1])                                     # skip model, this terminal
     monkeypatch.setattr(W, "_ask", lambda *a, **k: next(calls))
     W.run()
     # nothing chosen -> nothing written; assert we did not create a stray file
@@ -143,3 +142,93 @@ def test_the_cli_exposes_setup():
         if getattr(a, "choices", None):
             names.update(a.choices)
     assert "setup" in names
+
+
+# --- what to run next ----------------------------------------------------------------------
+#
+# The wizard shipped able to end on a README pointer: model configured, WhatsApp chosen, and
+# not one runnable command. These pin the rule that replaced it.
+
+def test_there_is_always_something_to_run():
+    """Even with nothing configured at all. The sizing engine needs no model and no channel,
+    so a first run has no excuse to end empty-handed."""
+    assert W.next_steps({}), "setup must never end without a command"
+    assert any("agronaut size" in s for s in W.next_steps({}))
+
+
+def test_a_configured_model_offers_the_terminal_chat_first():
+    steps = W.next_steps({"LLM_PROVIDER": "ollama"})
+    assert steps[0].startswith("agronaut ") or steps[0].startswith("agronaut#")
+    assert "agronaut  " in steps[0], f"expected the bare REPL first, got {steps[0]!r}"
+
+
+def test_choosing_whatsapp_still_ends_with_a_working_command():
+    """The exact reported failure: WhatsApp was picked, so no Telegram token exists, and the
+    old ending offered nothing that used the model that had just been configured."""
+    steps = W.next_steps({"LLM_PROVIDER": "anthropic", "WHATSAPP_TOKEN": "t"})
+    assert any(s.startswith("agronaut  ") for s in steps), "no terminal chat offered"
+    assert any("agronaut whatsapp" in s for s in steps)
+    assert not any("bot" in s for s in steps), "offered the Telegram bot without a token"
+
+
+def test_a_channel_is_only_offered_once_its_credentials_exist():
+    steps = W.next_steps({"LLM_PROVIDER": "ollama"})
+    assert not any("agronaut bot" in s for s in steps)
+    assert not any("agronaut whatsapp" in s for s in steps)
+
+
+def test_the_whole_configuration_counts_not_just_this_run():
+    """Someone who set their model last week and adds Telegram today still has a model."""
+    config = {**W.parse_env("LLM_PROVIDER=ollama\n"), "TELEGRAM_BOT_TOKEN": "t"}
+    steps = W.next_steps(config)
+    assert any(s.startswith("agronaut  ") for s in steps)
+    assert any("agronaut bot" in s for s in steps)
+
+
+def test_parse_env_ignores_comments_and_blanks():
+    parsed = W.parse_env("# a note\n\nLLM_PROVIDER=ollama\nnot a pair\nB = 2\n")
+    assert parsed == {"LLM_PROVIDER": "ollama", "B": "2"}
+
+
+def test_the_terminal_is_the_first_channel_offered(tmp_path, monkeypatch):
+    """Ordering is load-bearing, not cosmetic. The terminal works the moment setup exits;
+    WhatsApp needs a business account and a public address. Offering them in the other order
+    is what sent the maintainer down a dead end on his own first run.
+
+    This also pins the option numbers that `run()`'s branches switch on, which is what broke
+    when they were last reordered.
+    """
+    seen: list[list[tuple[str, str]]] = []
+
+    def _spy(prompt, options, default=1):
+        seen.append(options)
+        return 4 if "model" in prompt else 1
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    monkeypatch.setattr(W, "_ask", _spy)
+    W.run()
+
+    channel_options = seen[-1]
+    labels = [label for label, _ in channel_options]
+    assert "terminal" in labels[0].lower(), f"terminal must be offered first, got {labels}"
+    assert "whatsapp" in labels[-1].lower(), f"WhatsApp must be offered last, got {labels}"
+    # The price people actually trip over is the address, not the account.
+    whatsapp_note = channel_options[-1][1].lower()
+    assert "https" in whatsapp_note or "address" in whatsapp_note, whatsapp_note
+
+
+def test_a_run_that_configures_nothing_still_tells_you_what_works(tmp_path, monkeypatch,
+                                                                  capsys):
+    """The old dead end read 'Nothing to save. Run `agronaut setup` again when you have your
+    keys', which is wrong: the sizing engine needs no keys and works right then."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    calls = iter([4, 1])                                     # skip model, this terminal
+    monkeypatch.setattr(W, "_ask", lambda *a, **k: next(calls))
+    W.run()
+    out = capsys.readouterr().out
+    assert "agronaut size" in out
+    assert "README" not in out, "setup must not end by pointing at the README"


### PR DESCRIPTION
## What this changes

Found by installing the PyPI package and running `agronaut setup`, one day after 1.0.0 shipped. Model configured, WhatsApp chosen, then two lines pointing at the README and nothing else. The person who wrote the tool could not get from a successful install to a working conversation.

**The terminal was never named.** `cli.py` opens with "Bare `agronaut` is the chat REPL, which is what most people want" and `--help` ends with "Run with no arguments to start chatting". The wizard never printed it. Its closing block offered `agronaut size`, which needs no model at all, and `agronaut bot` only if Telegram was chosen. So unless you picked Telegram, setup never gave you one command that used the model it had just configured, and picking "Terminal only" printed the same two lines.

`next_steps()` now derives the closing advice from the whole configuration rather than this run's changes, so someone who set their model last week and adds a channel today still gets told about the chat they already have. It always returns at least one command. The empty-config dead end was wrong on its own terms too, since the sizing engine needs no keys and worked right then.

**WhatsApp collected nothing.** You could choose it, finish setup, and have a .env with no WhatsApp variable in it. It now prompts for the token, phone number id, app secret and allowed numbers, generates the verify token instead of letting people hunt the dashboard for a value they are supposed to invent, and calls `whatsapp_doctor` on what was entered. That module already diagnoses exactly these failures and the wizard had been telling people to run it themselves, later.

**The real blocker was never stated.** Telegram long-polls, so a laptop behind NAT works. WhatsApp needs Meta to POST to a public HTTPS address. That is why one channel takes two minutes and the other defeats people. `whatsapp.py` says it in its docstring and the process logs it on startup, and neither reached the person choosing. The wizard now prints the cloudflared and ngrok one-liners, says the callback URL is that address plus `/webhook`, and says plainly that a laptop is the wrong host for anything lasting.

The channel menu is reordered by what each option costs: this terminal, then Telegram, then WhatsApp with its real price on the label.

## How it was verified

Ran the wizard down both paths in a temp config dir.

Ollama plus terminal:

```
  Try it:
    agronaut            # chat with the agent, right here in this terminal
    agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000
```

Skip-model plus WhatsApp now walks the Meta values, prints the tunnel step, and ends:

```
  Try it:
    agronaut size --fish tilapia --crop lettuce --area 12 --temp 27 --water 3000

  No model configured, so chat is off, but the sizing engine above needs
  none. Run `agronaut setup` again when you have a key, or pick Ollama to
  run one on this machine with no key at all.
```

```
ruff .......... All checks passed!
pytest ........ 1254 passed          (1246 before, 8 new)
safety_eval ... 384/384
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

Not applicable: nothing under `aqua_model/` is touched, and no user-facing number changes.

## What this does NOT do

- **Does not make WhatsApp work on a laptop.** It cannot. The webhook needs a reachable address, so the honest fix was to say so at the point of choosing rather than after an hour of dashboard work.
- **Does not verify the Meta values against the Graph API at prompt time** the way the Telegram token is checked. `whatsapp_doctor` runs straight after and reports, which covers it, but it is a weaker loop than Telegram's.
- **Does not add `agronaut doctor`** for the model provider, corpus and database. `whatsapp_doctor` shows the pattern works and generalising it is its own piece of work.
- **No first-run smoke test in CI.** Nothing tests install-to-first-answer end to end, which is why this shipped in the first place. The new tests cover the wizard's logic, not a real install.
