### PR TITLE
feat(cli): `agronaut doctor`, and the bug that testing it for real exposed

### DIFF
--- a/agronaut_agent/cli.py
+++ b/agronaut_agent/cli.py
@@ -10,6 +10,7 @@ owns it, so this module stays a dispatcher and only a dispatcher.
     agronaut design ...                             # alias for `size`
     agronaut web                                    # the Streamlit app
     agronaut bot                                    # the Telegram bot
+    agronaut doctor                                 # what is configured, and what is broken
     agronaut --version                              # which build is this, and from where
     agronaut update                                 # check PyPI and upgrade
 """
@@ -122,6 +123,12 @@ def _cmd_traces(args) -> int:
     return 0
 
 
+def _cmd_doctor(args) -> int:
+    from . import doctor
+
+    return doctor.main()
+
+
 def _cmd_update(args) -> int:
     from . import version_info
 
@@ -189,6 +196,8 @@ def _build_parser() -> argparse.ArgumentParser:
     wa.add_argument("--url", metavar="HTTPS_URL",
                     help="your public webhook URL, to test that Meta can actually reach it")
     wa.set_defaults(func=_cmd_whatsapp)
+    sub.add_parser("doctor", help="check your install, config, provider, corpus and data"
+                   ).set_defaults(func=_cmd_doctor)
     up = sub.add_parser("update", help="check for a newer release and install it")
     up.add_argument("--check", action="store_true",
                     help="report whether an update exists without installing it")

--- a/agronaut_agent/doctor.py
+++ b/agronaut_agent/doctor.py
@@ -1,0 +1,275 @@
+"""`agronaut doctor` — which half of your setup is broken.
+
+Built because the maintainer typed `agronaut doctor` twice, on two different days, while
+stuck on a problem this command answers in a second. The problem was that a stale copy of
+the package, left in site-packages by an older wheel, was shadowing an editable install; the
+tool showed the old behaviour, `pip show` reported a version that matched neither, and
+nothing anywhere would say which files were actually loaded.
+
+The design copies `whatsapp_doctor`, which already worked: a flat list of `Check`, each with
+a status, a label, a detail and a `fix:` line, rendered together with an exit code. That
+command becomes one section here rather than a separate thing to remember.
+
+Two rules the checks all follow:
+
+* **Nothing may raise.** This is what you run when things are already broken, so a check that
+  throws is reported as that check failing, never as a traceback.
+* **Offline is a normal state.** A check that needs the network says it was skipped rather
+  than claiming a failure it did not observe.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+from .whatsapp_doctor import FAIL, OK, WARN, Check
+
+SKIP = "warn"          # rendered as WARN; a check that could not run is not a pass
+
+
+def _safe(fn, label: str) -> list[Check]:
+    """Run one check group, converting any escape into a reported failure."""
+    try:
+        return fn()
+    except Exception as err:  # noqa: BLE001 — a diagnostic must never be what breaks
+        return [Check(FAIL, f"{label}: the check itself failed", f"{type(err).__name__}: {err}",
+                      "please paste this into an issue, it is a bug in doctor")]
+
+
+# --- the checks ---------------------------------------------------------------------------
+
+def check_install() -> list[Check]:
+    """Which code is running, and whether something is shadowing it.
+
+    The shadowing check is the reason this command exists. An editable install puts a finder
+    at the END of sys.path, so a real package directory left in site-packages by an older
+    wheel wins over it silently: the checkout is "installed", every file in it is correct,
+    and none of it is what runs.
+    """
+    from . import version_info
+
+    install = version_info.current()
+    out = [Check(OK, f"agronaut {install.version}", f"running from {install.code_dir}")]
+
+    if install.is_editable:
+        checkout = install.editable_from
+        try:
+            install.code_dir.relative_to(checkout)
+            out.append(Check(OK, f"editable install tracking {checkout}"))
+        except ValueError:
+            out.append(Check(
+                FAIL, "an installed copy is SHADOWING your editable install",
+                f"pip records an editable install of {checkout}, but the code actually "
+                f"loaded is {install.code_dir}. Edits to the checkout do nothing.",
+                f"remove the stale copy: rm -rf {install.code_dir} "
+                f"(and its sibling aqua_model/, agent/, srcs/), then reinstall"))
+        if install.recorded_version:
+            out.append(Check(
+                WARN, f"pip still records {install.recorded_version}",
+                "an editable install writes its metadata once; the version above comes from "
+                "the checkout, which is the code that runs.",
+                f"pip install -e {checkout}   # only to make `pip show` agree"))
+    dists = version_info.distributions()
+    if len(dists) > 1:
+        where = ", ".join(str(getattr(d, "_path", "?")) for d in dists)
+        out.append(Check(
+            WARN, f"{len(dists)} installs of agronaut are visible at once", where,
+            "python picks one by sys.path order, so which code runs can change between "
+            "commands. Usually a checkout's agronaut.egg-info sitting beside a real install; "
+            "`rm -rf agronaut.egg-info` in the checkout clears it."))
+
+    if os.getenv("PYTHONPATH"):
+        out.append(Check(
+            WARN, "PYTHONPATH is set", f"PYTHONPATH={os.getenv('PYTHONPATH')}",
+            "it overrides installed packages, so what you test may not be what you shipped"))
+    return out
+
+
+def check_config() -> list[Check]:
+    """Which .env applies, and whether a second one is waiting to confuse you."""
+    from .setup_wizard import env_path
+
+    active = Path(env_path())
+    others = []
+    try:
+        from agent.env import user_config_dir
+
+        candidates = {Path.cwd() / ".env", Path(user_config_dir()) / ".env"}
+        others = [p for p in candidates if p.is_file() and p != active]
+    except Exception:  # noqa: BLE001
+        pass
+
+    if not active.is_file():
+        out = [Check(WARN, f"no .env at {active}", "nothing is configured from a file",
+                     "run `agronaut setup`")]
+    else:
+        out = [Check(OK, f"config {active}")]
+    for p in others:
+        out.append(Check(WARN, f"a second .env exists at {p}",
+                         "which one applies depends on your working directory",
+                         "delete the one you do not want, or always run from the same place"))
+    return out
+
+
+def check_provider() -> list[Check]:
+    """Is a model configured, and can it be reached. Network, so it can be skipped."""
+    from . import setup_wizard as W
+
+    provider = (os.getenv("LLM_PROVIDER") or "").strip()
+    model = (os.getenv("LLM_MODEL") or "").strip()
+    if not provider:
+        return [Check(WARN, "no model provider configured",
+                      "chat is off. The sizing engine does not need one and still works.",
+                      "run `agronaut setup`, or pick Ollama to run one locally with no key")]
+
+    out = [Check(OK, f"provider {provider}" + (f", model {model}" if model else ""))]
+    if provider == "ollama":
+        ok, msg = W.check_ollama()
+        out.append(Check(OK if ok else FAIL, f"ollama: {msg}",
+                         fix="" if ok else "start it with `ollama serve`"))
+    elif provider == "anthropic":
+        key = (os.getenv("ANTHROPIC_API_KEY") or "").strip()
+        if not key:
+            out.append(Check(FAIL, "ANTHROPIC_API_KEY is not set",
+                             fix="run `agronaut setup`"))
+        else:
+            ok, msg = W.check_anthropic_key(key)
+            out.append(Check(OK if ok else FAIL, f"anthropic: {msg}",
+                             fix="" if ok else "run `agronaut setup` to re-enter the key"))
+    else:
+        out.append(Check(SKIP, f"reachability of {provider} not checked",
+                         "doctor only probes ollama and anthropic so far"))
+    return out
+
+
+def check_knowledge() -> list[Check]:
+    """The corpus. A missing one is a FAIL, not a warning.
+
+    `paths.corpus_root` says why: the RAG layer logs a warning and then answers every
+    question with KNOWLEDGE_UNAVAILABLE, so the assistant sounds fine and cites nothing.
+    Looking like it works is the worst failure this project can have.
+    """
+    from . import paths
+
+    root = Path(paths.corpus_root())
+    docs = sorted((root / "knowledge").glob("*.md"))
+    if not docs:
+        return [Check(FAIL, "the knowledge corpus is missing", f"looked in {root / 'knowledge'}",
+                      "answers will cite nothing while still sounding confident. Reinstall.")]
+    status = OK if len(docs) >= 20 else WARN
+    return [Check(status, f"{len(docs)} knowledge documents", f"in {root / 'knowledge'}")]
+
+
+def check_reference_tables() -> list[Check]:
+    """The seven cited data tables. Their absence is what shipped broken in 1.0.0."""
+    from aqua_model.reference_data import SHIPPED, reference_dir
+
+    d = Path(reference_dir())
+    missing = [n for n in SHIPPED if not (d / n).is_file()]
+    if missing:
+        return [Check(FAIL, f"{len(missing)} of {len(SHIPPED)} reference tables missing",
+                      ", ".join(missing), "reinstall: pip install --force-reinstall agronaut")]
+    return [Check(OK, f"all {len(SHIPPED)} reference tables present", f"in {d}")]
+
+
+def check_validation_record() -> list[Check]:
+    """What the twin is entitled to claim. Derived, never asserted."""
+    from aqua_model import validation_status as vs
+
+    first = vs.validation_lines()[0]
+    if first.startswith("PREDICTIVE SKILL UNMEASURED"):
+        return [Check(FAIL, "the validation record did not ship",
+                      "every projection will disclaim itself as unmeasured",
+                      "reinstall: pip install --force-reinstall agronaut")]
+    return [Check(OK, "validation record present", first[:88])]
+
+
+def check_database() -> list[Check]:
+    """Present, readable, and a schema this build understands."""
+    from .paths import data_dir
+    from .store import SCHEMA_VERSION
+
+    path = Path(os.getenv("AGRONAUT_DB") or (Path(data_dir()) / "agronaut.sqlite3"))
+    if not path.is_file():
+        return [Check(OK, "no database yet", f"one will be created at {path} on first use")]
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        found = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        users = conn.execute("SELECT count(*) FROM users").fetchone()[0]
+    finally:
+        conn.close()
+    if found > SCHEMA_VERSION:
+        return [Check(FAIL, f"database schema v{found} is newer than this build (v{SCHEMA_VERSION})",
+                      f"at {path}", "upgrade: agronaut update")]
+    return [Check(OK, f"database schema v{found or SCHEMA_VERSION}, {users} users", str(path))]
+
+
+def check_channels() -> list[Check]:
+    """Telegram and WhatsApp, only as far as their configuration goes."""
+    out: list[Check] = []
+    token = (os.getenv("TELEGRAM_BOT_TOKEN") or "").strip()
+    if not token:
+        out.append(Check(SKIP, "Telegram not configured", "no TELEGRAM_BOT_TOKEN"))
+    else:
+        from .setup_wizard import check_telegram_token
+
+        ok, msg = check_telegram_token(token)
+        out.append(Check(OK if ok else FAIL, f"Telegram: {msg}",
+                         fix="" if ok else "run `agronaut setup` and paste a fresh token"))
+        if not (os.getenv("AGRONAUT_ALLOWED_IDS") or "").strip():
+            out.append(Check(WARN, "AGRONAUT_ALLOWED_IDS is empty",
+                             "anyone who finds the bot can talk to it"))
+    if not (os.getenv("WHATSAPP_TOKEN") or "").strip():
+        out.append(Check(SKIP, "WhatsApp not configured", "no WHATSAPP_TOKEN"))
+    else:
+        out.append(Check(OK, "WhatsApp is configured",
+                         "run `agronaut whatsapp --check` for the full chain"))
+    return out
+
+
+_GROUPS = (
+    ("install", check_install),
+    ("config", check_config),
+    ("model provider", check_provider),
+    ("knowledge", check_knowledge),
+    ("reference tables", check_reference_tables),
+    ("validation record", check_validation_record),
+    ("database", check_database),
+    ("channels", check_channels),
+)
+
+
+def run_checks() -> list[Check]:
+    out: list[Check] = []
+    for label, fn in _GROUPS:
+        out.extend(_safe(fn, label))
+    return out
+
+
+def report(checks: list[Check]) -> tuple[str, int]:
+    """Render, and an exit code: 0 if nothing FAILed, so it is usable in a script."""
+    lines = [c.render() for c in checks]
+    failed = [c for c in checks if c.status == FAIL]
+    warned = [c for c in checks if c.status == WARN]
+    lines.append("")
+    if failed:
+        lines.append(f"{len(failed)} thing(s) above are broken. Each has a fix: line.")
+    elif warned:
+        lines.append(f"Nothing is broken. {len(warned)} thing(s) worth a look.")
+    else:
+        lines.append("Everything checks out.")
+    # Deliberately narrow: a green doctor means the CONFIGURATION is coherent. What the model
+    # is entitled to claim is a separate question, answered by data/twin_validation.json, and
+    # a report that read as a clean bill of health for the whole system would undo the thing
+    # this project is careful about everywhere else.
+    lines.append("This checks your setup, not the accuracy of the advice. "
+                 "For that, see data/twin_validation.json.")
+    return "\n".join(lines), (1 if failed else 0)
+
+
+def main() -> int:
+    text, code = report(run_checks())
+    print(text)
+    return code

