### PR TITLE
fix(cli): --version reported the frozen metadata, not the code it was running

### DIFF
--- a/agronaut_agent/tests/test_version_info.py
+++ b/agronaut_agent/tests/test_version_info.py
@@ -155,3 +155,65 @@ def test_version_output_keeps_its_line_breaks(capsys):
     out = capsys.readouterr().out
     assert out.count("\n") >= 3, f"version output was flattened: {out!r}"
     assert "code" in out and "config" in out
+
+
+# --- the stale-metadata bug this module was written to prevent, and then had ----------------
+
+def _checkout(tmp_path, version="1.1.0"):
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "agronaut"\nversion = "{version}"\n')
+    return tmp_path
+
+
+def test_an_editable_install_reports_the_checkout_not_the_frozen_metadata(tmp_path,
+                                                                          monkeypatch):
+    """An editable install writes its dist-info once and never again, so bumping pyproject
+    leaves `importlib.metadata.version` answering a question about the past. Shipped as
+    1.1.0, this reported 1.0.0 on the machine the release was cut from."""
+    root = _checkout(tmp_path, "1.1.0")
+    monkeypatch.setattr(V, "_editable_target", lambda: root)
+    monkeypatch.setattr("importlib.metadata.version", lambda p: "1.0.0")
+
+    install = V.current()
+    assert install.version == "1.1.0", "reported the frozen metadata, not the running code"
+    assert install.recorded_version == "1.0.0"
+    assert "pip still records 1.0.0" in install.render()
+
+
+def test_no_drift_note_when_the_metadata_is_current(tmp_path, monkeypatch):
+    root = _checkout(tmp_path, "1.1.0")
+    monkeypatch.setattr(V, "_editable_target", lambda: root)
+    monkeypatch.setattr("importlib.metadata.version", lambda p: "1.1.0")
+
+    install = V.current()
+    assert install.version == "1.1.0"
+    assert install.recorded_version is None
+    assert "pip still records" not in install.render()
+
+
+def test_a_normal_install_still_trusts_its_metadata(monkeypatch):
+    """Only editable installs go stale. A wheel's metadata is written from the same build."""
+    monkeypatch.setattr(V, "_editable_target", lambda: None)
+    monkeypatch.setattr("importlib.metadata.version", lambda p: "1.1.0")
+    assert V.current().version == "1.1.0"
+    assert V.current().recorded_version is None
+
+
+def test_an_unreadable_checkout_falls_back_rather_than_failing(tmp_path, monkeypatch):
+    """No pyproject, or a dynamic version. A diagnostic must never be what breaks."""
+    monkeypatch.setattr(V, "_editable_target", lambda: tmp_path)   # empty dir
+    monkeypatch.setattr("importlib.metadata.version", lambda p: "1.0.0")
+    assert V.current().version == "1.0.0"
+
+
+def test_update_compares_the_running_version_not_the_stale_one(tmp_path, monkeypatch, capsys):
+    """The visible consequence: `agronaut update` offered an upgrade that was installed."""
+    root = _checkout(tmp_path, "1.1.0")
+    monkeypatch.setattr(V, "_editable_target", lambda: root)
+    monkeypatch.setattr("importlib.metadata.version", lambda p: "1.0.0")
+    monkeypatch.setattr(V, "latest_on_pypi", lambda timeout=0: ("1.1.0", ""))
+
+    assert V.run_update() == 0
+    out = capsys.readouterr().out
+    assert "Up to date" in out
+    assert "1.0.0 -> 1.1.0" not in out, "offered an upgrade the checkout already has"

--- a/agronaut_agent/version_info.py
+++ b/agronaut_agent/version_info.py
@@ -35,6 +35,7 @@ class Install:
     version: str
     code_dir: Path
     editable_from: Path | None      # the checkout, when installed with `pip install -e`
+    recorded_version: str | None = None   # what pip has on file, when it has gone stale
 
     @property
     def is_editable(self) -> bool:
@@ -46,6 +47,9 @@ class Install:
             lines.append(f"  code    {self.code_dir}")
             lines.append(f"          editable install, tracking {self.editable_from}")
             lines.append("          so `git pull` there is what updates it, not `agronaut update`")
+            if self.recorded_version:
+                lines.append(f"          version read from that checkout; pip still records "
+                             f"{self.recorded_version} until you reinstall")
         else:
             lines.append(f"  code    {self.code_dir}")
         lines.append(f"  python  {sys.executable}")
