### PR TITLE
fix(doctor): one install seen twice was reported as two installs

### DIFF
--- a/agronaut_agent/tests/test_version_info.py
+++ b/agronaut_agent/tests/test_version_info.py
@@ -217,3 +217,21 @@ def test_update_compares_the_running_version_not_the_stale_one(tmp_path, monkeyp
     out = capsys.readouterr().out
     assert "Up to date" in out
     assert "1.0.0 -> 1.1.0" not in out, "offered an upgrade the checkout already has"
+
+
+def test_the_same_install_seen_twice_is_not_two_installs(monkeypatch):
+    """A site-packages directory can appear more than once on sys.path, and
+    `importlib.metadata.distributions()` then yields the same install repeatedly. Reported
+    raw, doctor said "2 installs of agronaut are visible at once" and printed one path twice,
+    sending a reader hunting for a conflict that did not exist."""
+    class _D:
+        def __init__(self, path):
+            self._path = path
+            self.metadata = {"Name": "agronaut"}
+
+    same = "/usr/lib/python3/site-packages/agronaut-1.1.0.dist-info"
+    monkeypatch.setattr("importlib.metadata.distributions",
+                        lambda: [_D(same), _D(same), _D("/other/agronaut.egg-info")])
+    found = V.distributions()
+    assert len(found) == 2, [str(d._path) for d in found]
+    assert len({str(d._path) for d in found}) == 2

--- a/agronaut_agent/version_info.py
+++ b/agronaut_agent/version_info.py
@@ -87,8 +87,22 @@ def distributions() -> list:
     try:
         from importlib.metadata import distributions as _all
 
-        return [d for d in _all()
-                if (d.metadata.get("Name") or "").lower() == PACKAGE]
+        seen: set[str] = set()
+        out = []
+        for d in _all():
+            if (d.metadata.get("Name") or "").lower() != PACKAGE:
+                continue
+            # Deduplicate by location. The same site-packages can appear more than once on
+            # sys.path, and `distributions()` then yields the same install repeatedly. Left
+            # raw, the doctor reported "2 installs of agronaut are visible at once" and
+            # printed one path twice, sending a reader hunting for a conflict that was not
+            # there. A duplicate is not a second install.
+            where = str(getattr(d, "_path", "") or d.metadata.get("Name"))
+            if where in seen:
+                continue
+            seen.add(where)
+            out.append(d)
+        return out
     except Exception:      # noqa: BLE001
         return []
 


### PR DESCRIPTION
Caught by running `agronaut doctor` on the maintainer's machine straight after merging it, rather than on the throwaway venv it was developed against:

```
[WARN] 2 installs of agronaut are visible at once
       /Library/.../agronaut-1.0.0.dist-info, /Library/.../agronaut-1.0.0.dist-info
```

The same path, printed twice. A site-packages directory can appear more than once on sys.path, and `importlib.metadata.distributions()` then yields the same install repeatedly. The ambiguity warning exists to catch a genuine conflict; here it invented one and pointed at a path with nothing wrong with it.

`distributions()` now deduplicates by location. The warning still fires for a real conflict, the case the throwaway venv exercised: a checkout's egg-info beside a real dist-info.

## Verified

Re-ran on the machine that produced the bad output; the false warning is gone and the real-conflict case still reports. 1300 tests, safety eval 395/395, ruff clean.

## What this does NOT do

Does not change when the warning fires for genuinely different locations, and does not attempt to decide which of two real installs wins. It reports the ambiguity and leaves the choice to the reader.