### PR TITLE
docs(plan): WhatsApp voice shipped, so stop listing it as unbuilt

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -125,8 +125,7 @@ The two defects that undermine "consultative agent with memory" for every user, 
   - **Deliberately still open:** the Tier-2 photo corpus (`data/vision_corpus/`) is empty —
     it needs the operator's own field photographs and cannot be synthesised. Until it is
     populated, the guard and the triage table are verified against handwritten strings, not
-    against real photographs. Also unbuilt: a specialist image classifier, and voice input on
-    WhatsApp.
+    against real photographs. Also unbuilt: a specialist image classifier (#71).
 
 ---
 


### PR DESCRIPTION
One stale sentence in `docs/PLAN.md`.

Task 1.6 closes with "Also unbuilt: a specialist image classifier, and voice input on WhatsApp." The second half stopped being true at `8ba1d63`:

- `agronaut_agent/channels/whatsapp_adapter.py:115` parses inbound `audio`, `voice`, and `document` messages whose mime is audio.
- Line 285 hands them to `agent.handle_voice`, the same seam Telegram uses, so the transcript runs through a normal turn with memory, tools and cited knowledge intact.

The classifier half is still true, so it keeps the line and picks up its issue number (#71).

Found while auditing the plan against the code. It is the second stale claim in two days: #121 described a vision-provider gap that closed at `3b847c1`, and has now been corrected and retitled. The pattern is worth naming, because it is the mirror image of the one in the last audit. That one was capability built and left unwired. This is capability built and left undocumented, so the tracker understates what the project does and a contributor could pick up work that is already finished.

Docs only, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHudfUziAwZdDRa6GrC1ED