### PR TITLE
feat(cli): `agronaut --version` and `agronaut update`, because the version number was lying

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,7 +535,13 @@ agronaut bot                     # the Telegram bot
 agronaut review                  # approve/reject pending community insights
 agronaut analytics               # usage summary: latency p50/p95, tokens, feedback
 agronaut traces                  # recent turns as pipeline traces (no message text)
+agronaut --version               # version, the code path it loaded, and the .env it reads
+agronaut update                  # check PyPI for a newer release and install it
 ```
+
+`--version` prints where the code came from, not just a number. If you have both a checkout
+and a `pip install`, that path is the only way to tell which one you are running, and getting
+it wrong is how you end up debugging a bug you already fixed.
 
 **Where it keeps things.** In a checkout, the knowledge base, the reference tables, the
 fetched-page cache and the SQLite memory DB all sit beside the source, as before. Installed

--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -10,6 +10,8 @@ owns it, so this module stays a dispatcher and only a dispatcher.
     agronaut design ...                             # alias for `size`
     agronaut web                                    # the Streamlit app
     agronaut bot                                    # the Telegram bot
+    agronaut --version                              # which build is this, and from where
+    agronaut update                                 # check PyPI and upgrade
 """
 
 from __future__ import annotations
@@ -120,12 +122,44 @@ def _cmd_traces(args) -> int:
     return 0
 
 
+def _cmd_update(args) -> int:
+    from . import version_info
+
+    return version_info.run_update(check_only=args.check)
+
+
+class _ShowVersion(argparse.Action):
+    """Print the install description verbatim, then exit.
+
+    Not argparse's built-in "version" action: that one hands the string to the help formatter,
+    which re-wraps it into a paragraph and destroys the alignment that makes the paths
+    readable. A bare version number is also what misled a maintainer holding both a checkout
+    and a pip install, reading 1.0.0 for a stale copy and for the live code alike, so the
+    layout here is the feature.
+
+    Importing `version_info` inside __call__ keeps it off the path of every other command.
+    """
+
+    def __init__(self, option_strings, dest=argparse.SUPPRESS,
+                 default=argparse.SUPPRESS, help=None):
+        super().__init__(option_strings=option_strings, dest=dest, default=default,
+                         nargs=0, help=help)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        from . import version_info
+
+        print(version_info.current().render())
+        parser.exit()
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="agronaut",
         description="Aquaponics assistant: chat, computed sizing, web app, bot.",
         epilog="Run with no arguments to start chatting.",
     )
+    p.add_argument("--version", "-V", action=_ShowVersion,
+                   help="show the version, where it is installed, and which .env it reads")
     p.set_defaults(func=_cmd_chat)  # bare `agronaut` -> chat
     sub = p.add_subparsers(dest="cmd")
 
@@ -155,6 +189,10 @@ def _build_parser() -> argparse.ArgumentParser:
     wa.add_argument("--url", metavar="HTTPS_URL",
                     help="your public webhook URL, to test that Meta can actually reach it")
     wa.set_defaults(func=_cmd_whatsapp)
+    up = sub.add_parser("update", help="check for a newer release and install it")
+    up.add_argument("--check", action="store_true",
+                    help="report whether an update exists without installing it")
+    up.set_defaults(func=_cmd_update)
     sub.add_parser("review", help="approve/reject pending community insights").set_defaults(
         func=_cmd_review)
     sub.add_parser("analytics", help="summarise recorded usage").set_defaults(func=_cmd_analytics)

--- a/agronaut_agent/tests/test_version_info.py
+++ b/agronaut_agent/tests/test_version_info.py
@@ -1,0 +1,157 @@
+"""Which build is this, and how do you move it forward.
+
+Written after an evening lost to the question. A maintainer with both a checkout and a
+`pip install agronaut` ran `agronaut setup`, got the old wizard, and had no way to find out
+why: `pip show` reported 1.0.0 for the stale copy in site-packages and for the live checkout
+alike, and the CLI would not say which files it had loaded. The version number was the thing
+that lied, so these tests are mostly about the parts printed next to it.
+"""
+
+from pathlib import Path
+
+from agronaut_agent import version_info as V
+
+CHECKOUT = Path("/home/grower/Agronaut")
+
+
+def _install(version="1.0.0", editable=None):
+    return V.Install(version=version, code_dir=CHECKOUT / "agronaut_agent",
+                     editable_from=editable)
+
+
+# --- comparing versions --------------------------------------------------------------------
+
+def test_a_later_minor_is_behind():
+    assert V.compare("1.0.0", "1.1.0") == "behind"
+
+
+def test_ten_beats_nine():
+    """String comparison would call 1.10.0 older than 1.9.0 and offer a downgrade."""
+    assert V.compare("1.9.0", "1.10.0") == "behind"
+    assert V.compare("1.10.0", "1.9.0") == "ahead"
+
+
+def test_a_checkout_ahead_of_the_release_is_not_behind():
+    """Normal for a maintainer, and it must not be reported as an available update."""
+    assert V.compare("1.2.0", "1.1.0") == "ahead"
+
+
+def test_equal_is_current():
+    assert V.compare("1.1.0", "1.1.0") == "current"
+
+
+# --- what --version prints -----------------------------------------------------------------
+
+def test_the_path_is_printed_not_just_the_number():
+    """The number alone is what misled everyone. The path is the answer."""
+    out = _install().render()
+    assert "1.0.0" in out
+    assert str(CHECKOUT / "agronaut_agent") in out
+
+
+def test_an_editable_install_says_so_and_says_where_updates_come_from():
+    out = _install(editable=CHECKOUT).render()
+    assert "editable" in out
+    assert str(CHECKOUT) in out
+    assert "git pull" in out
+
+
+def test_a_normal_install_does_not_claim_to_be_editable():
+    assert "editable" not in _install().render()
+
+
+# --- agronaut update -----------------------------------------------------------------------
+
+def test_update_refuses_to_overwrite_an_editable_install(monkeypatch, capsys):
+    """pip would replace the checkout link with a released copy and silently detach the
+    command from the code being edited. That is the exact failure this module exists for."""
+    called = []
+    monkeypatch.setattr(V, "current", lambda: _install(editable=CHECKOUT))
+    monkeypatch.setattr(V, "latest_on_pypi", lambda timeout=0: ("1.1.0", ""))
+    monkeypatch.setattr("subprocess.call", lambda *a, **k: called.append(a) or 0)
+
+    assert V.run_update() == 0
+    out = capsys.readouterr().out
+    assert not called, "pip was run against an editable install"
+    assert f"git -C {CHECKOUT} pull" in out
+    assert "--force-reinstall" in out, "no escape hatch offered for leaving the checkout"
+
+
+def test_update_installs_for_a_normal_install(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(V, "current", lambda: _install())
+    monkeypatch.setattr(V, "latest_on_pypi", lambda timeout=0: ("1.1.0", ""))
+    monkeypatch.setattr("subprocess.call", lambda cmd, *a, **k: called.append(cmd) or 0)
+
+    assert V.run_update() == 0
+    assert called and called[0][:2] == V.upgrade_command()[:2]
+    assert "--upgrade" in called[0]
+    assert "1.1.0" in capsys.readouterr().out
+
+
+def test_check_only_reports_without_installing(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(V, "current", lambda: _install())
+    monkeypatch.setattr(V, "latest_on_pypi", lambda timeout=0: ("1.1.0", ""))
+    monkeypatch.setattr("subprocess.call", lambda *a, **k: called.append(a) or 0)
+
+    assert V.run_update(check_only=True) == 0
+    assert not called
+    assert "1.0.0 -> 1.1.0" in capsys.readouterr().out
+
+
+def test_a_build_ahead_of_pypi_is_not_offered_a_downgrade(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(V, "current", lambda: _install(version="1.2.0"))
+    monkeypatch.setattr(V, "latest_on_pypi", lambda timeout=0: ("1.1.0", ""))
+    monkeypatch.setattr("subprocess.call", lambda *a, **k: called.append(a) or 0)
+
+    assert V.run_update() == 0
+    assert not called
+    assert "newer than" in capsys.readouterr().out
+
+
+def test_no_network_is_reported_not_swallowed(monkeypatch, capsys):
+    monkeypatch.setattr(V, "current", lambda: _install())
+    monkeypatch.setattr(V, "latest_on_pypi",
+                        lambda timeout=0: (None, "could not reach PyPI: timed out"))
+    assert V.run_update() == 1
+    assert "could not reach PyPI" in capsys.readouterr().out
+
+
+def test_the_upgrade_uses_this_interpreter(monkeypatch):
+    """A bare `pip` would upgrade whichever Python is first on PATH, which is how someone
+    ends up running the upgrade and seeing no change at all."""
+    import sys
+
+    assert V.upgrade_command()[0] == sys.executable
+    assert V.upgrade_command()[1:3] == ["-m", "pip"]
+
+
+# --- wired into the CLI --------------------------------------------------------------------
+
+def test_the_cli_exposes_version_and_update():
+    from agronaut_agent.cli import _build_parser
+
+    parser = _build_parser()
+    flags = {o for a in parser._actions for o in a.option_strings}
+    assert "--version" in flags
+    names = set()
+    for a in parser._actions:
+        if getattr(a, "choices", None):
+            names.update(a.choices)
+    assert "update" in names
+
+
+def test_version_output_keeps_its_line_breaks(capsys):
+    """argparse's built-in version action re-wraps the string through the help formatter and
+    turns the aligned paths into a paragraph, which is why this uses its own action."""
+    import pytest
+
+    from agronaut_agent.cli import _build_parser
+
+    with pytest.raises(SystemExit):
+        _build_parser().parse_args(["--version"])
+    out = capsys.readouterr().out
+    assert out.count("\n") >= 3, f"version output was flattened: {out!r}"
+    assert "code" in out and "config" in out

--- a/agronaut_agent/version_info.py
+++ b/agronaut_agent/version_info.py
@@ -1,0 +1,196 @@
+"""Which Agronaut is this, where did it come from, and how do you move it forward.
+
+This module exists because of a real evening lost to the question. A maintainer with both a
+git checkout and a `pip install agronaut` ran `agronaut setup`, got the old wizard, and had
+no way to tell why: `pip show agronaut` said 1.0.0 for the checkout and for a stale copy in
+site-packages alike, and nothing in the CLI would say which files it had actually loaded. The
+answer turned out to be orphaned package directories left in site-packages, shadowing an
+editable install that was pointing at the fixed code all along.
+
+So `agronaut --version` prints the version AND the path it loaded from AND whether that is an
+editable install, because the version number on its own was exactly the thing that lied.
+
+Pure and offline apart from `latest_on_pypi`, which is the only function here that touches the
+network and is the only one a caller has to be ready to have fail.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+PACKAGE = "agronaut"
+PYPI_JSON = f"https://pypi.org/pypi/{PACKAGE}/json"
+TIMEOUT = 15
+
+
+@dataclass(frozen=True)
+class Install:
+    """Where this Agronaut is running from."""
+
+    version: str
+    code_dir: Path
+    editable_from: Path | None      # the checkout, when installed with `pip install -e`
+
+    @property
+    def is_editable(self) -> bool:
+        return self.editable_from is not None
+
+    def render(self) -> str:
+        lines = [f"{PACKAGE} {self.version}"]
+        if self.is_editable:
+            lines.append(f"  code    {self.code_dir}")
+            lines.append(f"          editable install, tracking {self.editable_from}")
+            lines.append("          so `git pull` there is what updates it, not `agronaut update`")
+        else:
+            lines.append(f"  code    {self.code_dir}")
+        lines.append(f"  python  {sys.executable}")
+        lines.append(f"  config  {_config_path()}")
+        return "\n".join(lines)
+
+
+def _config_path() -> str:
+    """The .env this process would actually read.
+
+    Worth printing next to the version for the same reason: it changes with the working
+    directory (a checkout keeps its own), so "which config am I editing" is the second
+    question people get wrong after "which code am I running".
+    """
+    try:
+        from .setup_wizard import env_path
+
+        return str(env_path())
+    except Exception:      # noqa: BLE001 — a diagnostic must never be the thing that breaks
+        return "unknown"
+
+
+def _editable_target() -> Path | None:
+    """The checkout an editable install points at, or None for a normal install.
+
+    Read from the installer's own `direct_url.json` (PEP 610) rather than guessed from paths,
+    so it says what pip recorded rather than what the layout suggests.
+    """
+    try:
+        from importlib.metadata import distribution
+
+        dist = distribution(PACKAGE)
+        raw = dist.read_text("direct_url.json")
+        if not raw:
+            return None
+        data = json.loads(raw)
+        if not (data.get("dir_info") or {}).get("editable"):
+            return None
+        url = data.get("url", "")
+        prefix = "file://"
+        return Path(url[len(prefix):]) if url.startswith(prefix) else None
+    except Exception:      # noqa: BLE001
+        return None
+
+
+def current() -> Install:
+    """Describe the running install. Never raises: this is what you run when things are odd."""
+    try:
+        from importlib.metadata import version as _v
+
+        ver = _v(PACKAGE)
+    except Exception:      # noqa: BLE001 — a source checkout with nothing installed
+        ver = "unknown (not installed as a package)"
+    return Install(version=ver,
+                   code_dir=Path(__file__).resolve().parent,
+                   editable_from=_editable_target())
+
+
+def latest_on_pypi(timeout: int = TIMEOUT) -> tuple[str | None, str]:
+    """The newest released version, or None and a reason. The only network call in here."""
+    try:
+        with urllib.request.urlopen(PYPI_JSON, timeout=timeout) as f:
+            return json.load(f)["info"]["version"], ""
+    except urllib.error.HTTPError as e:
+        return None, f"PyPI returned HTTP {e.code}"
+    except Exception as e:  # noqa: BLE001
+        return None, f"could not reach PyPI: {e}"
+
+
+def _as_tuple(v: str) -> tuple:
+    """Compare versions numerically where possible, so 1.10.0 beats 1.9.0.
+
+    Falls back to string comparison for anything with a suffix, which is deliberately crude:
+    this decides whether to print "an update is available", not whether to install one.
+    """
+    parts = []
+    for chunk in v.split("."):
+        digits = "".join(c for c in chunk if c.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def compare(installed: str, latest: str) -> str:
+    """'current', 'behind', or 'ahead'. Ahead is normal for a maintainer on a checkout."""
+    try:
+        a, b = _as_tuple(installed), _as_tuple(latest)
+    except Exception:      # noqa: BLE001
+        return "current" if installed == latest else "behind"
+    if a == b:
+        return "current"
+    return "behind" if a < b else "ahead"
+
+
+def upgrade_command() -> list[str]:
+    """Upgrade using THIS interpreter's pip.
+
+    `sys.executable`, not a bare `pip`: the console script is routinely invoked by absolute
+    path from a venv whose bin/ is not on PATH, and a bare `pip` would then upgrade a
+    different Python's copy and leave the user exactly where they started.
+    """
+    return [sys.executable, "-m", "pip", "install", "--upgrade", PACKAGE]
+
+
+def run_update(*, check_only: bool = False) -> int:
+    """`agronaut update`. Reports honestly, and refuses when upgrading would be wrong."""
+    import subprocess
+
+    install = current()
+    print(install.render())
+    print()
+
+    latest, why = latest_on_pypi()
+    if latest is None:
+        print(f"Could not check for updates: {why}")
+        return 1
+    state = compare(install.version, latest)
+    if state == "current":
+        print(f"Up to date. {latest} is the newest release.")
+        return 0
+    if state == "ahead":
+        print(f"This build ({install.version}) is newer than the newest release ({latest}).")
+        print("Nothing to update to. That is normal when running from a checkout.")
+        return 0
+
+    print(f"Update available: {install.version} -> {latest}")
+
+    if install.is_editable:
+        # Overwriting an editable install with a PyPI copy would silently detach the command
+        # from the checkout the developer is editing, which is the exact failure that made
+        # this module necessary. Refuse, and say where the real update comes from.
+        print("\nThis is an editable install, so pip would replace your checkout link with a")
+        print(f"released copy. Update the source instead:\n\n    git -C {install.editable_from} pull\n")
+        print("To leave the checkout behind and track releases:")
+        print(f"    {' '.join(upgrade_command())} --force-reinstall")
+        return 0
+
+    if check_only:
+        print(f"\nRun `agronaut update` to install it, or:\n    {' '.join(upgrade_command())}")
+        return 0
+
+    print()
+    result = subprocess.call(upgrade_command())
+    if result != 0:
+        print("\npip could not complete the upgrade. The command it ran was:")
+        print(f"    {' '.join(upgrade_command())}")
+        return result
+    print(f"\nUpdated. Check it with `agronaut --version` (expect {latest}).")
+    return 0


### PR DESCRIPTION
## What this changes

An evening went into finding out why `agronaut setup` kept showing the old wizard on a machine where the fix was already merged. The cause was orphaned package directories left in system site-packages by the 1.0.0 wheel, shadowing an editable install that had been pointing at the fixed checkout the whole time. `pip show agronaut` said 1.0.0 for both, and nothing in the CLI would say which files it had actually loaded.

Two commands, so that never costs anyone an evening again.

**`agronaut --version`** prints the path, not just the number:

```
agronaut 1.0.0
  code    /Users/rekin226/Desktop/agentic-coding/Agronaut/agronaut_agent
          editable install, tracking /Users/rekin226/Desktop/agentic-coding/Agronaut
          so `git pull` there is what updates it, not `agronaut update`
  python  /Library/Frameworks/Python.framework/Versions/3.14/bin/python3
  config  /Users/rekin226/.config/agronaut/.env