@@ -91,6 +95,26 @@ def _editable_target() -> Path | None:
         return None
 
 
+def _checkout_version(root: Path) -> str | None:
+    """The version in a checkout's pyproject.toml, which is the one actually running.
+
+    An editable install writes its dist-info once, at install time, and never again. Bump
+    pyproject and the recorded metadata stays behind until someone reinstalls, so
+    `importlib.metadata.version` answers a question about the past. That is precisely the
+    lie this module was written to stop, and it caught this module out: shipped as 1.1.0,
+    `agronaut --version` reported 1.0.0 on the machine the release was cut from, and
+    `agronaut update` then offered an upgrade that was already installed.
+    """
+    try:
+        import tomllib
+
+        with (root / "pyproject.toml").open("rb") as f:
+            value = tomllib.load(f)["project"]["version"]
+        return str(value) if value else None
+    except Exception:      # noqa: BLE001 — no pyproject, unreadable, or a dynamic version
+        return None
+
+
 def current() -> Install:
     """Describe the running install. Never raises: this is what you run when things are odd."""
     try:
@@ -99,9 +123,17 @@ def current() -> Install:
         ver = _v(PACKAGE)
     except Exception:      # noqa: BLE001 — a source checkout with nothing installed
         ver = "unknown (not installed as a package)"
+
+    editable = _editable_target()
+    recorded = None
+    if editable is not None:
+        live = _checkout_version(editable)
+        if live and live != ver:
+            ver, recorded = live, ver
     return Install(version=ver,
                    code_dir=Path(__file__).resolve().parent,
-                   editable_from=_editable_target())
+                   editable_from=editable,
+                   recorded_version=recorded)
 
 
 def latest_on_pypi(timeout: int = TIMEOUT) -> tuple[str | None, str]:


### PR DESCRIPTION
## What this changes

Reported from the maintainer's own terminal within an hour of 1.1.0 going out:

```
$ agronaut --version
agronaut 1.0.0
  code    /Users/rekin226/Desktop/agentic-coding/Agronaut/agronaut_agent
          editable install, tracking /Users/rekin226/Desktop/agentic-coding/Agronaut

$ agronaut update
Update available: 1.0.0 -> 1.1.0
```

Both wrong, on a checkout sitting at 1.1.0.

An editable install writes its `dist-info` once, at install time, and never again. Bump `pyproject.toml` and `importlib.metadata.version` keeps answering a question about the past. The install was made at 09:54 while pyproject still said 1.0.0; the bump landed at 10:15.

Which makes this the exact failure the module was written to stop, occurring inside the module written to stop it. `--version` exists because a bare version number lied about which code was running.

**The fix:** for an editable install the version comes from the checkout's `pyproject.toml`, because that is the code being executed. When it disagrees with what pip recorded, the difference is printed rather than hidden, because that is what explains `pip show` disagreeing with `agronaut --version`:

```
agronaut 1.1.0
  code    /Users/rekin226/Desktop/agentic-coding/Agronaut/agronaut_agent
          editable install, tracking /Users/rekin226/Desktop/agentic-coding/Agronaut
          so `git pull` there is what updates it, not `agronaut update`
          version read from that checkout; pip still records 1.0.0 until you reinstall
```

A normal wheel install still trusts its metadata, which is written from the same build as the code. An unreadable or dynamic-versioned checkout falls back rather than raising, because a diagnostic must never be the thing that breaks.

`agronaut update` inherits the fix and now says "Up to date" instead of offering an upgrade that is already installed.

## How it was verified

Ran both commands on the machine that reported the bug, before and after.

```
ruff .......... All checks passed!
pytest ........ 1284 passed          (1279 before, 5 new)
safety_eval ... 395/395
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

Not applicable: nothing under `aqua_model/` is touched, and no user-facing number changes.

## What this does NOT do

- **Does not affect anyone who installed from PyPI.** A wheel's metadata and its code ship from the same build, so 1.1.0 on PyPI reports 1.1.0. This only ever misreported on an editable checkout, which in practice means maintainers and contributors.
- **Does not detect a stale copy shadowing an editable install**, which is the other way the version can mislead and the one that cost an evening earlier. That is still `agronaut doctor` work.
- **Does not handle a dynamic version** (`dynamic = ["version"]` in pyproject). It falls back to the recorded metadata rather than guessing.