--- a/agronaut_agent/tests/test_doctor.py
+++ b/agronaut_agent/tests/test_doctor.py
@@ -1,0 +1,187 @@
+"""`agronaut doctor`: the checks, and the promise that none of them can raise.
+
+Built after the maintainer typed `agronaut doctor` twice while stuck on a problem it answers
+in a second: a stale copy of the package in site-packages was shadowing an editable install,
+so the checkout was "installed", every file in it was correct, and none of it was running.
+That check is the one this file guards hardest.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from agronaut_agent import doctor as D
+from agronaut_agent.whatsapp_doctor import FAIL, OK, WARN, Check
+
+CHECKOUT = Path("/home/grower/Agronaut")
+SITE = Path("/usr/lib/python3.12/site-packages")
+
+
+def _install(**kw):
+    from agronaut_agent.version_info import Install
+
+    base = dict(version="1.1.0", code_dir=CHECKOUT / "agronaut_agent",
+                editable_from=CHECKOUT, recorded_version=None)
+    base.update(kw)
+    return Install(**base)
+
+
+# --- the check this command exists for -----------------------------------------------------
+
+def test_a_stale_copy_shadowing_an_editable_install_is_a_failure(monkeypatch):
+    """pip records an editable install of the checkout, and the code that loads comes from
+    site-packages instead. Everything looks installed and nothing you edit takes effect."""
+    monkeypatch.setattr(D, "__name__", D.__name__)   # keep module identity explicit
+    from agronaut_agent import version_info
+
+    monkeypatch.setattr(version_info, "current",
+                        lambda: _install(code_dir=SITE / "agronaut_agent"))
+    checks = D.check_install()
+    bad = [c for c in checks if c.status == FAIL]
+    assert bad, "shadowing was not reported"
+    assert "SHADOWING" in bad[0].label
+    assert str(SITE / "agronaut_agent") in bad[0].detail
+    assert "rm -rf" in bad[0].fix, "no concrete fix offered"
+
+
+def test_a_healthy_editable_install_is_not_reported_as_shadowed(monkeypatch):
+    from agronaut_agent import version_info
+
+    monkeypatch.setattr(version_info, "current", lambda: _install())
+    assert not [c for c in D.check_install() if c.status == FAIL]
+
+
+def test_pythonpath_is_flagged(monkeypatch):
+    """It overrides installed packages, which is how a verification stops meaning anything."""
+    from agronaut_agent import version_info
+
+    monkeypatch.setattr(version_info, "current", lambda: _install())
+    monkeypatch.setenv("PYTHONPATH", "/somewhere")
+    labels = [c.label for c in D.check_install()]
+    assert any("PYTHONPATH is set" in x for x in labels)
+
+
+def test_stale_pip_metadata_is_a_warning_not_a_failure(monkeypatch):
+    from agronaut_agent import version_info
+
+    monkeypatch.setattr(version_info, "current", lambda: _install(recorded_version="1.0.0"))
+    checks = D.check_install()
+    assert not [c for c in checks if c.status == FAIL]
+    assert any(c.status == WARN and "1.0.0" in c.label for c in checks)
+
+
+# --- nothing may raise ---------------------------------------------------------------------
+
+def test_a_check_that_explodes_is_reported_not_raised():
+    """This is what you run when things are already broken."""
+    def boom():
+        raise RuntimeError("disk on fire")
+
+    out = D._safe(boom, "install")
+    assert len(out) == 1 and out[0].status == FAIL
+    assert "disk on fire" in out[0].detail
+
+
+def test_run_checks_never_raises_even_with_everything_unset(monkeypatch):
+    for var in ("LLM_PROVIDER", "LLM_MODEL", "ANTHROPIC_API_KEY", "TELEGRAM_BOT_TOKEN",
+                "WHATSAPP_TOKEN", "AGRONAUT_ALLOWED_IDS", "PYTHONPATH"):
+        monkeypatch.delenv(var, raising=False)
+    checks = D.run_checks()
+    assert checks, "no checks ran"
+    assert all(isinstance(c, Check) for c in checks)
+
+
+# --- the missing-corpus case, which is the worst failure the project can have ---------------
+
+def test_a_missing_corpus_is_a_failure_not_a_warning(monkeypatch, tmp_path):
+    """It answers every question with KNOWLEDGE_UNAVAILABLE while sounding fine, so it must
+    not be reported as a soft warning."""
+    from agronaut_agent import paths
+
+    monkeypatch.setattr(paths, "corpus_root", lambda: tmp_path)   # no knowledge/ inside
+    checks = D.check_knowledge()
+    assert checks[0].status == FAIL
+    assert "cite nothing" in checks[0].fix
+
+
+def test_a_present_corpus_passes(monkeypatch, tmp_path):
+    from agronaut_agent import paths
+
+    (tmp_path / "knowledge").mkdir()
+    for i in range(21):
+        (tmp_path / "knowledge" / f"doc{i}.md").write_text("x")
+    monkeypatch.setattr(paths, "corpus_root", lambda: tmp_path)
+    assert D.check_knowledge()[0].status == OK
+
+
+# --- the report contract -------------------------------------------------------------------
+
+def test_exit_code_is_nonzero_only_when_something_failed():
+    _, code = D.report([Check(OK, "fine"), Check(WARN, "hmm")])
+    assert code == 0
+    _, code = D.report([Check(OK, "fine"), Check(FAIL, "broken")])
+    assert code == 1
+
+
+def test_the_report_does_not_claim_the_advice_is_good():
+    """A green doctor means the configuration is coherent. Saying more would undo the thing
+    this project is careful about everywhere else."""
+    text, _ = D.report([Check(OK, "fine")])
+    assert "not the accuracy of the advice" in text
+    assert "twin_validation.json" in text
+
+
+def test_the_cli_exposes_doctor():
+    from agronaut_agent.cli import _build_parser
+
+    names = set()
+    for a in _build_parser()._actions:
+        if getattr(a, "choices", None):
+            names.update(a.choices)
+    assert "doctor" in names
+
+
+@pytest.mark.parametrize("newer", [2, 5])
+def test_a_future_database_schema_is_a_failure(monkeypatch, tmp_path, newer):
+    import sqlite3
+
+    from agronaut_agent import store
+
+    db = tmp_path / "agronaut.sqlite3"
+    store._Db(db)
+    conn = sqlite3.connect(str(db))
+    conn.execute(f"PRAGMA user_version = {store.SCHEMA_VERSION + newer}")
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("AGRONAUT_DB", str(db))
+    checks = D.check_database()
+    assert checks[0].status == FAIL
+    assert "newer than this build" in checks[0].label
+
+
+def test_editable_detection_survives_the_cli_building_its_parser():
+    """The bug this pins: `_build_parser()` puts the project root on sys.path, so
+    `importlib.metadata` starts finding the checkout's legacy `agronaut.egg-info`. It carries
+    no direct_url.json, so editability came back False and the shadowing check above silently
+    never ran. Found by planting a real stale copy, not by a mock, because the mock passed.
+    """
+    from agronaut_agent import version_info
+    from agronaut_agent.cli import _build_parser
+
+    before = version_info._editable_target()
+    _build_parser()
+    after = version_info._editable_target()
+    assert before == after, (
+        "building the parser changed editable detection: "
+        f"{before} -> {after}. _editable_target must scan every distribution, "
+        "not trust whichever sys.path order surfaces first.")
+
+
+def test_distributions_returns_every_visible_agronaut():
+    """More than one is a real state and itself a symptom, so it must not be collapsed."""
+    from agronaut_agent import version_info
+
+    found = version_info.distributions()
+    assert isinstance(found, list)
+    for d in found:
+        assert (d.metadata.get("Name") or "").lower() == "agronaut"

--- a/agronaut_agent/version_info.py
+++ b/agronaut_agent/version_info.py
@@ -72,27 +72,49 @@ def _config_path() -> str:
         return "unknown"
 
 
+def distributions() -> list:
+    """Every discoverable distribution named `agronaut`, not just the first one found.
+
+    More than one is possible and is itself a symptom: a checkout on sys.path carries a
+    legacy `agronaut.egg-info` beside whatever pip installed, and `importlib.metadata` returns
+    them in sys.path order. `agronaut_agent/cli.py` puts the project root on sys.path while
+    building its parser, so the egg-info can win, and it carries no `direct_url.json`.
+
+    That is not hypothetical. It silently disabled the shadowed-install check in `doctor`:
+    the checkout's egg-info was found first, editability came back False, and the one check
+    written to catch a stale copy never ran. Scanning them all is the fix.
+    """
+    try:
+        from importlib.metadata import distributions as _all
+
+        return [d for d in _all()
+                if (d.metadata.get("Name") or "").lower() == PACKAGE]
+    except Exception:      # noqa: BLE001
+        return []
+
+
 def _editable_target() -> Path | None:
     """The checkout an editable install points at, or None for a normal install.
 
     Read from the installer's own `direct_url.json` (PEP 610) rather than guessed from paths,