```

Editability comes from pip's own `direct_url.json` (PEP 610), so it reports what pip recorded rather than what the layout suggests. The config path is there because it is the second thing people get wrong: it follows the working directory, so a checkout reads a different `.env` from a shell in `$HOME`.

It uses its own argparse action instead of the built-in `version` one, which hands the string to the help formatter and re-wraps those aligned paths into an unreadable paragraph. A test pins the line breaks.

**`agronaut update`** checks PyPI and installs, with two refusals that matter:

- **An editable install is never overwritten.** pip would replace the checkout link with a released copy and silently detach the command from the code being edited, which is a variant of the bug above. It prints `git -C <checkout> pull` instead, and offers `--force-reinstall` for anyone who genuinely wants to leave the checkout behind.
- **A build ahead of PyPI is not offered a downgrade.** Normal on a checkout, and it would otherwise read as an available update.

`--check` reports without installing. Version comparison is numeric so 1.10.0 beats 1.9.0. The upgrade runs `sys.executable -m pip`, never a bare `pip`, because the console script is routinely invoked by absolute path from a venv whose `bin/` is not on PATH, and a bare pip would upgrade a different Python and leave the user where they started.

## How it was verified

Both commands run against the real install, plus 15 unit tests covering the branches a live run cannot reach (an available update, a network failure, a build ahead of PyPI).

```
ruff .......... All checks passed!
pytest ........ 1279 passed          (1264 before, 15 new)
safety_eval ... 384/384
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

Not applicable: nothing under `aqua_model/` is touched, and no user-facing number changes.

## What this does NOT do

- **Does not detect the shadowing that caused all this.** If orphaned directories from an old wheel sit in site-packages, `--version` now shows you the path they came from, but nothing warns that a stale copy is winning over an editable install. That is `agronaut doctor` work.
- **Does not check for updates in the background or on startup.** `update` only runs when asked. No phone-home.
- **No `--pre` or version pinning.** `agronaut update` tracks the newest stable release, nothing else.
- **Does not fix a broken venv install**, only reports the path so you can see which one you are in.
