### PR TITLE
fix(repl): one unreachable provider ended the session with a traceback

### DIFF
--- a/agronaut_agent/channels/base.py
+++ b/agronaut_agent/channels/base.py
@@ -59,3 +59,52 @@ def chunk(text: str, size: int = 4000) -> list[str]:
     if buf:
         parts.append(buf)
     return parts
+
+
+def explain_turn_failure(exc: BaseException) -> str:
+    """Turn an exception from a turn into something an operator can act on.
+
+    A dead model provider is by far the most common way a turn fails, and it is not an
+    exotic state: `agronaut setup` will happily save `LLM_PROVIDER=ollama` after reporting
+    that Ollama is not running, because the operator may be about to start it. The next
+    thing they do is ask a question, and the honest answer is "the model is not reachable",
+    not a traceback.
+
+    Every branch ends by naming the sizing engine. It needs no model at all, so there is
+    always something true to offer, which is the same rule `setup_wizard.next_steps` follows.
+    """
+    name = type(exc).__name__
+    text = f"{name}: {exc}".lower()
+
+    unreachable = ("connect" in text and "error" in text) or "refused" in text \
+        or "max retries" in text or "failed to establish" in text or "timed out" in text
+    rejected = any(code in text for code in ("401", "403", "unauthorized", "forbidden",
+                                             "invalid api key", "authentication"))
+    missing_model = "not found" in text and "model" in text
+
+    import os
+
+    provider = os.getenv("LLM_PROVIDER") or "the configured provider"
+    if unreachable:
+        where = ""
+        if provider == "ollama":
+            host = os.getenv("OLLAMA_HOST", "http://localhost:11434")
+            where = f" at {host}"
+        return (f"I could not reach {provider}{where}, so I cannot answer that right now.\n"
+                + ("Start it with `ollama serve`, then try again.\n"
+                   if provider == "ollama" else
+                   "Check your connection, then try again.\n")
+                + "Run `agronaut setup` to switch provider. The sizing engine needs no "
+                  "model and still works: `agronaut size --help`")
+    if rejected:
+        return (f"{provider} rejected the API key, so I cannot answer that right now.\n"
+                "Run `agronaut setup` to re-enter it. The sizing engine needs no model and "
+                "still works: `agronaut size --help`")
+    if missing_model:
+        model = os.getenv("LLM_MODEL") or "the configured model"
+        pull = f"`ollama pull {model}`" if provider == "ollama" else "your provider's console"
+        return (f"{provider} does not have {model}. Get it with {pull}, then try again.\n"
+                "The sizing engine needs no model and still works: `agronaut size --help`")
+    return (f"That turn failed ({name}: {exc}).\n"
+            "If it keeps happening, `agronaut setup` re-checks your configuration. The "
+            "sizing engine needs no model and still works: `agronaut size --help`")

--- a/agronaut_agent/channels/repl.py
+++ b/agronaut_agent/channels/repl.py
@@ -7,8 +7,50 @@ configured tool-calling provider (e.g. LLM_PROVIDER=nvidia).
 
 from __future__ import annotations
 
+import logging
+import os
+
 from ..core import AgronautAgent