-    so it says what pip recorded rather than what the layout suggests.
+    so it says what pip recorded rather than what the layout suggests. Checks every
+    distribution, because the first one found is not reliably the installed one.
     """
-    try:
-        from importlib.metadata import distribution
-
-        dist = distribution(PACKAGE)
-        raw = dist.read_text("direct_url.json")
-        if not raw:
-            return None
-        data = json.loads(raw)
-        if not (data.get("dir_info") or {}).get("editable"):
-            return None
-        url = data.get("url", "")
-        prefix = "file://"
-        return Path(url[len(prefix):]) if url.startswith(prefix) else None
-    except Exception:      # noqa: BLE001
-        return None
+    for dist in distributions():
+        try:
+            raw = dist.read_text("direct_url.json")
+            if not raw:
+                continue
+            data = json.loads(raw)
+            if not (data.get("dir_info") or {}).get("editable"):
+                continue
+            url = data.get("url", "")
+            prefix = "file://"
+            if url.startswith(prefix):
+                return Path(url[len(prefix):])
+        except Exception:  # noqa: BLE001 — a broken sibling must not hide a good one
+            continue
+    return None
 
 
 def _checkout_version(root: Path) -> str | None:


### PR DESCRIPTION
## What this changes

`agronaut doctor` exists now. It was typed twice, on two different days, by the maintainer, while stuck on a problem it answers in a second: a stale copy of the package left in site-packages by an older wheel was shadowing an editable install. The checkout was "installed", every file in it was correct, and none of it was what ran. `pip show` reported a version matching neither, and nothing would say which files were actually loaded.

It reports on the install, the config, the model provider, the knowledge corpus, the seven reference tables, the validation record, the database and the channels. Design copied from `whatsapp_doctor`, which already worked: a flat list of `Check` with status, label, detail and a `fix:` line, rendered with an exit code, so it is usable in a script.

Two rules every check follows: **nothing may raise**, because this is what you run when things are already broken, and **offline is skipped, not failed**.

## The bug testing it for real exposed

The mocked test for the shadowing check passed. Then I planted an actual stale copy in a throwaway venv and ran the installed console script, and **the check did not fire.**

`agronaut_agent/cli.py` puts the project root on `sys.path` while building its parser. That makes `importlib.metadata` discover the checkout's legacy `agronaut.egg-info` beside the real dist-info and return it first. The egg-info carries no `direct_url.json`, so `_editable_target()` returned `None`, `is_editable` went False, and the one check written to catch a stale copy was silently skipped.

```
doctor.main()            -> [FAIL] an installed copy is SHADOWING your editable install
cli.main(['doctor'])     -> (nothing)     # same process, same modules
```

Two fixes:

- `_editable_target` scans **every** distribution named agronaut rather than trusting whichever sys.path order surfaces first.
- doctor warns when more than one is visible at once, because that ambiguity is itself the symptom rather than a curiosity.

A regression test builds the parser and asserts editable detection is unchanged across it.

## How it was verified

Planted a real stale copy in a throwaway venv, then ran the **installed console script**, not the module:

```
[FAIL] an installed copy is SHADOWING your editable install
       pip records an editable install of /Users/.../Agronaut, but the code actually
       loaded is /.../site-packages/agronaut_agent. Edits to the checkout do nothing.
       fix: remove the stale copy: rm -rf /.../site-packages/agronaut_agent ...
[WARN] 2 installs of agronaut are visible at once
exit code: 1
```

```
ruff .......... All checks passed!
pytest ........ 1299 passed          (1284 before, 15 new)
safety_eval ... 395/395
```

- [x] `pytest` is green
- [x] `python -m scripts.safety_eval` exits 0
- [x] New behaviour has a test that would have failed before this change

## Trust-zone checklist

Not applicable: nothing under `aqua_model/` is touched, and no user-facing number changes.

## What this does NOT do

- **Cannot diagnose a shadow old enough to predate it.** If the stale copy is from a version without `doctor`, `agronaut doctor` is "invalid choice" and you are back to reading `sys.path` by hand. That is precisely what happened here, and no version of this command can fix it retroactively.
- **Only probes ollama and anthropic** for provider reachability. Other providers report as not checked rather than passing.
- **Does not check that the advice is any good**, and says so in its own output. A green doctor means the configuration is coherent. What the model may claim lives in `data/twin_validation.json`.
- **No `--json` yet.** #149 lists it as optional; the human-readable output came first.

Closes #149