-from .base import ChannelAdapter
+from .base import ChannelAdapter, explain_turn_failure
+
+
+class _DropTracebacks(logging.Filter):
+    """Keep the warning, drop the stack trace, for an interactive session only.
+
+    `agent/llm.py` logs a provider failure with `exc_info=True`, which is right for
+    `agronaut bot` where the trace goes to a log file nobody is staring at. In a REPL it
+    prints forty lines of httpx internals directly at a person who is then handed a plain
+    explanation anyway, and the trace is what they read first. The one-line warning is
+    genuinely useful, so it stays. Set AGRONAUT_DEBUG=1 to get the traces back.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.exc_info = None
+        record.exc_text = None
+        return True
+
+
+def _quiet_tracebacks() -> None:
+    """Install the filter where the records actually get emitted.
+
+    A filter on a logger only sees records logged directly on it, never ones propagated from
+    a child, so filtering the root logger does nothing to `agent.llm`'s warnings. Handler
+    filters do see propagated records, but this process has no handlers at all, so logging
+    falls back to `logging.lastResort` and prints the trace before anything of ours runs.
+    Attaching our own handler is what actually takes effect.
+    """
+    if os.getenv("AGRONAUT_DEBUG"):
+        return
+    root = logging.getLogger()
+    if root.handlers:
+        for handler in root.handlers:
+            handler.addFilter(_DropTracebacks())
+        return
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    handler.addFilter(_DropTracebacks())
+    root.addHandler(handler)
 
 
 class ReplChannel(ChannelAdapter):
@@ -19,6 +61,7 @@ class ReplChannel(ChannelAdapter):
         self.user = user
 
     def run(self) -> None:
+        _quiet_tracebacks()
         print("Agronaut REPL — type 'quit' to exit, '/reset' to clear.")
         while True:
             try:
@@ -32,4 +75,15 @@ class ReplChannel(ChannelAdapter):
                 print("(conversation reset)")
                 continue
             if text:
-                print("agronaut>", self.agent.handle_message(self.channel_name, self.user, text))
+                # The Telegram adapter has guarded a turn for a long time ("never leave the
+                # user hanging on an unexpected error"); the REPL did not, so an unreachable
+                # provider killed the session with an httpx traceback. That matters more now
+                # that `agronaut setup` ends by recommending this channel first: the most
+                # recommended path was the least robust one.
+                try:
+                    reply = self.agent.handle_message(self.channel_name, self.user, text)
+                except (EOFError, KeyboardInterrupt):
+                    raise
+                except Exception as exc:  # noqa: BLE001 — explained, and the session lives
+                    reply = explain_turn_failure(exc)
+                print("agronaut>", reply)

--- a/agronaut_agent/tests/test_setup_wizard.py
+++ b/agronaut_agent/tests/test_setup_wizard.py
@@ -232,3 +232,34 @@ def test_a_run_that_configures_nothing_still_tells_you_what_works(tmp_path, monk
     out = capsys.readouterr().out
     assert "agronaut size" in out
     assert "README" not in out, "setup must not end by pointing at the README"
+
+
+def test_option_two_really_reaches_the_telegram_branch(tmp_path, monkeypatch):
+    """`run()` switches on the menu's numbers, so reordering the menu silently reassigns the
+    branches. Nothing caught that: every other test either skips the channel step or asserts
+    on labels. This one drives the number and checks the token actually lands."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    calls = iter([4, 2])                                     # skip model, Telegram
+    monkeypatch.setattr(W, "_ask", lambda *a, **k: next(calls))
+    monkeypatch.setattr("builtins.input", lambda *a: "111:abc")
+    monkeypatch.setattr(W, "check_telegram_token", lambda t: (True, "@AgronautBOT"))
+    monkeypatch.setattr(W, "_capture_telegram_id", lambda t: "424242")
+    W.run()
+    written = (tmp_path / "cfg" / "agronaut" / ".env").read_text()
+    assert "TELEGRAM_BOT_TOKEN=111:abc" in written
+    assert "AGRONAUT_ALLOWED_IDS=424242" in written
+
+
+def test_option_three_really_reaches_the_whatsapp_branch(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "cfg"))
+    calls = iter([4, 3])                                     # skip model, WhatsApp
+    monkeypatch.setattr(W, "_ask", lambda *a, **k: next(calls))
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    monkeypatch.setattr(W.getpass, "getpass", lambda *a: "")
+    W.run()
+    out = capsys.readouterr().out
+    # The tunnel is the part that actually blocks people, so it has to be said out loud.
+    assert "cloudflared" in out and "/webhook" in out
+    assert "developers.facebook.com" in out

--- a/agronaut_agent/tests/test_turn_failure.py
+++ b/agronaut_agent/tests/test_turn_failure.py
@@ -1,0 +1,91 @@
+"""A failed turn has to say what to do, and must not take the session with it.
+
+The Telegram adapter has guarded a turn for a long time ("never leave the user hanging on an
+unexpected error"). The REPL did not, so an unreachable model provider killed it with an
+httpx traceback. That became urgent when `agronaut setup` started recommending the terminal
+first: the most recommended channel was the least robust one.
+"""
+
+import logging
+
+import pytest
+
+from agronaut_agent.channels.base import explain_turn_failure
+from agronaut_agent.channels.repl import ReplChannel, _DropTracebacks
+
+
+class _Boom:
+    """An agent whose turn always fails, the way a dead provider makes it fail."""
+
+    def __init__(self, exc):
+        self.exc = exc
+        self.calls = 0
+
+    def handle_message(self, *a, **k):
+        self.calls += 1
+        raise self.exc
+
+    def reset(self, *a, **k):
+        pass
+
+
+def test_an_unreachable_provider_is_explained_not_dumped(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
+    msg = explain_turn_failure(ConnectionError("[Errno 61] Connection refused"))
+    assert "could not reach ollama" in msg.lower()
+    assert "http://localhost:11434" in msg
+    assert "ollama serve" in msg
+
+
+def test_a_rejected_key_is_not_reported_as_a_network_problem(monkeypatch):
+    """Different fix entirely: retyping a key versus starting a server."""
+    monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+    msg = explain_turn_failure(RuntimeError("401 Unauthorized: invalid api key"))
+    assert "rejected the api key" in msg.lower()
+    assert "agronaut setup" in msg
+
+
+def test_every_explanation_offers_something_that_still_works(monkeypatch):
+    """The sizing engine needs no model at all, so there is always a true thing to offer.
+    Same rule the setup wizard's closing advice follows."""
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    for exc in (ConnectionError("refused"),
+                RuntimeError("401 unauthorized"),
+                RuntimeError("model not found"),
+                ValueError("something nobody predicted")):
+        assert "agronaut size" in explain_turn_failure(exc)
+
+
+def test_the_repl_survives_a_failing_turn(monkeypatch, capsys):
+    """The regression this file exists for: one bad turn used to end the session."""
+    agent = _Boom(ConnectionError("[Errno 61] Connection refused"))
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+    replies = iter(["how big a tank for 50 tilapia?", "and for 100?", "quit"])
+    monkeypatch.setattr("builtins.input", lambda *a: next(replies))
+
+    ReplChannel(agent).run()
+
+    out = capsys.readouterr().out
+    assert agent.calls == 2, "the session died on the first failure"
+    assert out.count("could not reach ollama") == 2
+    assert "Traceback" not in out
+
+
+def test_ctrl_c_still_exits(monkeypatch):
+    """The guard must not swallow the interrupt that ends the session."""
+    agent = _Boom(KeyboardInterrupt())
+    monkeypatch.setattr("builtins.input", lambda *a: "anything")
+    with pytest.raises(KeyboardInterrupt):
+        ReplChannel(agent).run()
+
+
+def test_the_traceback_filter_keeps_the_message(caplog):
+    """Drop the forty lines of httpx internals, keep the one line that says what happened."""
+    record = logging.LogRecord("agent.llm", logging.WARNING, __file__, 1,
+                               "primary LLM failed; retrying once before fallback", (), None)
+    record.exc_text = "Traceback (most recent call last): ..."
+    assert _DropTracebacks().filter(record) is True
+    assert record.exc_info is None
+    assert record.exc_text is None
+    assert "primary LLM failed" in record.getMessage()


### PR DESCRIPTION
## What this changes

Follow-up to #143, found by asking whether that PR actually made things smooth and then running the path rather than trusting it.

#143 made `agronaut setup` recommend the terminal first, which makes the REPL the most travelled channel. It was also the only channel with no guard around a turn. The Telegram adapter has caught a failing turn for a long time ("never leave the user hanging on an unexpected error"); `ReplChannel.run` called `handle_message` bare, so an unreachable provider raised `httpx.ConnectError` straight through the loop and ended the session.

That combination is the bad one: the wizard now confidently points a new user at a command that crashes with forty lines of httpx internals. It is not an exotic state either, because the wizard will save `LLM_PROVIDER=ollama` right after reporting that Ollama is not running, on the reasonable assumption that the operator is about to start it.

**Before**, with Ollama configured and not running:

```
  File ".../httpx/_transports/default.py", line 118, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: [Errno 61] Connection refused
$
```

**After:**

```
WARNING: primary LLM failed; retrying once before fallback
WARNING: primary LLM failed twice; using fallback model
agronaut> I could not reach ollama at http://localhost:11434, so I cannot answer that right now.
Start it with `ollama serve`, then try again.
Run `agronaut setup` to switch provider. The sizing engine needs no model and still works: `agronaut size --help`
you>
```

`explain_turn_failure` separates the cases that have different fixes, since "start the server" and "retype your key" are not the same instruction. Every branch ends by naming the sizing engine, which needs no model and therefore always works, which is the same rule `setup_wizard.next_steps` follows. `KeyboardInterrupt` and `EOFError` are re-raised, so Ctrl-C still exits.

Interactive tracebacks are quietened too. `agent/llm.py` logs the failure with `exc_info=True`, right for `agronaut bot` where it lands in a log, wrong in front of a person who is about to get a plain explanation and reads the trace first. The one-line warning stays and `AGRONAUT_DEBUG=1` brings the traces back.

Also adds the test that was missing: `run()` switches on the channel menu's numbers, so reordering the menu silently reassigns the branches, and nothing checked that option 2 still reaches Telegram. That is precisely what #143 changed.

## How it was verified

Ran the real command against a provider that is not there, not just unit tests.

```
ruff .......... All checks passed!
pytest ........ 1264 passed          (1254 before, 10 new)
safety_eval ... 384/384
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

Not applicable: nothing under `aqua_model/` is touched, and no user-facing number changes.

## What this does NOT do

- **Does not make WhatsApp connect.** Nothing in this PR or #143 can. Meta needs a public HTTPS endpoint and a business account; the honest fix was to say so at the point of choosing.
- **Does not guard `handle_image` or `handle_voice` in the REPL.** Only `handle_message` goes through the REPL loop today.
- **Does not touch two pre-existing import-time warnings** that still print before the banner: a `langchain_nvidia_ai_endpoints` UserWarning about a missing API key, shown even when the provider is Ollama, and langchain's `USER_AGENT environment variable not set`. Noisy on a first run, unrelated to this change, worth their own issue.
- **Still no first-run smoke test in CI.** Nothing exercises install-to-first-answer end to end, which is how both this and #143 shipped.
